### PR TITLE
Handles rare exceptions in locationID handling on this page

### DIFF
--- a/src/main/webapp/encounters/encounterVM.jsp
+++ b/src/main/webapp/encounters/encounterVM.jsp
@@ -76,7 +76,9 @@
     	String locs = "";
     	List<String> lids = myShepherd.getAllLocationIDs();
     	for (String l : lids) {
-        	locs += "\t'" + l + "',\n";
+    		if(l!=null){
+        		locs += "\t'" + l.replaceAll("'"," ") + "',\n";
+    		}
     	}
 		%>
 

--- a/src/main/webapp/encounters/encounterVM.jsp
+++ b/src/main/webapp/encounters/encounterVM.jsp
@@ -77,7 +77,7 @@
     	List<String> lids = myShepherd.getAllLocationIDs();
     	for (String l : lids) {
     		if(l!=null){
-        		locs += "\t'" + l.replaceAll("'"," ") + "',\n";
+        		locs += "\t\"" + l + "\",\n";
     		}
     	}
 		%>


### PR DESCRIPTION
This fix handles two rare issues related to locationID that can happen to cause visual matcher page failures (failure to display any content at all)

1. The fix prevents single quotes in location ID names from breaking JavaScript via use of the single qute delimiter
2. The fix ensures that any LocationID is not null.

