### PR TITLE
disallow submission when files uploaded, but none valid

### DIFF
--- a/src/main/java/org/ecocean/media/AssetStore.java
+++ b/src/main/java/org/ecocean/media/AssetStore.java
@@ -584,7 +584,7 @@ public abstract class AssetStore implements java.io.Serializable {
                 if (exif != null) data.put("exif", exif);
             } catch (IOException ioe) {
                 System.out.println("WARNING: extractMetadataExif threw " + ioe.toString() + " on " +
-                    ma + "; ignoring");
+                    ma + "; file=" + file + "; ignoring");
             }
         }
         return new MediaAssetMetadata(data);

--- a/src/main/java/org/ecocean/media/MediaAsset.java
+++ b/src/main/java/org/ecocean/media/MediaAsset.java
@@ -1482,7 +1482,7 @@ public class MediaAsset extends Base implements java.io.Serializable {
             } else {
                 System.out.println(
                     "WARNING: validateSourceImage was called on a non-image or corrupt MediaAsset with Id: "
-                    + this.getId());
+                    + this.getId() + "; path=" + lPath);
                 this.validImageForIA = false;
             }
         }

--- a/src/main/java/org/ecocean/servlet/EncounterForm.java
+++ b/src/main/java/org/ecocean/servlet/EncounterForm.java
@@ -453,6 +453,18 @@ public class EncounterForm extends HttpServlet {
                 makeMediaAssetsFromJavaFileItemObject(item, encID, astore, enc, newAnnotations,
                     genus, specificEpithet);
             }
+            int numFilesAdded = 0;
+            int numFilesGood = 0;
+            for (Annotation ann : newAnnotations) {
+                MediaAsset ma = ann.getMediaAsset();
+                if (ma == null) continue;
+                numFilesAdded += 1;
+                if (ma.isValidImageForIA()) numFilesGood += 1;
+            }
+            if ((numFilesAdded > 0) && (numFilesGood == 0)) {
+                System.out.println("no files good out of " + numFilesAdded + "; aborting submission");
+                throw new ServletException("No valid images files found in " + numFilesAdded + " files submitted");
+            }
             System.out.println("BBB: Checking if we have social files...");
             if (socialFiles.size() > 0) {
                 int numSocialFiles = socialFiles.size();


### PR DESCRIPTION
this is a "fix" which blocks (classic/servlet) encounter submission when files are sent from the form, but _all of them_ are invalid.
this will hopefully prevent so-called "zombie encounters" from popping up.

notes:
- this prevents submission by throwing a ServletException which is not very graceful at all and not a great user experience
- however, this is legacy submission and hopefully not long of this earth?
- plus, the case that triggers this seems to be pretty rare and might even be triggered by some browser issue (duplicate posting) that the user doesnt even see
- it was much easier than trying to do a very elegant message for this rare case