### PR TITLE
now accepts 1 digit month, day, hour, minute

### DIFF
--- a/frontend/src/pages/BulkImport/BulkImportStore.js
+++ b/frontend/src/pages/BulkImport/BulkImportStore.js
@@ -116,14 +116,43 @@ export class BulkImportStore {
     "Encounter.year": {
       required: true,
       validate: (val) => {
-        const FORMATS = [
-          "YYYY",
-          "YYYY-MM",
-          "YYYY-MM-DD",
-          "YYYY-MM-DDTHH",
-          "YYYY-MM-DDTHH:mm",
-        ];
-        const parsed = dayjs(val, FORMATS, true);
+        if (val == null) return false;
+        const FLEXIBLE_DATE_RE =
+          /^(\d{4})(?:-(\d{1,2})(?:-(\d{1,2})(?:T(\d{1,2})(?::(\d{1,2}))?)?)?)?$/;
+
+        const str = String(val).trim();
+        if (!str) return false;
+
+        const m = str.match(FLEXIBLE_DATE_RE);
+        if (!m) {
+          return false;
+        }
+
+        const [, year, month, day, hour, minute] = m;
+
+        let normalized = year;
+        let format = "YYYY";
+
+        if (month !== undefined) {
+          normalized += "-" + month.padStart(2, "0");
+          format += "-MM";
+        }
+
+        if (day !== undefined) {
+          normalized += "-" + day.padStart(2, "0");
+          format += "-DD";
+        }
+
+        if (hour !== undefined) {
+          normalized += "T" + hour.padStart(2, "0");
+          format += "[T]HH";
+        }
+
+        if (minute !== undefined) {
+          normalized += ":" + minute.padStart(2, "0");
+          format += ":mm";
+        }
+        const parsed = dayjs(normalized, format, true);
         return parsed.isValid() && !parsed.isAfter(dayjs());
       },
       message: "BULKIMPORT_ERROR_INVALID_DATEFORMAT",


### PR DESCRIPTION
This PR updates the `Encounter.year` validation used in bulk import so that it accepts more flexible date input while still enforcing strict and safe parsing.

Users can now enter dates where month, day, hour, and minute can be either 1 or 2 digits (e.g. `2025-2-4`, `2025-02-4`, `2025-2-04`, `2025-02-04`, `2025-2-4T9:5`, etc.).

PR fixes #1309 
