### PR TITLE
Added code to be able to use environment variables and docker/kubernetes secrets for the db credentials

### DIFF
--- a/src/main/java/org/ecocean/ShepherdPMF.java
+++ b/src/main/java/org/ecocean/ShepherdPMF.java
@@ -87,6 +87,7 @@ public class ShepherdPMF {
         while (propsNames.hasMoreElements()) {
           String name = (String) propsNames.nextElement();
           if (name.startsWith("datanucleus") || name.startsWith("javax.jdo")) {
+              System.out.println("Properties: " + name + "=" + props.getProperty(name).trim());
             dnProperties.setProperty(name, props.getProperty(name).trim());
           }
         }

--- a/src/main/java/org/ecocean/ShepherdPMF.java
+++ b/src/main/java/org/ecocean/ShepherdPMF.java
@@ -33,6 +33,7 @@ import java.util.TreeMap;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+import java.io;
 
 public class ShepherdPMF {
 

--- a/src/main/java/org/ecocean/ShepherdPMF.java
+++ b/src/main/java/org/ecocean/ShepherdPMF.java
@@ -33,7 +33,7 @@ import java.util.TreeMap;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-import java.io;
+import java.io.*;
 
 public class ShepherdPMF {
 
@@ -93,11 +93,13 @@ public class ShepherdPMF {
         }
 
         /********************************************************************************************************************************************/
-        /* This code below allows you to define the Database Connection parameters in environment variables and also Docker or Kubernetes secrets.  */ 
-        /* You can create a setenv.sh script containing exports for environment variables and place the script in the $CATALINA_HOME/bin directory. */
+        /* This code below allows you to define the Database Connection parameters (user, password and connection URL in environment variables      */
+        /* and also Docker or Kubernetes secrets.                                                                                                   */ 
+        /*                                                                                                                                          */   
+        /* You create a setenv.sh script containing exports for the environment variables and place the script in the $CATALINA_HOME/bin directory. */
         /* The catalina.sh script will call the setenv.sh script (if it exists) before it launches Tomcat.                                          */ 
-        /* This allows you specify the Database Connection parameters: user, password and connection URL at run time instead of hardcoded in the    */ 
-        /* jdoconfig.properties file which is inside the wildbook.war file. This also makes it easy to use with Docker and Kubernetes.              */
+        /* This allows you specify the Database Connection parameters: user, password and connection URL at run time instead of hardcoding them in  */ 
+        /* the jdoconfig.properties file which is inside the wildbook.war file. This also makes it easy to use with Docker and Kubernetes.          */
         /* And you define the Database Connection parameters as Docker secrets or Kubernetes secrets which makes the credentials secure.            */  
         /********************************************************************************************************************************************/  
         /*                                                                                                                                          */       

--- a/src/main/java/org/ecocean/ShepherdPMF.java
+++ b/src/main/java/org/ecocean/ShepherdPMF.java
@@ -33,7 +33,8 @@ import java.util.TreeMap;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class ShepherdPMF {
 
@@ -148,9 +149,14 @@ public class ShepherdPMF {
         /********************************************************************************************************************************************/
             String dbUserSecretFile = System.getenv("DB_USER_FILE");
             if (dbUserSecretFile != null && !dbUserSecretFile.isEmpty()) {
-                System.out.println("The DB_USER_FILE environment variable was specified, will retrieve the value from the file and use it to connect to the Database.");
-                dbUser = IO.from(new File(dbUserSecretFile)).toString();
-                dnProperties.setProperty("datanucleus.ConnectionUserName", dbUser.trim());
+                try {
+                    dbUser = new String(Files.readAllBytes(Paths.get(dbUserSecretFile)));
+                    dnProperties.setProperty("datanucleus.ConnectionUserName", dbUser.trim());
+                } catch (IOException exc) {
+                    exc.printStackTrace();
+                    System.out.println("I couldn't read the " + dbUserSecretFile + " file!");
+                    return null;
+                }
             }
         }
 
@@ -169,8 +175,14 @@ public class ShepherdPMF {
             String dbPasswordSecretFile = System.getenv("DB_PASSWORD_FILE");
             if (dbPasswordSecretFile != null && !dbPasswordSecretFile.isEmpty()) {
                 System.out.println("The DB_PASSWORD_FILE environment variable was specified, will retrieve the value from the file and use it to connect to the Database.");
-                dbPassword = IO.from(new File(dbPasswordSecretFile)).toString();
-                dnProperties.setProperty("datanucleus.ConnectionPassword", dbPassword.trim());
+                try {
+                    dbPassword = new String(Files.readAllBytes(Paths.get(dbPasswordSecretFile)));
+                    dnProperties.setProperty("datanucleus.ConnectionPassword", dbPassword.trim());
+                } catch (IOException exc) {
+                    exc.printStackTrace();
+                    System.out.println("I couldn't read the " + dbPasswordSecretFile + " file!");
+                    return null;
+                }
             }
         }
 
@@ -189,8 +201,14 @@ public class ShepherdPMF {
             String dbConnectionURLFile = System.getenv("DB_PASSWORD_FILE");
             if (dbConnectionURLFile != null && !dbConnectionURLFile.isEmpty()) {
                 System.out.println("The DB_CONNECTION_URL_FILE environment variable was specified, will retrieve the value from the file and use it to connect to the Database.");
-                dbConnectionURL = IO.from(new File(dbConnectionURLFile)).toString();
-                dnProperties.setProperty("datanucleus.ConnectionURL", dbConnectionURL.trim());
+                try {
+                    dbConnectionURL = new String(Files.readAllBytes(Paths.get(dbConnectionURLFile)));
+                    dnProperties.setProperty("datanucleus.ConnectionURL", dbConnectionURL.trim());
+                } catch (IOException exc) {
+                    exc.printStackTrace();
+                    System.out.println("I couldn't read the " + dbConnectionURLFile + " file!");
+                    return null;
+                }
             }
         }    
         

--- a/src/main/java/org/ecocean/ShepherdPMF.java
+++ b/src/main/java/org/ecocean/ShepherdPMF.java
@@ -206,6 +206,7 @@ public class ShepherdPMF {
         String dbUser = System.getenv("DB_USER");
         if (dbUser != null && !dbUser.isEmpty()) {
             System.out.println("The DB_USER environment variable was specified, will use it to connect to the Database.");
+            // System.out.println("The database user retrieved from environment variable was " + dbUser);
             dnProperties.setProperty("datanucleus.ConnectionUserName", dbUser.trim());
         } else {
         /*****************************************************************************************************************************************************/             
@@ -213,8 +214,10 @@ public class ShepherdPMF {
         /*****************************************************************************************************************************************************/ 
             String dbUserSecretFile = System.getenv("DB_USER_FILE");
             if (dbUserSecretFile != null && !dbUserSecretFile.isEmpty()) {
+                System.out.println("The DB_USER_FILE environment variable was specified, will retrieve the value from the file and use it to connect to the Database.");
                 try {
                     dbUser = new String(Files.readAllBytes(Paths.get(dbUserSecretFile)));
+                    // System.out.println("The database user retrieved from the secret was " + dbUser);
                     dnProperties.setProperty("datanucleus.ConnectionUserName", dbUser.trim());
                 } catch (IOException exc) {
                     exc.printStackTrace();
@@ -231,6 +234,7 @@ public class ShepherdPMF {
         String dbPassword = System.getenv("DB_PASSWORD");    
         if (dbPassword != null && !dbPassword.isEmpty()) {
             System.out.println("The DB_PASSWORD environment variable was specified, will use it to connect to the Database.");
+            // System.out.println("The database password retrieved from the environment variable was " + dbPassword);
             dnProperties.setProperty("datanucleus.ConnectionPassword", dbPassword.trim());
         } else {
         /*****************************************************************************************************************************************************/ 
@@ -241,6 +245,7 @@ public class ShepherdPMF {
                 System.out.println("The DB_PASSWORD_FILE environment variable was specified, will retrieve the value from the file and use it to connect to the Database.");
                 try {
                     dbPassword = new String(Files.readAllBytes(Paths.get(dbPasswordSecretFile)));
+                    // System.out.println("The database password retrieved from the secret was " + dbPassword);
                     dnProperties.setProperty("datanucleus.ConnectionPassword", dbPassword.trim());
                 } catch (IOException exc) {
                     exc.printStackTrace();
@@ -257,6 +262,7 @@ public class ShepherdPMF {
         String dbConnectionURL = System.getenv("DB_CONNECTION_URL");
         if (dbConnectionURL != null && !dbConnectionURL.isEmpty()) {
             System.out.println("The DB_CONNECTION_URL environment variable was specified, will use it to connect to the Database.");
+            // System.out.println("The database connection URL retrieved from the environment variable was " + dbConnectionURL);
             dnProperties.setProperty("datanucleus.ConnectionURL", dbConnectionURL.trim());
         } else {
         /*****************************************************************************************************************************************************/            
@@ -267,6 +273,7 @@ public class ShepherdPMF {
                 System.out.println("The DB_CONNECTION_URL_FILE environment variable was specified, will retrieve the value from the file and use it to connect to the Database.");
                 try {
                     dbConnectionURL = new String(Files.readAllBytes(Paths.get(dbConnectionURLFile)));
+                    // System.out.println("The database connection URL retrieved from the secret was " + dbConnectionURL);
                     dnProperties.setProperty("datanucleus.ConnectionURL", dbConnectionURL.trim());
                 } catch (IOException exc) {
                     exc.printStackTrace();

--- a/src/main/java/org/ecocean/ShepherdPMF.java
+++ b/src/main/java/org/ecocean/ShepherdPMF.java
@@ -93,60 +93,124 @@ public class ShepherdPMF {
           }
         }
 
-        /********************************************************************************************************************************************/
-        /* This code below allows you to define the Database Connection parameters (user, password and connection URL in environment variables      */
-        /* and also Docker or Kubernetes secrets.                                                                                                   */ 
-        /*                                                                                                                                          */   
-        /* You create a setenv.sh script containing exports for the environment variables and place the script in the $CATALINA_HOME/bin directory. */
-        /* The catalina.sh script will call the setenv.sh script (if it exists) before it launches Tomcat.                                          */ 
-        /* This allows you specify the Database Connection parameters: user, password and connection URL at run time instead of hardcoding them in  */ 
-        /* the jdoconfig.properties file which is inside the wildbook.war file. This also makes it easy to use with Docker and Kubernetes.          */
-        /* And you define the Database Connection parameters as Docker secrets or Kubernetes secrets which makes the credentials secure.            */  
-        /********************************************************************************************************************************************/  
-        /*                                                                                                                                          */       
-        /* Example setenv.sh file                                                                                                                   */     
-        /*                                                                                                                                          */
-        /* #!/usr/bin/env bash                                                                                                                      */
-        /* printf 'Setting Database Connection environment variables\n'                                                                             */
-        /*                                                                                                                                          */
-        /* export DB_USER="wildbook"                                                                                                                */
-        /* # export DB_USER_FILE=/run/secrets/db-user                                                                                               */     
-        /* export DB_PASSWORD="Passw0rd#"                                                                                                           */
-        /* # export DB_PASSWORD_FILE=/run/secrets/db-password                                                                                       */
-        /* export DB_CONNECTION_URL="jdbc:mysql://mysql-wildbook:3306/wildbook?useSSL=false&allowPublicKeyRetrieval=true"                           */
-        /* # export DB_CONNECTION_URL_FILE=/run/secrets/db-connection-url                                                                           */ 
-        /********************************************************************************************************************************************/
-        /*                                                                                                                                          */
-        /* Example docker-compose.yml file below.                                                                                                   */ 
-        /*                                                                                                                                          */   
-        /* Put the setenv.sh script in the directory where the docker-compose.yml file exists. Docker will mount the local setenv.sh file to        */
-        /* /usr/local/tomcat/bin/setenv.sh when the docker container is started.                                                                    */
-        /*                                                                                                                                          */ 
-        /* version: '3.3'                                                                                                                           */
-        /* configs:                                                                                                                                 */ 
-        /*   setenv.sh:                                                                                                                             */ 
-        /*     file: ./setenv.sh                                                                                                                    */ 
-        /* services:                                                                                                                                */ 
-        /*   tomcat-wildbook:                                                                                                                       */ 
-        /*     image: gforghetti/tomcat-wildbook:latest                                                                                             */ 
-        /*     configs:                                                                                                                             */ 
-        /*       - source: setenv.sh                                                                                                                */ 
-        /*         target: /usr/local/tomcat/bin/setenv.sh                                                                                          */ 
-        /*                                                                                                                                          */    
-        /********************************************************************************************************************************************/     
+        /*****************************************************************************************************************************************************/
+        /* This code below allows you to define the Database Connection parameters (user, password and connection URL in environment variables               */
+        /* and also Docker or Kubernetes secrets.                                                                                                            */
+        /*                                                                                                                                                   */ 
+        /* You create a setenv.sh script containing exports for the environment variables and place the script in the $CATALINA_HOME/bin directory.          */
+        /* The catalina.sh script will call the setenv.sh script (if it exists) before it launches Tomcat.                                                   */
+        /* This allows you specify the Database Connection parameters: user, password and connection URL at run time instead of hardcoding them in           */
+        /* the jdoconfig.properties file which is inside the wildbook.war file. This also makes it easy to use with Docker and Kubernetes.                   */
+        /* And you can also define the Database Connection parameters as Docker secrets or Kubernetes secrets which makes the credentials secure.            */
+        /*****************************************************************************************************************************************************/
+        /*                                                                                                                                                   */
+        /* Example setenv.sh file                                                                                                                            */
+        /*                                                                                                                                                   */
+        /* #!/usr/bin/env bash                                                                                                                               */
+        /* printf 'Setting Database Connection environment variables\n'                                                                                      */
+        /*                                                                                                                                                   */
+        /* export DB_USER="wildbook"                                                                                                                         */
+        /* # export DB_USER_FILE=/run/secrets/wildbook-db-user                                                                                               */
+        /* export DB_PASSWORD="Passw0rd#"                                                                                                                    */
+        /* # export DB_PASSWORD_FILE=/run/secrets/wildbook-db-password                                                                                       */
+        /* export DB_CONNECTION_URL="jdbc:mysql://mysql-wildbook:3306/wildbook?useSSL=false&allowPublicKeyRetrieval=true"                                    */
+        /* # export DB_CONNECTION_URL_FILE=/run/secrets/wildbook-db-connection-url                                                                           */
+        /*****************************************************************************************************************************************************/
+        /*                                                                                                                                                   */
+        /* Example docker-compose.yml file below.                                                                                                            */
+        /*                                                                                                                                                   */
+        /* Put the setenv.sh script in the directory where the docker-compose.yml file exists. Docker will mount the local setenv.sh file to                 */
+        /* /usr/local/tomcat/bin/setenv.sh when the docker container is started.                                                                             */
+        /*                                                                                                                                                   */
+        /* version: '3.3'                                                                                                                                    */
+        /* configs:                                                                                                                                          */
+        /*   setenv.sh:                                                                                                                                      */
+        /*     file: ./setenv.sh                                                                                                                             */
+        /* services:                                                                                                                                         */
+        /*   tomcat-wildbook:                                                                                                                                */
+        /*     image: gforghetti/tomcat-wildbook:latest                                                                                                      */
+        /*     configs:                                                                                                                                      */
+        /*       - source: setenv.sh                                                                                                                         */
+        /*         target: /usr/local/tomcat/bin/setenv.sh                                                                                                   */
+        /*         uid: '0'                                                                                                                                  */
+        /*         gid: '0'                                                                                                                                  */
+        /*         mode: 0700                                                                                                                                */
+        /*                                                                                                                                                   */
+        /*****************************************************************************************************************************************************/ 
+        /* To use Docker secrets.                                                                                                                            */
+        /*****************************************************************************************************************************************************/
+        /* Example setenv.sh file                                                                                                                            */
+        /*                                                                                                                                                   */
+        /* #!/usr/bin/env bash                                                                                                                               */
+        /* printf 'Setting Database Connection environment variables\n'                                                                                      */
+        /*                                                                                                                                                   */
+        /* # export DB_USER="wildbook"                                                                                                                       */
+        /* export DB_USER_FILE=/run/secrets/wildbook-db-user                                                                                                 */
+        /* # export DB_PASSWORD="Passw0rd#"                                                                                                                  */
+        /* export DB_PASSWORD_FILE=/run/secrets/wildbook-db-password                                                                                         */
+        /* # export DB_CONNECTION_URL="jdbc:mysql://mysql-wildbook:3306/wildbook?useSSL=false&allowPublicKeyRetrieval=true"                                  */
+        /* export DB_CONNECTION_URL_FILE=/run/secrets/wildbook-db-connection-url                                                                             */
+        /*                                                                                                                                                   */          
+        /* Create the Docker secrets                                                                                                                         */
+        /*                                                                                                                                                   */
+        /* $ echo "wildbook" | docker secret create wildbook-db-user -                                                                                       */
+        /* yhma28514l3spyj6033ym155y                                                                                                                         */
+        /*                                                                                                                                                   */     
+        /* $ echo "Passw0rd#" | docker secret create wildbook-db-password -                                                                                  */
+        /* 6q3gew26hvv3x314ahzxgfceb                                                                                                                         */
+        /*                                                                                                                                                   */
+        /* $ echo "jdbc:mysql://mysql-wildbook:3306/wildbook?useSSL=false&allowPublicKeyRetrieval=true" | docker secret create wildbook-db-connection-url -  */
+        /* 9ur97son802lopbpaj8q1ant8                                                                                                                         */
+        /*                                                                                                                                                   */
+        /* $ docker secret ls                                                                                                                                */
+        /* ID                           NAME                         DRIVER              CREATED              UPDATED                                        */
+        /* 9ur97son802lopbpaj8q1ant8    wildbook-db-connection-url                       5 seconds ago        5 seconds ago                                  */
+        /* m6q3gew26hvv3x314ahzxgfceb   wildbook-db-password                             41 seconds ago       41 seconds ago                                 */
+        /* yhma28514l3spyj6033ym155y    wildbook-db-user                                 About a minute ago   About a minute ago                             */
+        /*                                                                                                                                                   */
+        /*****************************************************************************************************************************************************/
+        /* docker-compose.yml file with the secrets.                                                                                                         */
+        /*                                                                                                                                                   */
+        /* version: '3.3'                                                                                                                                    */
+        /* configs:                                                                                                                                          */
+        /*   setenv.sh:                                                                                                                                      */
+        /*     file: ./setenv.sh                                                                                                                             */
+        /* secrets:                                                                                                                                          */
+        /*   wildbook-db-user:                                                                                                                               */
+        /*     external: true                                                                                                                                */
+        /*   wildbook-db-password:                                                                                                                           */
+        /*     external: true                                                                                                                                */
+        /*   wildbook-db-connection-url:                                                                                                                     */
+        /*     external: true                                                                                                                                */
+        /* services:                                                                                                                                         */
+        /*   tomcat-wildbook:                                                                                                                                */
+        /*     image: gforghetti/tomcat-wildbook:latest                                                                                                      */
+        /*     configs:                                                                                                                                      */
+        /*       - source: setenv.sh                                                                                                                         */
+        /*         target: /usr/local/tomcat/bin/setenv.sh                                                                                                   */
+        /*         uid: '0'                                                                                                                                  */
+        /*         gid: '0'                                                                                                                                  */
+        /*         mode: 0700                                                                                                                                */
+        /*     secrets:                                                                                                                                      */
+        /*       - wildbook-db-user                                                                                                                          */
+        /*       - wildbook-db-password                                                                                                                      */
+        /*       - wildbook-db-connection-url                                                                                                                */
+        /*                                                                                                                                                   */
+        /* # Note the same wildbook-db-user and wildbook-db-passord secrets can be specified to a MySQL docker database container.                           */
+        /*****************************************************************************************************************************************************/
 
-        /********************************************************************************************************************************************/ 
-        /* Retrieve the Database user from an environment Variable                                                                                  */
-        /********************************************************************************************************************************************/
+        /*****************************************************************************************************************************************************/ 
+        /* Retrieve the Database user from an environment Variable                                                                                           */
+        /*****************************************************************************************************************************************************/ 
         System.out.println("Checking for the DB_USER environment variable.");
         String dbUser = System.getenv("DB_USER");
         if (dbUser != null && !dbUser.isEmpty()) {
             System.out.println("The DB_USER environment variable was specified, will use it to connect to the Database.");
             dnProperties.setProperty("datanucleus.ConnectionUserName", dbUser.trim());
         } else {
-        /********************************************************************************************************************************************/            
-        /* Retrieve the Database User from a file. This allows the use of Docker Secrets and Kubernetes Secrets!                                    */
-        /********************************************************************************************************************************************/
+        /*****************************************************************************************************************************************************/             
+        /* Retrieve the Database User from a file. This allows the use of Docker Secrets and Kubernetes Secrets!                                             */
+        /*****************************************************************************************************************************************************/ 
             String dbUserSecretFile = System.getenv("DB_USER_FILE");
             if (dbUserSecretFile != null && !dbUserSecretFile.isEmpty()) {
                 try {
@@ -160,18 +224,18 @@ public class ShepherdPMF {
             }
         }
 
-        /********************************************************************************************************************************************/ 
-        /* Retrieve the Database password from an environment Variable */
-        /********************************************************************************************************************************************/ 
+        /*****************************************************************************************************************************************************/ 
+        /* Retrieve the Database password from an environment Variable                                                                                       */
+        /*****************************************************************************************************************************************************/  
         System.out.println("Checking for the DB_PASSWORD environment variable.");
         String dbPassword = System.getenv("DB_PASSWORD");    
         if (dbPassword != null && !dbPassword.isEmpty()) {
             System.out.println("The DB_PASSWORD environment variable was specified, will use it to connect to the Database.");
             dnProperties.setProperty("datanucleus.ConnectionPassword", dbPassword.trim());
         } else {
-        /********************************************************************************************************************************************/ 
-        /* Retrieve the Database Password from a file. This allows the use of Docker Secrets and Kubernetes Secrets!                                */
-        /********************************************************************************************************************************************/ 
+        /*****************************************************************************************************************************************************/ 
+        /* Retrieve the Database Password from a file. This allows the use of Docker Secrets and Kubernetes Secrets!                                         */
+        /*****************************************************************************************************************************************************/  
             String dbPasswordSecretFile = System.getenv("DB_PASSWORD_FILE");
             if (dbPasswordSecretFile != null && !dbPasswordSecretFile.isEmpty()) {
                 System.out.println("The DB_PASSWORD_FILE environment variable was specified, will retrieve the value from the file and use it to connect to the Database.");
@@ -186,19 +250,19 @@ public class ShepherdPMF {
             }
         }
 
-        /********************************************************************************************************************************************/ 
-        /* Retrieve the Database Connection URL from an environment Variable                                                                        */
-        /********************************************************************************************************************************************/ 
+        /*****************************************************************************************************************************************************/ 
+        /* Retrieve the Database Connection URL from an environment Variable                                                                                 */
+        /*****************************************************************************************************************************************************/  
         System.out.println("Checking for the DB_CONNECTION_URL environment variable.");
         String dbConnectionURL = System.getenv("DB_CONNECTION_URL");
         if (dbConnectionURL != null && !dbConnectionURL.isEmpty()) {
             System.out.println("The DB_CONNECTION_URL environment variable was specified, will use it to connect to the Database.");
             dnProperties.setProperty("datanucleus.ConnectionURL", dbConnectionURL.trim());
         } else {
-        /********************************************************************************************************************************************/              
-        /* Retrieve the Database Connection URL from a file. This allows the use of Docker Secrets and Kubernetes Secrets!                          */
-        /********************************************************************************************************************************************/         
-            String dbConnectionURLFile = System.getenv("DB_PASSWORD_FILE");
+        /*****************************************************************************************************************************************************/            
+        /* Retrieve the Database Connection URL from a file. This allows the use of Docker Secrets and Kubernetes Secrets!                                   */
+        /*****************************************************************************************************************************************************/         
+            String dbConnectionURLFile = System.getenv("DB_CONNECTION_URL_FILE");
             if (dbConnectionURLFile != null && !dbConnectionURLFile.isEmpty()) {
                 System.out.println("The DB_CONNECTION_URL_FILE environment variable was specified, will retrieve the value from the file and use it to connect to the Database.");
                 try {

--- a/src/main/java/org/ecocean/ShepherdPMF.java
+++ b/src/main/java/org/ecocean/ShepherdPMF.java
@@ -87,10 +87,33 @@ public class ShepherdPMF {
         while (propsNames.hasMoreElements()) {
           String name = (String) propsNames.nextElement();
           if (name.startsWith("datanucleus") || name.startsWith("javax.jdo")) {
-              System.out.println("Properties: " + name + "=" + props.getProperty(name).trim());
-            dnProperties.setProperty(name, props.getProperty(name).trim());
+              dnProperties.setProperty(name, props.getProperty(name).trim());
           }
         }
+
+        /* Retrieve the Database user from an environment Variable */
+        System.out.println("Checking for the DB_USER environment variable.");
+        String dbUser = System.getenv("DB_USER");
+        if (dbUser != null && !dbUser.isEmpty()) {
+            System.out.println("The DB_USER environment variable was specified, will use it to connect to the Database.");
+            dnProperties.setProperty("datanucleus.ConnectionUserName", dbUser.trim());
+        }
+
+        /* Retrieve the Database password from an environment Variable */
+        System.out.println("Checking for the DB_PASSWORD environment variable.");
+        String dbPassword = System.getenv("DB_PASSWORD");    
+        if (dbPassword != null && !dbPassword.isEmpty()) {
+            System.out.println("The DB_PASSWORD environment variable was specified, will use it to connect to the Database.");
+            dnProperties.setProperty("datanucleus.ConnectionPassword", dbPassword.trim());
+        }
+
+        /* Retrieve the Database Connection URL from an environment Variable */
+        System.out.println("Checking for the DB_CONNECTION_URL environment variable.");
+        String dbConnectionURL = System.getenv("DB_CONNECTION_URL");
+        if (dbConnectionURL != null && !dbConnectionURL.isEmpty()) {
+            System.out.println("The The DB_CONNECTION_URL environment variable was specified, will use it to connect to the Database.");
+            dnProperties.setProperty("datanucleus.ConnectionURL", dbConnectionURL.trim());
+        }    
         
         //make sure to close an old PMF if switching
         //if(pmf!=null){pmf.close();}

--- a/src/main/java/org/ecocean/servlet/ServletUtilities.java
+++ b/src/main/java/org/ecocean/servlet/ServletUtilities.java
@@ -524,42 +524,42 @@ public static Connection getConnection() throws SQLException {
   Properties connectionProps = new Properties();
 
   /* Retrieve the Database user from an environment Variable */
-  System.out.Println("Checking for the DB_USER environment variable.");
+  System.out.println("Checking for the DB_USER environment variable.");
   String dbUser = System.getenv("DB_USER");
   /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
   if (dbUser  == null || dbUser.isEmpty()) {
-      System.out.Println("The DB_USER environment variable was not specified, will use the datanucleus.ConnectionUserName value from the jdoconfig.properties file.");
+      System.out.println("The DB_USER environment variable was not specified, will use the datanucleus.ConnectionUserName value from the jdoconfig.properties file.");
       dbUser = CommonConfiguration.getProperty("datanucleus.ConnectionUserName","context0");
   } else {
-      System.out.Println("The DB_USER environment variable was specified, will use it to connect to the Database.");
+      System.out.println("The DB_USER environment variable was specified, will use it to connect to the Database.");
   }
 
   /* Store the Database user in the Connection Properties */
   connectionProps.put("user", dbUser);
   
   /* Retrieve the Database password from an environment Variable */
-  System.out.Println("Checking for the DB_PASSWORD environment variable.");
+  System.out.println("Checking for the DB_PASSWORD environment variable.");
   String dbPassword = System.getenv("DB_PASSWORD");
   /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
   if (dbPassword  == null || dbPassword.isEmpty()) {
-      System.out.Println("The DB_PASSWORD environment variable was not specified, will use the datanucleus.ConnectionPassword value from the jdoconfig.properties file.");
+      System.out.println("The DB_PASSWORD environment variable was not specified, will use the datanucleus.ConnectionPassword value from the jdoconfig.properties file.");
       dbPassword = CommonConfiguration.getProperty("datanucleus.ConnectionPassword","context0");
   } else {
-      System.out.Println("The DB_PASSWORD environment variable was specified, will use it to connect to the Database.");
+      System.out.println("The DB_PASSWORD environment variable was specified, will use it to connect to the Database.");
   }
 
   /* Store the Database password in the Connection Properties */
   connectionProps.put("password", dbPassword);
 
   /* Retrieve the Database Connection URL from an environment Variable */
-  System.out.Println("Checking for the DB_CONNECTION_URL environment variable.");
+  System.out.println("Checking for the DB_CONNECTION_URL environment variable.");
   String connectionURL = System.getenv("DB_CONNECTION_URL");
   /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
   if (connectionURL == null || connectionURL.isEmpty()) {
-      System.out.Println("The DB_CONNECTION_URL environment variable was not specified, will use the datanucleus.ConnectionURL value from the jdoconfig.properties file.");
+      System.out.println("The DB_CONNECTION_URL environment variable was not specified, will use the datanucleus.ConnectionURL value from the jdoconfig.properties file.");
       connectionURL = CommonConfiguration.getProperty("datanucleus.ConnectionURL","context0");
   } else {
-      System.out.Println("The The DB_CONNECTION_URL environment variable was specified, will use it to connect to the Database.");
+      System.out.println("The The DB_CONNECTION_URL environment variable was specified, will use it to connect to the Database.");
   }
 
   /* Go ahead and connect to the Database */

--- a/src/main/java/org/ecocean/servlet/ServletUtilities.java
+++ b/src/main/java/org/ecocean/servlet/ServletUtilities.java
@@ -553,13 +553,13 @@ public static Connection getConnection() throws SQLException {
 
   /* Retrieve the Database Connection URL from an environment Variable */
   System.out.println("Checking for the DB_CONNECTION_URL environment variable.");
-  String connectionURL = System.getenv("DB_CONNECTION_URL");
+  String dbConnectionURL = System.getenv("DB_CONNECTION_URL");
   /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
-  if (connectionURL == null || connectionURL.isEmpty()) {
+  if (dbConnectionURL == null || dbConnectionURL.isEmpty()) {
       System.out.println("The DB_CONNECTION_URL environment variable was not specified, will use the datanucleus.ConnectionURL value from the jdoconfig.properties file.");
       dbConnectionURL = CommonConfiguration.getProperty("datanucleus.ConnectionURL","context0");
   } else {
-      System.out.println("The The DB_CONNECTION_URL environment variable was specified, will use it to connect to the Database.");
+      System.out.println("The DB_CONNECTION_URL environment variable was specified, will use it to connect to the Database.");
   }
 
   /* Go ahead and connect to the Database */

--- a/src/main/java/org/ecocean/servlet/ServletUtilities.java
+++ b/src/main/java/org/ecocean/servlet/ServletUtilities.java
@@ -522,13 +522,36 @@ public static Connection getConnection() throws SQLException {
 
   Connection conn = null;
   Properties connectionProps = new Properties();
-  connectionProps.put("user", CommonConfiguration.getProperty("datanucleus.ConnectionUserName","context0"));
-  connectionProps.put("password", CommonConfiguration.getProperty("datanucleus.ConnectionPassword","context0"));
 
+  /* Retrieve the Database user from an environment Variable */
+  String dbUser = System.getenv("DB_USER");
+  /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
+  if (dbUser  == null || dbUser.isEmpty()) {
+      dbUser = CommonConfiguration.getProperty("datanucleus.ConnectionUserName","context0");
+  }
 
-  conn = DriverManager.getConnection(
-  CommonConfiguration.getProperty("datanucleus.ConnectionURL","context0"),
-  connectionProps);
+  /* Store the Database user in the Connection Properties */
+  connectionProps.put("user", dbUser);
+  
+  /* Retrieve the Database password from an environment Variable */
+  String dbPassword = System.getenv("DB_PASSWORD");
+  /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
+  if (dbPassword  == null || dbPassword.isEmpty()) {
+      dbPassword = CommonConfiguration.getProperty("datanucleus.ConnectionPassword","context0");
+  }
+
+  /* Store the Database password in the Connection Properties */
+  connectionProps.put("password", dbPassword);
+
+  /* Retrieve the Database Connection URL from an environment Variable */
+  String connectionURL = System.getenv("DB_CONNECTION_URL");
+  /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
+  if (connectionURL == null || connectionURL.isEmpty()) {
+      connectionURL = CommonConfiguration.getProperty("datanucleus.ConnectionURL","context0");
+  }
+
+  /* Go ahead and connect to the Database */
+  conn = DriverManager.getConnection(connectionURL, connectionProps);  
 
   System.out.println("Connected to database for authentication.");
   return conn;
@@ -585,7 +608,6 @@ public static String getContext(HttpServletRequest request){
       if(currentURL.indexOf(domainNames.get(p))!=-1){return thisContext;}
 
     }
-
 
   }
 

--- a/src/main/java/org/ecocean/servlet/ServletUtilities.java
+++ b/src/main/java/org/ecocean/servlet/ServletUtilities.java
@@ -524,30 +524,42 @@ public static Connection getConnection() throws SQLException {
   Properties connectionProps = new Properties();
 
   /* Retrieve the Database user from an environment Variable */
+  System.out.Println("Checking for the DB_USER environment variable.");
   String dbUser = System.getenv("DB_USER");
   /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
   if (dbUser  == null || dbUser.isEmpty()) {
+      System.out.Println("The DB_USER environment variable was not specified, will use the datanucleus.ConnectionUserName value from the jdoconfig.properties file.");
       dbUser = CommonConfiguration.getProperty("datanucleus.ConnectionUserName","context0");
+  } else {
+      System.out.Println("The DB_USER environment variable was specified, will use it to connect to the Database.");
   }
 
   /* Store the Database user in the Connection Properties */
   connectionProps.put("user", dbUser);
   
   /* Retrieve the Database password from an environment Variable */
+  System.out.Println("Checking for the DB_PASSWORD environment variable.");
   String dbPassword = System.getenv("DB_PASSWORD");
   /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
   if (dbPassword  == null || dbPassword.isEmpty()) {
+      System.out.Println("The DB_PASSWORD environment variable was not specified, will use the datanucleus.ConnectionPassword value from the jdoconfig.properties file.");
       dbPassword = CommonConfiguration.getProperty("datanucleus.ConnectionPassword","context0");
+  } else {
+      System.out.Println("The DB_PASSWORD environment variable was specified, will use it to connect to the Database.");
   }
 
   /* Store the Database password in the Connection Properties */
   connectionProps.put("password", dbPassword);
 
   /* Retrieve the Database Connection URL from an environment Variable */
+  System.out.Println("Checking for the DB_CONNECTION_URL environment variable.");
   String connectionURL = System.getenv("DB_CONNECTION_URL");
   /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
   if (connectionURL == null || connectionURL.isEmpty()) {
+      System.out.Println("The DB_CONNECTION_URL environment variable was not specified, will use the datanucleus.ConnectionURL value from the jdoconfig.properties file.");
       connectionURL = CommonConfiguration.getProperty("datanucleus.ConnectionURL","context0");
+  } else {
+      System.out.Println("The The DB_CONNECTION_URL environment variable was specified, will use it to connect to the Database.");
   }
 
   /* Go ahead and connect to the Database */

--- a/src/main/java/org/ecocean/servlet/ServletUtilities.java
+++ b/src/main/java/org/ecocean/servlet/ServletUtilities.java
@@ -522,48 +522,13 @@ public static Connection getConnection() throws SQLException {
 
   Connection conn = null;
   Properties connectionProps = new Properties();
+  connectionProps.put("user", CommonConfiguration.getProperty("datanucleus.ConnectionUserName","context0"));
+  connectionProps.put("password", CommonConfiguration.getProperty("datanucleus.ConnectionPassword","context0"));
 
-  /* Retrieve the Database user from an environment Variable */
-  System.out.println("Checking for the DB_USER environment variable.");
-  String dbUser = System.getenv("DB_USER");
-  /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
-  if (dbUser  == null || dbUser.isEmpty()) {
-      System.out.println("The DB_USER environment variable was not specified, will use the datanucleus.ConnectionUserName value from the jdoconfig.properties file.");
-      dbUser = CommonConfiguration.getProperty("datanucleus.ConnectionUserName","context0");
-  } else {
-      System.out.println("The DB_USER environment variable was specified, will use it to connect to the Database.");
-  }
 
-  /* Store the Database user in the Connection Properties */
-  connectionProps.put("user", dbUser);
-  
-  /* Retrieve the Database password from an environment Variable */
-  System.out.println("Checking for the DB_PASSWORD environment variable.");
-  String dbPassword = System.getenv("DB_PASSWORD");
-  /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
-  if (dbPassword  == null || dbPassword.isEmpty()) {
-      System.out.println("The DB_PASSWORD environment variable was not specified, will use the datanucleus.ConnectionPassword value from the jdoconfig.properties file.");
-      dbPassword = CommonConfiguration.getProperty("datanucleus.ConnectionPassword","context0");
-  } else {
-      System.out.println("The DB_PASSWORD environment variable was specified, will use it to connect to the Database.");
-  }
-
-  /* Store the Database password in the Connection Properties */
-  connectionProps.put("password", dbPassword);
-
-  /* Retrieve the Database Connection URL from an environment Variable */
-  System.out.println("Checking for the DB_CONNECTION_URL environment variable.");
-  String dbConnectionURL = System.getenv("DB_CONNECTION_URL");
-  /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
-  if (dbConnectionURL == null || dbConnectionURL.isEmpty()) {
-      System.out.println("The DB_CONNECTION_URL environment variable was not specified, will use the datanucleus.ConnectionURL value from the jdoconfig.properties file.");
-      dbConnectionURL = CommonConfiguration.getProperty("datanucleus.ConnectionURL","context0");
-  } else {
-      System.out.println("The DB_CONNECTION_URL environment variable was specified, will use it to connect to the Database.");
-  }
-
-  /* Go ahead and connect to the Database */
-  conn = DriverManager.getConnection(dbConnectionURL, connectionProps);  
+  conn = DriverManager.getConnection(
+  CommonConfiguration.getProperty("datanucleus.ConnectionURL","context0"),
+  connectionProps);
 
   System.out.println("Connected to database for authentication.");
   return conn;
@@ -620,6 +585,7 @@ public static String getContext(HttpServletRequest request){
       if(currentURL.indexOf(domainNames.get(p))!=-1){return thisContext;}
 
     }
+
 
   }
 

--- a/src/main/java/org/ecocean/servlet/ServletUtilities.java
+++ b/src/main/java/org/ecocean/servlet/ServletUtilities.java
@@ -557,13 +557,13 @@ public static Connection getConnection() throws SQLException {
   /* If it's null or empty then go ahead and retrieve it from the jdoconfig.properties file */
   if (connectionURL == null || connectionURL.isEmpty()) {
       System.out.println("The DB_CONNECTION_URL environment variable was not specified, will use the datanucleus.ConnectionURL value from the jdoconfig.properties file.");
-      connectionURL = CommonConfiguration.getProperty("datanucleus.ConnectionURL","context0");
+      dbConnectionURL = CommonConfiguration.getProperty("datanucleus.ConnectionURL","context0");
   } else {
       System.out.println("The The DB_CONNECTION_URL environment variable was specified, will use it to connect to the Database.");
   }
 
   /* Go ahead and connect to the Database */
-  conn = DriverManager.getConnection(connectionURL, connectionProps);  
+  conn = DriverManager.getConnection(dbConnectionURL, connectionProps);  
 
   System.out.println("Connected to database for authentication.");
   return conn;


### PR DESCRIPTION
I added code to the ShepherdPMF.java module to use environment variables, or Docker secrets, or Kubernetes secrets for the Wildbook Database connections parameters:

datanucleus.ConnectionURL
datanucleus.ConnectionUserName
datanucleus.ConnectionPassword

This allows folks to deploy Wildbook in docker containers with docker-compose, docker stack deploy, or Kubernetes deployments very easily and securely.  No need to edit the jdoconfig.properties file and "rebuild" the war file.  See example below.

I've added lots of comments in the ShepherdPMF.java module.

The setup of the environment variables and secrets in done in a Tomcat **setenv.sh** script.
If the required variables are not exported then the jdoconfig.properties values are used.

## Example

```bash
$ echo "wildbook" | docker secret create wildbook-db-user -
yhma28514l3spyj6033ym155y

$ echo "Passw0rd#" | docker secret create wildbook-db-password -
6q3gew26hvv3x314ahzxgfceb

$ echo "jdbc:mysql://mysql-wildbook:3306/wildbook?useSSL=false&allowPublicKeyRetrieval=true" | docker secret create wildbook-db-connection-url -
9ur97son802lopbpaj8q1ant8

$ docker secret ls
ID                          NAME                         DRIVER              CREATED              UPDATED
9ur97son802lopbpaj8q1ant8   wildbook-db-connection-url                       5 seconds ago        5 seconds ago
6q3gew26hvv3x314ahzxgfceb   wildbook-db-password                             41 seconds ago       41 seconds ago
yhma28514l3spyj6033ym155y   wildbook-db-user                                 About a minute ago   About a minute ago
```

```yaml
$ cat docker-compose.yml
version: '3.3'

networks:
  wildbook-network:

volumes:
  wildbook-mysql-data:

configs:
  setenv.sh:
    file: ./setenv.sh

secrets:
  wildbook-db-user:
    external: true
  wildbook-db-password:
    external: true
  wildbook-db-connection-url:
    external: true

services:
  tomcat-wildbook:
    image: gforghetti/tomcat-wildbook:latest
    depends_on:
      - mysql-wildbook
    configs:
      - source: setenv.sh
        target: /usr/local/tomcat/bin/setenv.sh
        uid: '0'
        gid: '0'
        mode: 0700
    secrets:
      - wildbook-db-user
      - wildbook-db-password
      - wildbook-db-connection-url
    networks:
      - wildbook-network
    ports:
      - "8080:8080"

  mysql-wildbook:
    image: mysql:latest
    environment:
      - MYSQL_RANDOM_ROOT_PASSWORD="true"
      - MYSQL_DATABASE=wildbook
#      - MYSQL_USER=wildbook
      - MYSQL_USER_FILE=/run/secrets/wildbook-db-user
#      - MYSQL_PASSWORD=Passw0rd#
      - MYSQL_PASSWORD_FILE=/run/secrets/wildbook-db-password
    secrets:
      - wildbook-db-user
      - wildbook-db-password
    volumes:
      - wildbook-mysql-data:/var/lib/mysql
    networks:
      - wildbook-network
```

```bash
$ docker stack deploy app -c docker-compose.yml
Creating network app_wildbook-network
Creating config app_setenv.sh
Creating service app_mysql-wildbook
Creating service app_tomcat-wildbook
```

```bash
$ docker container ls
CONTAINER ID        IMAGE                               COMMAND                  CREATED             STATUS              PORTS                 NAMES
d683d2ebc330        mysql:latest                        "docker-entrypoint.s…"   40 seconds ago      Up 38 seconds       3306/tcp, 33060/tcp   app_mysql-wildbook.1.qcze2qwt0f21zidhjkpo48hzi
59ed27d7e919        gforghetti/tomcat-wildbook:latest   "catalina.sh run"        42 seconds ago      Up 39 seconds       8080/tcp              app_tomcat-wildbook.1.xoxo7fbsdw885mtc0iogrtgtp
```

```bash
$ docker container exec -it app_tomcat-wildbook.1.xoxo7fbsdw885mtc0iogrtgtp bash
bash-4.4# cd /run/secrets/
bash-4.4# ls -la
total 20
drwxr-xr-x    2 root     root          4096 Feb 10 20:05 .
drwxr-xr-x    1 root     root          4096 Feb 10 20:05 ..
-r--r--r--    1 root     root            84 Feb 10 20:05 wildbook-db-connection-url
-r--r--r--    1 root     root            10 Feb 10 20:05 wildbook-db-password
-r--r--r--    1 root     root             9 Feb 10 20:05 wildbook-db-user
bash-4.4# cat wildbook-db-connection-url
jdbc:mysql://mysql-wildbook:3306/wildbook?useSSL=false&allowPublicKeyRetrieval=true
bash-4.4# cat wildbook-db-password
Passw0rd#
bash-4.4# cat wildbook-db-user
wildbook
bash-4.4# exit
```

```bash
$ docker container logs app_tomcat-wildbook.1.xoxo7fbsdw885mtc0iogrtgtp 2>&1 | grep 'DB_'
Checking for the DB_USER environment variable.
The DB_USER_FILE environment variable was specified, will retrieve the value from the file and use it to connect to the Database.
Checking for the DB_PASSWORD environment variable.
The DB_PASSWORD_FILE environment variable was specified, will retrieve the value from the file and use it to connect to the Database.
Checking for the DB_CONNECTION_URL environment variable.
The DB_CONNECTION_URL_FILE environment variable was specified, will retrieve the value from the file and use it to connect to the Database.
```

<img width="1580" alt="login" src="https://user-images.githubusercontent.com/5776430/52539033-a2df9380-2d47-11e9-84a3-26b05cbb894d.png">

<img width="1836" alt="logged_in" src="https://user-images.githubusercontent.com/5776430/52539036-a83cde00-2d47-11e9-9add-4f302de0db32.png">
