### PR TITLE
set background indexing false when background indexing done (even on failure)

### DIFF
--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -159,7 +159,9 @@ public class OpenSearch {
                         myShepherd.rollbackAndClose();
                     } catch (Exception ex) {
                         ex.printStackTrace();
+                    } finally {
                         myShepherd.rollbackAndClose();
+                        unsetActiveIndexingBackground();
                     }
                 }
             }, 2, // initial delay


### PR DESCRIPTION
a failed sub-task (indexing of individual classes) would cause background indexing boolean to stay `true`, preventing subsequent background indexing attempts from running. 