### PR TITLE
Invert Encounter permissions check

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -3964,9 +3964,9 @@ public class Encounter extends Base implements java.io.Serializable {
         try {
             q = myShepherd.getPM().newQuery("javax.jdo.query.SQL", sql);
             List results = (List)q.execute();
+            Util.mark("perm: start encs, size=" + results.size(), startT);
             Iterator it = results.iterator();
             q.closeAll();
-            Util.mark("perm: start encs, size=" + results.size(), startT);
             while (it.hasNext()) {
                 Object[] row = (Object[])it.next();
                 String id = (String)row[0];

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -3966,7 +3966,6 @@ public class Encounter extends Base implements java.io.Serializable {
             List results = (List)q.execute();
             Util.mark("perm: start encs, size=" + results.size(), startT);
             Iterator it = results.iterator();
-            q.closeAll();
             while (it.hasNext()) {
                 Object[] row = (Object[])it.next();
                 String id = (String)row[0];
@@ -4036,7 +4035,7 @@ public class Encounter extends Base implements java.io.Serializable {
             System.out.println("opensearchIndexPermissions(): failed during encounter loop: " + ex);
             ex.printStackTrace();
         } finally {
-            
+        	if(q!=null)q.closeAll();
         }
         Util.mark("perm: done encs", startT);
         myShepherd.rollbackAndClose();

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -4005,7 +4005,7 @@ public class Encounter extends Base implements java.io.Serializable {
                 //better: ask the question, who else can see this encounter via collaboration?
                 //get the entry set for all collaborations
                 Set<String> uids=collab.keySet();
-                //iterate over the entry set
+                //iterate over the key set
                 Iterator<String> uidsIter=uids.iterator();
                 while(uidsIter.hasNext()) {
                 	
@@ -4013,7 +4013,7 @@ public class Encounter extends Base implements java.io.Serializable {
                 	String localUid = uidsIter.next();
                 	//get the list of usernames in this entry
                 	Set<String> localCollabs = collab.get(localUid);
-                	//eva;uate if the submitterId (a username) of this encounter is in this list
+                	//evaluate if the submitterId (a username) of this encounter is in this list
                 	if(localCollabs.contains(submitterId)) {
                 		//if the submitterId is in the list, put the uid of the user in viewUsers for OpenSearch
                 		viewUsers.put(localUid);


### PR DESCRIPTION
This inverts the permissions list sent to OpenSearch for an Encounter.

Previously we asked the question: who is the Encounter owner collaborating with to determine who else could see it. This ignored the fact that orgAdmins can see data for users in their org.

This PR inverts the logic and says: based on the ownership of the Encounter, who else can see the Encounter via collaboration (direct of dynamic via orgAdmin roles).

Should not impact performance as we're just rearranging iteration logic on existing arrays.

PR also reduces memory leak risk by properly closing query after Iterator is created. 


PR fixes #1149 

**Before you Submit!**
* Is all the text internationalized?
* If you made a change to the header, did you update the react, jsp, and html?
* Are all depedencies at a locked version?
* Did you adhere to [best practices](https://wildbook.docs.wildme.org/contribute/code-guide.html)?
* Is there a quick [unit test](https://wildbook.docs.wildme.org/contribute/tests.html) you can add?
