### PR TITLE
Fixes rare copy and paste error related to social unit display in mat…

### DIFF
--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -1373,12 +1373,12 @@ console.info('qdata[%s] = %o', taskId, qdata);
                 var displayName = ft.displayName;
                 if (encId) {
                 	imgInfo += ' <a xstyle="margin-top: -6px;" class="enc-link"  href="encounters/encounter.jsp?number=' + encId + '" title="open encounter ' + encId + '">Enc ' + encId.substring(0,6) + '</a>';
-                	console.log("another encId = "+encId);
+                	//console.log("another encId = "+encId);
                 }
                 if (indivId) imgInfo += ' <a class="indiv-link" title="open individual page"  href="individuals.jsp?number=' + indivId + '">' + displayName + '</a>';
                 //add social unit name
                 if(socialUnitName){
-                	thisResultLine.append('<a class="indiv-link"  href="socialUnit.jsp?name=' + socialUnitName + '" title="'+socialUnitName+'">' + socialUnitName.substring(0,10) + '</a>');
+                	imgInfo +='<a class="indiv-link"  href="socialUnit.jsp?name=' + socialUnitName + '" title="'+socialUnitName+'">' + socialUnitName.substring(0,10) + '</a>';
                 }
             }
             imgInfo += '</li>';


### PR DESCRIPTION
…ch results

Fixes a long-standing copy and paste error that could break JS rendering in iaResults.jsp and produce an artifically small subset of results where a match candidate belonged to a social unit.
