### PR TITLE
Switch to postDelete for unindexing in WildbookLifecycleManager

### DIFF
--- a/src/main/java/org/ecocean/WildbookLifecycleListener.java
+++ b/src/main/java/org/ecocean/WildbookLifecycleListener.java
@@ -29,12 +29,10 @@ public class WildbookLifecycleListener implements StoreLifecycleListener, Delete
         
         if (Base.class.isInstance(obj)) {
             Base base = (Base)obj;
-            System.out.println("WildbookLifecycleListener preDelete() event on " + base);
             try {
                 
             	base.opensearchUnindexDeep();
-            	
-                
+            	               
             } catch (Exception ex) {
                 ex.printStackTrace();
             }

--- a/src/main/java/org/ecocean/WildbookLifecycleListener.java
+++ b/src/main/java/org/ecocean/WildbookLifecycleListener.java
@@ -14,32 +14,11 @@ public class WildbookLifecycleListener implements StoreLifecycleListener, Delete
     public void preDelete(InstanceLifecycleEvent event) {
         Persistable obj = (Persistable)event.getSource();
 
-/*
-        System.out.println("WildbookLifecycleListener preDelete() event type=" +
-            event.getEventType() + "; source=" + obj + "; target=" + event.getTarget() +
-            "; detachedInstance=" + event.getDetachedInstance() + "; persistentInstance=" +
-            event.getPersistentInstance());
- */
-        if (Base.class.isInstance(obj)) {
-            Base base = (Base)obj;
-            System.out.println("WildbookLifecycleListener preDelete() event on " + base);
-            try {
-                
-            	//old way = direct indexing
-            	//base.opensearchUnindexDeep();
-            	//new way - put indexing in managed queue
-            	IndexingManager im=IndexingManagerFactory.getIndexingManager();
-            	im.addIndexingQueueEntry(base,true);
-            	
-                
-            } catch (Exception ex) {
-                ex.printStackTrace();
-            }
-        }
+
     }
 
     public void postDelete(InstanceLifecycleEvent event) {
-        Persistable obj = (Persistable)event.getSource();
+        Persistable obj = (Persistable)event.getDetachedInstance();
 
         // cannot actually use obj, as it will throw: javax.jdo.JDOUserException: Cannot read fields from a deleted object
 /*
@@ -47,6 +26,20 @@ public class WildbookLifecycleListener implements StoreLifecycleListener, Delete
             event.getEventType() + "; source id=" + obj.dnGetObjectId());
         // System.out.println("WildbookLifecycleListener postDelete() event type=" + event.getEventType() + "; source=" + obj + "; target=" + event.getTarget() + "; detachedInstance=" + event.getDetachedInstance() + "; persistentInstance=" + event.getPersistentInstance());
  */
+        
+        if (Base.class.isInstance(obj)) {
+            Base base = (Base)obj;
+            System.out.println("WildbookLifecycleListener preDelete() event on " + base);
+            try {
+                
+            	base.opensearchUnindexDeep();
+            	
+                
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
+        
     }
 
     public void preStore(InstanceLifecycleEvent event) {}


### PR DESCRIPTION
Predelete unindexing was allowing later lifecycle states to reindex the object. Post delete allows us to unindex last and use a detached database object to check with OpenSearch

