### PR TITLE
iaResultsSetID.jsp fix: skip loop when otherEncIds is null

### DIFF
--- a/src/main/webapp/iaResultsSetID.jsp
+++ b/src/main/webapp/iaResultsSetID.jsp
@@ -98,7 +98,7 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
 	//res.put("encounterOther", otherEncIds);
 	List<Encounter> otherEncs = new ArrayList<Encounter>();
         List<MarkedIndividual> otherIndivs = new ArrayList<MarkedIndividual>();
-        for (String oeId : otherEncIds) {
+        if (otherEncIds != null) for (String oeId : otherEncIds) {
 		Encounter oenc = myShepherd.getEncounter(oeId);
 		myShepherd.getPM().refresh(oenc);
 


### PR DESCRIPTION
PR fixes #1033 

only enter loop when we dont have a null value

from the notes on the issue (adding emphasis):

> the 500 error thrown when a user does the noted action is due to a NullPointerException at this line of code: `for (String oeId : otherEncIds) {` (namely, `otherEncIds` is null).
> 
> i believe the code **still will work as expected**, getting the desired results, if we simply prevent this loop from happening when otherEncIds is null. however, **someone one more familiar with this Project-specific variation on the behavior of this page should review**.