### PR TITLE
Fix date added end of day filter in legacy Encounter Search

### DIFF
--- a/src/main/java/org/ecocean/EncounterQueryProcessor.java
+++ b/src/main/java/org/ecocean/EncounterQueryProcessor.java
@@ -44,6 +44,7 @@ public class EncounterQueryProcessor extends QueryProcessor {
         String jdoqlVariableDeclaration = "";
         String parameterDeclaration = "";
         String context = "context0";
+        long endOfDayMilliseconds = 24 * 60 * 60 * 1000 - 1;
 
         context = ServletUtilities.getContext(request);
         Shepherd myShepherd = new Shepherd(context);
@@ -1442,7 +1443,7 @@ public class EncounterQueryProcessor extends QueryProcessor {
                     long date1Millis = date1.getMillis();
                     long date2Millis = date2.getMillis();
                     // if same dateTime is set by both pickers, then add a full day of milliseconds to picker2 to cover the entire day
-                    date2Millis += (24 * 60 * 60 * 1000 - 1);
+                    date2Millis += endOfDayMilliseconds;
 
                     prettyPrint.append("Dates between: " +
                         date1.toString(ISODateTimeFormat.date()) + " and " +
@@ -1472,10 +1473,10 @@ public class EncounterQueryProcessor extends QueryProcessor {
                         date2.toString(ISODateTimeFormat.date()) + "<br />");
                     if (filter.equals(SELECT_FROM_ORG_ECOCEAN_ENCOUNTER_WHERE)) {
                         filter += "((dwcDateAddedLong >= " + date1.getMillis() +
-                            ") && (dwcDateAddedLong <= " + date2.getMillis() + "))";
+                            ") && (dwcDateAddedLong <= " + (date2.getMillis()+endOfDayMilliseconds) + "))";
                     } else {
                         filter += " && ((dwcDateAddedLong >= " + date1.getMillis() +
-                            ") && (dwcDateAddedLong <= " + date2.getMillis() + "))";
+                            ") && (dwcDateAddedLong <= " + (date2.getMillis()+endOfDayMilliseconds) + "))";
                     }
                 } catch (NumberFormatException nfe) {
                     // do nothing, just skip on


### PR DESCRIPTION
Fixes the end of the range selector for legacy Encounter Search's Date Added filter to be inclusive of the whole day (i.e. up to 23:59:59.999).

PR fixes #1049 
