### PR TITLE
sort bulk import listing of encounters

### DIFF
--- a/frontend/src/components/SimpleDataTable.jsx
+++ b/frontend/src/components/SimpleDataTable.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useContext } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import DataTable from "react-data-table-component";
 import ReactPaginate from "react-paginate";
 import { Row, Col } from "react-bootstrap";
@@ -26,26 +26,13 @@ const SimpleDataTable = ({ columns = [], data = [], perPage = 10 }) => {
     setPagedData(data.slice(start, end));
   }, [data, currentPage, perPage]);
 
-  const wrappedColumns = useMemo(() => {
-    const indexColumn = {
-      id: "__index",
-      name: "#",
-      selector: (_, index) => index + 1 + currentPage * perPage,
-      sortable: false,
-      width: "60px",
-      cell: (_, index) => index + 1 + currentPage * perPage,
-    };
-
-    const userColumns = columns.map((col) => ({
-      id: col.selector,
-      name: col.name,
-      selector: col.selector,
-      sortable: col.sortable ?? true,
-      cell: col.cell || ((row) => row[col.selector] || "-"),
-    }));
-
-    return [indexColumn, ...userColumns];
-  }, [columns, currentPage, perPage]);
+  const userColumns = columns.map((col) => ({
+    id: col.selector,
+    name: col.name,
+    selector: col.selector,
+    sortable: col.sortable ?? true,
+    cell: col.cell || ((row) => row[col.selector] || "-"),
+  }));
 
   const conditionalRowStyles = [
     {
@@ -70,13 +57,13 @@ const SimpleDataTable = ({ columns = [], data = [], perPage = 10 }) => {
 
   const dataWithIndex = pagedData.map((row, index) => ({
     ...row,
-    tableID: currentPage * perPage + index,
+    tableID: row.tableID ?? currentPage * perPage + index + 1,
   }));
 
   return (
     <div className="container mt-3">
       <DataTable
-        columns={wrappedColumns}
+        columns={userColumns}
         data={dataWithIndex}
         customStyles={customStyles}
         conditionalRowStyles={conditionalRowStyles}

--- a/frontend/src/pages/BulkImport/BulkImportTask.jsx
+++ b/frontend/src/pages/BulkImport/BulkImportTask.jsx
@@ -122,24 +122,20 @@ const BulkImportTask = observer(() => {
     };
   });
 
-  const sortedTableData = tableData.sort((a, b) => {
-    return new Date(b.createdMillis) - new Date(a.createdMillis);
-  });
+  const sortedTableData = tableData
+    .sort((a, b) => {
+      return new Date(a.createdMillis) - new Date(b.createdMillis);
+    })
+    .map((item, index) => ({
+      tableID: index + 1,
+      ...item,
+    }));
 
   const columns = [
     {
-      name: "Created At",
-      selector: (row) => row.createdMillis,
-      cell: (row) => {
-        console.log("Created At:", row.createdMillis);
-        const date = new Date(Number(row.createdMillis));
-        if (isNaN(date)) return "-";
-        return date
-          .toISOString()
-          .replace("T", " ")
-          .replace("Z", "")
-          .slice(0, 19);
-      },
+      name: "#",
+      cell: (row) => row.tableID,
+      selector: (row) => row.tableID,
     },
     {
       name: "Encounter ID",

--- a/frontend/src/pages/BulkImport/BulkImportTask.jsx
+++ b/frontend/src/pages/BulkImport/BulkImportTask.jsx
@@ -118,10 +118,29 @@ const BulkImportTask = observer(() => {
       individualName: item.individualDisplayName || item.individualId || "-",
       imageCount: item.numberMediaAssets,
       class: classArray,
+      createdMillis: item.createdMillis || "-",
     };
   });
 
+  const sortedTableData = tableData.sort((a, b) => {
+    return new Date(b.createdMillis) - new Date(a.createdMillis);
+  });
+
   const columns = [
+    {
+      name: "Created At",
+      selector: (row) => row.createdMillis,
+      cell: (row) => {
+        console.log("Created At:", row.createdMillis);
+        const date = new Date(Number(row.createdMillis));
+        if (isNaN(date)) return "-";
+        return date
+          .toISOString()
+          .replace("T", " ")
+          .replace("Z", "")
+          .slice(0, 19);
+      },
+    },
     {
       name: "Encounter ID",
       selector: (row) => row.encounterID,
@@ -389,7 +408,7 @@ const BulkImportTask = observer(() => {
           />
         </div>
 
-        <SimpleDataTable columns={columns} data={tableData} />
+        <SimpleDataTable columns={columns} data={sortedTableData} />
       </section>
 
       <Row>

--- a/src/main/java/org/ecocean/api/BulkImport.java
+++ b/src/main/java/org/ecocean/api/BulkImport.java
@@ -896,12 +896,13 @@ public class BulkImport extends ApiBase {
         Set<String> indivIds = new HashSet<String>();
         if (task.numberEncounters() > 0) {
             JSONArray encArr = new JSONArray();
-            for (Encounter enc : task.getEncounters()) {
+            for (Encounter enc : task.getEncountersOrderByCreated()) {
                 JSONObject encj = new JSONObject();
                 encj.put("id", enc.getId());
                 if (detailed) {
                     encj.put("id", enc.getId());
                     encj.put("date", enc.getDate());
+                    encj.put("createdMillis", enc.getDWCDateAddedLong());
                     encj.put("occurrenceId", enc.getOccurrenceID());
                     if (enc.hasMarkedIndividual()) {
                         indivIds.add(enc.getIndividualID());

--- a/src/main/java/org/ecocean/servlet/importer/ImportTask.java
+++ b/src/main/java/org/ecocean/servlet/importer/ImportTask.java
@@ -82,6 +82,20 @@ public class ImportTask implements java.io.Serializable {
         return encounters;
     }
 
+    public List<Encounter> getEncountersOrderByCreated() {
+        if (encounters == null) return null;
+        List<Encounter> sorted = new ArrayList<Encounter>(encounters);
+        Collections.sort(sorted, new Comparator<Encounter>() {
+            @Override public int compare(Encounter encA, Encounter encB) {
+                Long longA = encA.getDWCDateAddedLong();
+                Long longB = encB.getDWCDateAddedLong();
+                if ((longA == null) || (longB == null)) return 0;
+                return Long.compare(longA, longB);
+            }
+        });
+        return sorted;
+    }
+
     public void setEncounters(List<Encounter> encs) {
         encounters = encs;
     }


### PR DESCRIPTION
PR fixes #1270 

- bulk import api now returns listing of encounters in order they were created (to match spreadsheet order)
- each encounter also has additional field `createdMillis` to facilitate sorting on frontend