### PR TITLE
show individual name rather than uuid in bulk import listing

### DIFF
--- a/frontend/src/pages/BulkImport/BulkImportTask.jsx
+++ b/frontend/src/pages/BulkImport/BulkImportTask.jsx
@@ -115,6 +115,7 @@ const BulkImportTask = observer(() => {
       user: item.submitter?.displayName || "-",
       occurrenceID: item.occurrenceId || "-",
       individualID: item.individualId || "-",
+      individualName: item.individualDisplayName || item.individualId || "-",
       imageCount: item.numberMediaAssets,
       class: classArray,
     };
@@ -165,15 +166,15 @@ const BulkImportTask = observer(() => {
     },
     {
       name: "Individual ID",
-      selector: (row) => row.individualID,
+      selector: (row) => row.individualName,
       cell: (row) =>
-        row.individualID !== "-" ? (
+        row.individualName !== "-" ? (
           <a
             href={`/individuals.jsp?id=${row.individualID}`}
             target="_blank"
             rel="noreferrer"
           >
-            {row.individualID}
+            {row.individualName}
           </a>
         ) : (
           "-"

--- a/src/main/java/org/ecocean/api/BulkImport.java
+++ b/src/main/java/org/ecocean/api/BulkImport.java
@@ -905,6 +905,7 @@ public class BulkImport extends ApiBase {
                     if (enc.hasMarkedIndividual()) {
                         indivIds.add(enc.getIndividualID());
                         encj.put("individualId", enc.getIndividualID());
+                        encj.put("individualDisplayName", enc.getDisplayName());
                     }
                     encj.put("numberMediaAssets", enc.numAnnotations());
                     User sub = enc.getSubmitterUser(myShepherd);


### PR DESCRIPTION
- add `individualDisplayName` to each encounter in api for bulk import tasks
- frontend displays above instead of uuid

PR fixes #1248 
