### PR TITLE
Ensures theta set on Annotation as well as in the parameters

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -365,7 +365,7 @@ public class Annotation extends Base implements java.io.Serializable {
     }
 
 // .theta property on Annotation usage is deprecated, instead we get
-// the value from the Feature [and likewise deprecate setTheta)]
+// the value from the Feature [ and likewise deprecate setTheta() ]
     public double getTheta() {
         Feature ft = getFeature();
 


### PR DESCRIPTION
The Annotation theta was being stored only in the parameters of the Annotation and not on the theta of the Annotation itself. Thsi meant that everything looked good from the Wildbook side, but the new Manual Annotation tool was sending theta to WBIA as 0.0 always. This ensures that theta is stored on the Annotation too.
