### PR TITLE
time math bug fix (for indexing)

### DIFF
--- a/src/main/java/org/ecocean/Util.java
+++ b/src/main/java/org/ecocean/Util.java
@@ -164,7 +164,6 @@ public class Util {
         List<String> values = CommonConfiguration.getIndexedPropertyValues("samplingProtocol",
             context);
         List<OptionDesc> list = new ArrayList<OptionDesc>();
-
         int valuesSize = values.size();
 
         for (int i = 0; i < valuesSize; i++) {
@@ -597,7 +596,7 @@ public class Util {
         return null;
     }
 
-    //GPS Longitude: "-69.0° 22.0' 45.62999999998169"",
+    // GPS Longitude: "-69.0° 22.0' 45.62999999998169"",
     public static Double latlonDMStoDD(String dms) {
         String[] d = dms.split(" +");
 
@@ -1120,7 +1119,7 @@ public class Util {
     public static long getVersionFromModified(final String modified) {
         if (!stringExists(modified)) return 0;
         try {
-            String iso8601 = getISO8601Date(modified);
+            String iso8601 = roundISO8601toMillis(getISO8601Date(modified));
             if (iso8601 == null) return 0;
             // switching from DateTimeFormatter to DateTime here because the math seems to line up with how psql does it -jon
             return new DateTime(iso8601).getMillis();
@@ -1128,6 +1127,12 @@ public class Util {
             e.printStackTrace();
             return 0;
         }
+    }
+
+    public static String roundISO8601toMillis(final String input) {
+        if ((input == null) || (input.length() < 24)) return input;
+        float seconds = Float.parseFloat(input.substring(17)) + 0.0005f;
+        return input.substring(0, 17) + String.valueOf(seconds).substring(0, 6);
     }
 
     // note: this respect user.receiveEmails - you have been warned
@@ -1145,7 +1150,6 @@ public class Util {
     public static String getISO8601Date(final String date) {
         if (date == null) return null;
         String iso8601 = date.replace(" ", "T");
-
         if (iso8601.length() == 10) iso8601 += "T00:00:00";
         // TODO: better testing of date's string format (or transition to date format support?)
         if (iso8601.length() < 16) return null;

--- a/src/main/java/org/ecocean/Util.java
+++ b/src/main/java/org/ecocean/Util.java
@@ -1131,8 +1131,11 @@ public class Util {
 
     public static String roundISO8601toMillis(final String input) {
         if ((input == null) || (input.length() < 24)) return input;
-        float seconds = Float.parseFloat(input.substring(17)) + 0.0005f;
-        return input.substring(0, 17) + String.valueOf(seconds).substring(0, 6);
+        try {
+            float seconds = Float.parseFloat(input.substring(17)) + 0.0005f;
+            return input.substring(0, 17) + String.valueOf(seconds).substring(0, 6);
+        } catch (Exception ex) {}
+        return input;
     }
 
     // note: this respect user.receiveEmails - you have been warned

--- a/src/test/java/org/ecocean/UtilTest.java
+++ b/src/test/java/org/ecocean/UtilTest.java
@@ -1,0 +1,27 @@
+package org.ecocean;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.Assert.*;
+
+class UtilTest {
+    @Test void testRoundISO8601toMillis() {
+        // should just passthru unchanged
+        String testVal = "2024-10-28T16:36:56.656";
+
+        assertEquals(testVal, Util.roundISO8601toMillis(testVal));
+        testVal = "2024-10-28T16:36:56";
+        assertEquals(testVal, Util.roundISO8601toMillis(testVal));
+        assertNull(Util.roundISO8601toMillis(null));
+
+        // this should round up
+        testVal = "2024-10-28T16:36:56.656839";
+        assertEquals("2024-10-28T16:36:56.657", Util.roundISO8601toMillis(testVal));
+        // round down
+        testVal = "2024-10-28T16:36:56.656039";
+        assertEquals("2024-10-28T16:36:56.656", Util.roundISO8601toMillis(testVal));
+
+        // should fall thru due to exception in parsing float
+        testVal = "2024-10-28T16:36:56.1ABC";
+        assertEquals(testVal, Util.roundISO8601toMillis(testVal));
+    }
+}


### PR DESCRIPTION
but in time conversion had problem with microseconds getting rounded wrong and causing index time math to be off.
fixed with a method to round to nearest milliseconds on ISO8601 times.

PR fixes #861 
