### PR TITLE
use meta-refresh to redirect legacy bulk import page to new react-based bulk import

### DIFF
--- a/src/main/webapp/import/instructions.jsp
+++ b/src/main/webapp/import/instructions.jsp
@@ -14,6 +14,7 @@
 	org.apache.commons.io.FileUtils" %>
 <%@ page import="org.ecocean.shepherd.core.Shepherd" %>
 
+
 <%
 String context = ServletUtilities.getContext(request);
 Shepherd myShepherd=new Shepherd(context);
@@ -30,6 +31,7 @@ String wbName = ContextConfiguration.getNameForContext(context);
 
 %>
 <jsp:include page="../header.jsp" flush="true"/>
+<meta http-equiv="refresh" content="0; url=/react/bulk-import" />
 <style> 
 .import-explanation {
 }


### PR DESCRIPTION
`/import/instructions.jsp` is the page used to start a _legacy_ bulk import. some users have this bookmarked and thus are doing legacy bulk imports.

this change inserts a `<meta ...>` refresh on this page which should kick the user to the new import page.

PR fixes #1223 