### PR TITLE
fix for incorrect country list (in react-based validation)

### DIFF
--- a/src/main/java/org/ecocean/Util.java
+++ b/src/main/java/org/ecocean/Util.java
@@ -4,8 +4,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -1215,5 +1217,19 @@ public class Util {
         if (iso8601.length() < 16) return null;
         if (iso8601.length() == 16) iso8601 += 'Z';
         return iso8601;
+    }
+
+    // from issue #1227, there are a couple ways to derive a list of valid countries (e.g. for validating
+    // bulk import data), including some based on CommonConfiguration. for now we are using a canned list
+    // but might be adjusted later to allow customization
+    public static List<String> getCountries() {
+        List<String> cnames = new ArrayList<String>();
+
+        for (String code : Locale.getISOCountries()) {
+            Locale obj = new Locale("", code);
+            cnames.add(obj.getDisplayCountry());
+        }
+        Collections.sort(cnames);
+        return cnames;
     }
 }

--- a/src/main/java/org/ecocean/api/SiteSettings.java
+++ b/src/main/java/org/ecocean/api/SiteSettings.java
@@ -90,8 +90,7 @@ public class SiteSettings extends ApiBase {
                 CommonConfiguration.getIndexedPropertyValues("lifeStage", context));
             settings.put("livingStatus",
                 CommonConfiguration.getIndexedPropertyValues("livingStatus", context));
-            settings.put("country",
-                CommonConfiguration.getIndexedPropertyValues("country", context));
+            settings.put("country", Util.getCountries());
             settings.put("annotationViewpoint", Annotation.getAllValidViewpointsSorted());
             settings.put("patterningCode",
                 CommonConfiguration.getIndexedPropertyValues("patterningCode", context));

--- a/src/test/java/org/ecocean/UtilTest.java
+++ b/src/test/java/org/ecocean/UtilTest.java
@@ -1,6 +1,7 @@
 package org.ecocean;
 
 import java.util.Calendar;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import static org.junit.Assert.*;
 
@@ -42,5 +43,16 @@ class UtilTest {
         assertTrue(Util.dateIsInFuture(year, month + 1, null));
         assertTrue(Util.dateIsInFuture(year, month, day + 1));
         assertTrue(Util.dateIsInFuture(year + 1, month, day));
+    }
+
+    // some of these assertions may fail if the world collapses
+    // into political chaos
+    @Test void testCountries() {
+        List<String> cs = Util.getCountries();
+
+        assertNotNull(cs);
+        assertTrue(cs.size() > 100);
+        assertTrue(cs.contains("Palestinian Territories"));
+        assertTrue(cs.contains("United States"));
     }
 }


### PR DESCRIPTION
list of valid countries (used by react-based bulk import) was incorrect. now uses full list, rather than CommonConfiguration-based one. 

PR fixes #1227 
