### PR TITLE
Implemented explicit occurrence links for the CoOccurrence graph

### DIFF
--- a/src/main/webapp/individualSearchResultsAnalysis.jsp
+++ b/src/main/webapp/individualSearchResultsAnalysis.jsp
@@ -772,7 +772,7 @@ if(maxTimeBetweenResights>0){
 <script>
   let parser = new JSONParser('<%=individualIds%>', true, 50);
   let querier = new JSONQuerier(wildbookGlobals);
-  querier.preFetchData(null, null, null, [setupSocialgraph], ["#socialDiagram"], [parser]);
+  querier.preFetchData(null, null, null, [setupSocialGraph], ["#socialDiagram"], [parser]);
 </script>
 	 
  <div id="chart_div"></div>

--- a/src/main/webapp/javascript/bubbleDiagram/encounter-calls.js
+++ b/src/main/webapp/javascript/bubbleDiagram/encounter-calls.js
@@ -182,8 +182,7 @@ var makeTable = function(items, tableHeadLocation, tableBodyLocation, sortOn) {
     	    })
 	    .enter().append("td")
 	    .html(function(d) {
-		//console.log("Dxj", d);
-		//console.log("Dxk", typeof d);
+		console.log("D", d);
 		
 		if(d == 'TissueSample') {
 		    return "<img class='encounterImg' src='images/microscope.gif'/>";
@@ -197,15 +196,10 @@ var makeTable = function(items, tableHeadLocation, tableBodyLocation, sortOn) {
 		if(d == 'both') {
 		    return "<img class='encounterImg' src='images/microscope.gif'/><img class='encounterImg' src='images/Crystal_Clear_filesystem_folder_image.png'/>";
 		}
-		
 		if(typeof d == "object") {
-			//console.log("Dxm it's an object", typeof d);
 		    if(d.length <= 2) {
-		    	//console.log("Dxp it's an array");
-		    	//console.log("Dxo", d);
 			if(d[0] == 'edit'){
-				//console.log("Dxl it's an edit", d);
-			    return "XXY<button type='button' name='button' value='" + d[1] + "' class='btn btn-sm btn-block editRelationshipBtn' id='edit" + d[1] + "'>Edit</button>";
+			    return "<button type='button' name='button' value='" + d[1] + "' class='btn btn-sm btn-block editRelationshipBtn' id='edit" + d[1] + "'>Edit</button>";
 			} if(d[0] == 'remove') {
 			    return "<button type='button' name='button' value='" + d[1] + "' class='btn btn-sm btn-block deleteRelationshipBtn' id='remove" + d[1] + "'>Remove</button><div class='confirmDelete' value='" + d[1] + "'><p>Are you sure you want to delete this relationship?</p><button class='btn btn-sm btn-block yesDelete' type='button' name='button' value='" +d[1]+ "'>Yes</button><button class='btn btn-sm btn-block cancelDelete' type='button' name='button' value='" + d[1] + "'>No</button></div>";
 			}
@@ -215,8 +209,9 @@ var makeTable = function(items, tableHeadLocation, tableBodyLocation, sortOn) {
 			return "<a target='_blank' href='individuals.jsp?number=" + d[0] + "'>" + d[5] + "</a><br><span>" + dict['nickname'] + " : " + d[1]+ "</span><br><span>" + dict['alternateID'] + ": " + d[2] + "</span><br><span>" + dict['sex'] + ": " + d[3] + "</span><br><span>" + dict['haplotype'] +": " + d[4] + "</span>";
 		    }
 		}
-
-		//console.log("Dxz",d);
+		if(d == "GOS") {
+		    return "<a target='_blank' href='socialUnit.jsp?name=" + d + "'>" + d + "</a>"
+		}
 		return d; 
 	    });
 	
@@ -241,23 +236,6 @@ var makeTable = function(items, tableHeadLocation, tableBodyLocation, sortOn) {
 		} 
 		if(d == 'both') {
 		    return "<img class='encounterImg' src='images/microscope.gif'/><img class='encounterImg' src='images/Crystal_Clear_filesystem_folder_image.png'/>";
-		}
-		if(typeof d == "object") {
-			//console.log("Dxm it's an object", typeof d);
-		    if(d.length <= 2) {
-		    	//console.log("Dxp it's an array");
-		    	//console.log("Dxo", d);
-			if(d[0] == 'edit'){
-				//console.log("Dxl it's an edit", d);
-			    return "<button type='button' name='button' value='" + d[1] + "' class='btn btn-sm btn-block editRelationshipBtn' id='edit" + d[1] + "'>Edit</button>";
-			} if(d[0] == 'remove') {
-			    return "<button type='button' name='button' value='" + d[1] + "' class='btn btn-sm btn-block deleteRelationshipBtn' id='remove" + d[1] + "'>Remove</button><div class='confirmDelete' value='" + d[1] + "'><p>Are you sure you want to delete this relationship?</p><button class='btn btn-sm btn-block yesDelete' type='button' name='button' value='" +d[1]+ "'>Yes</button><button class='btn btn-sm btn-block cancelDelete' type='button' name='button' value='" + d[1] + "'>No</button></div>";
-			}
-			return d[0].italics() + "-" + d[1];
-		    }
-		    if(d.length > 2) {
-			return "<a target='_blank' href='individuals.jsp?number=" + d[0] + "'>" + d[5] + "</a><br><span>" + dict['nickname'] + " : " + d[1]+ "</span><br><span>" + dict['alternateID'] + ": " + d[2] + "</span><br><span>" + dict['sex'] + ": " + d[3] + "</span><br><span>" + dict['haplotype'] +": " + d[4] + "</span>";
-		    }
 		}
 		return d;
 	    });
@@ -483,7 +461,7 @@ var getRelationshipTableData = function(individualID) {
 	    var relatedSocialUnitName = jsonData[i].relatedSocialUnitName;
 	    var type = jsonData[i].type;
 	    var relationship = new Object();
-	    relationship = {"roles": [markedIndividualRole, relationshipWithRole], "relationshipWith": [whaleID], "type": type, "socialUnit": relatedSocialUnitName, "edit": ["edit", relationshipID], "remove": ["remove", relationshipID]};
+	    relationship = {roles: [markedIndividualRole, relationshipWithRole], relationshipWith: [whaleID], type: type, socialUnit: relatedSocialUnitName, edit: ["edit", relationshipID], remove: ["remove", relationshipID]};
 	    relationshipArray.push(relationship);
 	}
 	getIndividualData(relationshipArray);

--- a/src/main/webapp/javascript/relationshipDiagrams/forceLayoutAbstract.js
+++ b/src/main/webapp/javascript/relationshipDiagrams/forceLayoutAbstract.js
@@ -4,7 +4,7 @@ class ForceLayoutAbstract extends GraphAbstract {
 	super(individualId, containerId);
 
 	//Link attributes
-	this.linkWidth = 0.25;
+	this.linkWidth = 3;
 	this.maxLenScalar = 2.5;
 
 	//Link marker attributes

--- a/src/main/webapp/javascript/relationshipDiagrams/graphAbstract.js
+++ b/src/main/webapp/javascript/relationshipDiagrams/graphAbstract.js
@@ -393,6 +393,10 @@ class GraphAbstract { //See static attributes below class
 	let target = (link.target.data.individualID === this.id) ? "source" : "target";
 
 	let tooltipHtml = "";
+	if (link.explicitOccurrence) {
+	    tooltipHtml += "<b>Explicit Occurrence</b><br/>";
+	}
+	
 	let totalLinks = link.count, numLinks = 0;
 	for (let enc of link.validEncounters) {
 	    let time = enc.time;
@@ -405,7 +409,7 @@ class GraphAbstract { //See static attributes below class
 		break;
 	    }
 	    
-	    if (time)
+	    if (time && time.day && time.month && time.year)
 		tooltipHtml += "<b>Date: </b>" + time.day + "/" + time.month + "/" + time.year + " ";
 	    if (loc && typeof loc.lat == "number")
 		tooltipHtml += "<b>Longitude: </b>" + loc.lon + " ";
@@ -473,20 +477,18 @@ class GraphAbstract { //See static attributes below class
      * Zoom in when button is pressed
      */	
     zoomIn() {
-	
-	this.zoom.scaleBy(this.svg.transition().duration(750), 1.5);
+	this.zoom.translateExtent([[this.focusedNode.x, this.focusedNode.y],
+				   [this.focusedNode.x, this.focusedNode.y]])
+	    .scaleBy(this.svg.transition().duration(750), 1.5);
     }
 
     /**
      * Zoom out when button is pressed
      */	
     zoomOut() {
-	/*let scale = d3.event.transform.k;
-	this.svg.transition()
-	    .duration(this.transitionDuration)
-	    .attr("transform", "scale(" + (k / 1.5)  + ")");*/
-	
-	this.zoom.scaleBy(this.svg.transition().duration(750), 1 / 1.5);
+	this.zoom.translateExtent([[this.focusedNode.x, this.focusedNode.y],
+				   [this.focusedNode.x, this.focusedNode.y]])
+	    .scaleBy(this.svg.transition().duration(750), 1 / 1.5);
     }
 
     /**


### PR DESCRIPTION
## Changes

The CoOccurrence graph now displays explicit occurrences in addition to the previous links derived from spatial/temporal thresholds and encounters.

![image](https://user-images.githubusercontent.com/38484708/84983367-73842800-b0ed-11ea-8e2b-54d8a264ccab.png)

As pictured above, all links display a numeric count describing the number of spatial/temporal threshold derived "occurrences" which exist. Additionally, if an explicit occurrence exists, the corresponding link will feature an asterisk and prove unfilterable (though the "occurrence" count will still change). Let me know if you have any ideas for more intuitive ways to notify the user of the explicit occurrences. I played around with some different text colors/link styles but found the contrast lacking.

Additionally, the global species SocialGraph was fixed.

![image](https://user-images.githubusercontent.com/38484708/84983342-649d7580-b0ed-11ea-81df-dd042f85396f.png)

## ToDo

As you may observe, there is still no guarantee that all explicit occurrences will be included in the CoOccurrence graph. This is due to the maxNodes limitation along with the methodology by which nodes are selected. The typical goal is to display 30 some nodes, with preference granted to those which share more direct social relationships with the central node (if one exists). Otherwise node seleciton is effectively random. I intend to modify CoOccurrence graph to grant preference to nodes which share an occurrence with the central node (instead of a social relationship).

Currently explicit occurrence data is queried directly from the psql table. Would it be possible to create a .jsp file to optimize performance/encourage uniformity?

Let me know if any errors pop up, or if the code goes live. I'd like to verify everything seems to have integrated well. Thanks! :)