### PR TITLE
Change default context to Wildbook

### DIFF
--- a/src/main/resources/bundles/contexts.properties
+++ b/src/main/resources/bundles/contexts.properties
@@ -5,7 +5,7 @@ defaultContext = context0
 
 
 context0DataDir = wildbook_data_dir
-context0Name = Flukebook.org
+context0Name = Wildbook
 #context0DomainName0 = mydomain.com
 
 #context0DomainName1 = myotherdomain.com


### PR DESCRIPTION
Changes the default context to a generic "Wildbook" rather than Flukebook.org