### PR TITLE
Prevent users from saving emojis as their display name

### DIFF
--- a/src/main/webapp/myAccount.jsp
+++ b/src/main/webapp/myAccount.jsp
@@ -337,8 +337,14 @@ java.io.*" %>
 
 	<script>
 		function containsEmoji(text) {
-			var emojiRegex = /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]|[\u{1F900}-\u{1F9FF}]|[\u{1FA70}-\u{1FAFF}]|[\u{FE00}-\u{FE0F}]|[\u{1F018}-\u{1F270}]|[\u{238C}-\u{2454}]|[\u{20D0}-\u{20FF}]/gu;
-			return emojiRegex.test(text);
+			try {
+				var emojiRegex = /\p{Emoji}/gu;
+				return emojiRegex.test(text);
+			} catch (e) {
+				// for older browsers that don't support \p{Emoji}
+				var fallbackRegex = /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]|[\u{1F900}-\u{1F9FF}]|[\u{1FA70}-\u{1FAFF}]|[\u{FE00}-\u{FE0F}]|[\u{1F018}-\u{1F270}]|[\u{238C}-\u{2454}]|[\u{20D0}-\u{20FF}]/gu;
+				return fallbackRegex.test(text);
+			}
 		}
 
 		function sendButtonClicked() {


### PR DESCRIPTION
## Emoji Validation for Full Name Field

Added client-side validation to prevent users from entering emojis in the Full Name field on the profile page (`/myAccount.jsp`). This ensures the field remains searchable and readable across the platform.

### Changes Made
- **New Function**: `containsEmoji()` - Detects emojis using comprehensive Unicode regex patterns
- **Updated Function**: `sendButtonClicked()` - Now validates Full Name for emojis before form submission
- **UX Enhancement**: Users receive a clear alert message and auto-focus back to the field when emojis are detected
- 
### Files Modified
- `myAccount.jsp` - Added emoji validation logic in JavaScript section

PR fixes #1324

**Before you Submit!**
* ⚠️ Is all the text internationalized? - **Alert message hardcoded in English, needs i18n**
* If you made a change to the header, did you update the react, jsp, and html? - **N/A**
* Are all dependencies at a locked version? - **No new dependencies**
* Did you adhere to [best practices](https://wildbook.docs.wildme.org/contribute/code-guide.html)? - **Yes**
* Is there a quick [unit test](https://wildbook.docs.wildme.org/contribute/tests.html) you can add? - **Client-side validation; manual testing recommended**