### PR TITLE
Do not display map marker if latitude and longitude are not present on an Encounter

### DIFF
--- a/src/main/webapp/encounters/encounter.jsp
+++ b/src/main/webapp/encounters/encounter.jsp
@@ -1284,7 +1284,7 @@ if(CommonConfiguration.showProperty("showCountry",context)){
 	   		if(((enc.getDecimalLatitude()==null)||(enc.getDecimalLongitude()==null))||(!visible)){
 	   		%>
 
-	   			marker.setVisible(true);
+	   			marker.setVisible(false);
 
 	   		<%
 	   		}


### PR DESCRIPTION
This PR fixes a small logical flaw in the display logic of map markers, preventing a marker from being displayed at 0,0 on the map if the Encounter object does not have both a latitude and a longitude.

PR fixes #995 

**Before you Submit!**
* Is all the text internationalized?
* If you made a change to the header, did you update the react, jsp, and html?
* Are all depedencies at a locked version?
* Did you adhere to [best practices](https://wildbook.docs.wildme.org/contribute/code-guide.html)?
* Is there a quick [unit test](https://wildbook.docs.wildme.org/contribute/tests.html) you can add?
