### PR TITLE
Aligns allowed, default DB connections in DataNucleus to the same value in postgresq…

### DIFF
--- a/src/main/resources/bundles/jdoconfig.properties
+++ b/src/main/resources/bundles/jdoconfig.properties
@@ -49,7 +49,7 @@ datanucleus.connectionPoolingType = dbcp2
 #
 datanucleus.connectionPool.maxIdle=10
 datanucleus.connectionPool.minIdle=5
-datanucleus.connectionPool.maxActive=30
+datanucleus.connectionPool.maxActive=300
 datanucleus.connectionPool.maxWait=-1
 datanucleus.connectionPool.testSQL=SELECT 1
 #


### PR DESCRIPTION
…l.conf

Our default PostgreSQL allowed connections is 300 while DataNucleus limited Wildbook to 30, which may not be enough during intensive OpenSearch indexing. This commit aligns Wildbook's allowed DB connections with that of PostgreSQL and supports more intensive indexing by default. The net effect should be better responsiveness during indexing. 300 allowed connections is still quite conservative given the recommended hardware.
