### PR TITLE
search individual on both individual id and name

### DIFF
--- a/frontend/src/__tests__/pages/Encounter/EncounterStore.test.js
+++ b/frontend/src/__tests__/pages/Encounter/EncounterStore.test.js
@@ -242,7 +242,7 @@ describe("EncounterStore", () => {
 
       axios.post.mockResolvedValue({ data: { hits: mockResults } });
 
-      await store.searchIndividualsByName("Whale");
+      await store.searchIndividualsByNameAndId("Whale");
 
       expect(axios.post).toHaveBeenCalledWith(
         "/api/v3/search/individual?size=20&from=0",
@@ -312,7 +312,9 @@ describe("EncounterStore", () => {
     it("should handle individual search error", async () => {
       axios.post.mockRejectedValue(new Error("Search failed"));
 
-      await expect(store.searchIndividualsByName("test")).rejects.toThrow();
+      await expect(
+        store.searchIndividualsByNameAndId("test"),
+      ).rejects.toThrow();
       expect(toast.error).toHaveBeenCalled();
       expect(store.individualSearchResults).toEqual([]);
     });

--- a/frontend/src/__tests__/pages/Encounter/IdentifySectionEdit.test.js
+++ b/frontend/src/__tests__/pages/Encounter/IdentifySectionEdit.test.js
@@ -58,7 +58,7 @@ const makeStore = (overrides = {}) => ({
   identificationRemarksOptions: ["auto", "manual"],
   individualOptions: [],
   setIndividualOptions: jest.fn(),
-  searchIndividualsByName: jest.fn(),
+  searchIndividualsByNameAndId: jest.fn(),
   searchSightingsById: jest.fn(),
   setFieldValue: jest.fn(),
   setEditIdentifyCard: jest.fn(),
@@ -134,7 +134,7 @@ describe("IdentifySectionEdit", () => {
 
   test("INDIVIDUAL_ID loadOptions maps search results and sets individual options", async () => {
     const store = makeStore();
-    store.searchIndividualsByName.mockResolvedValueOnce({
+    store.searchIndividualsByNameAndId.mockResolvedValueOnce({
       data: {
         hits: [
           { id: 5, displayName: "Ind5" },
@@ -148,7 +148,7 @@ describe("IdentifySectionEdit", () => {
     const props = global.__SEARCH_PROPS__["INDIVIDUAL_ID"];
     const res = await props.loadOptions("in");
 
-    expect(store.searchIndividualsByName).toHaveBeenCalledWith("in");
+    expect(store.searchIndividualsByNameAndId).toHaveBeenCalledWith("in");
     expect(store.setIndividualOptions).toHaveBeenCalledWith([
       { value: "5", label: "Ind5" },
       { value: "6", label: "Ind6" },

--- a/frontend/src/pages/Encounter/IdentifySectionEdit.jsx
+++ b/frontend/src/pages/Encounter/IdentifySectionEdit.jsx
@@ -55,7 +55,7 @@ export const IdentifySectionEdit = observer(({ store }) => {
         onChange={(v) => store.setFieldValue("identify", "individualId", v)}
         options={store.individualOptions}
         loadOptions={async (q) => {
-          const resp = await store.searchIndividualsByName(q);
+          const resp = await store.searchIndividualsByNameAndId(q);
           const options = (resp.data.hits || []).map((it) => ({
             value: String(it.id),
             label: it.displayName,

--- a/frontend/src/pages/Encounter/stores/EncounterStore.js
+++ b/frontend/src/pages/Encounter/stores/EncounterStore.js
@@ -260,7 +260,7 @@ class EncounterStore {
 
   debouncedSearchIndividuals = debounce(async (inputValue) => {
     if (inputValue && inputValue.length >= 2) {
-      await this.searchIndividualsByName(inputValue);
+      await this.searchIndividualsByNameAndId(inputValue);
     } else {
       this.clearIndividualSearchResults();
     }
@@ -1144,7 +1144,7 @@ class EncounterStore {
     this._encounterData = nextEncounter;
   }
 
-  async searchIndividualsByName(inputValue) {
+  async searchIndividualsByNameAndId(inputValue) {
     this._searchingIndividuals = true;
 
     try {
@@ -1161,6 +1161,8 @@ class EncounterStore {
                     },
                   ]
                 : []),
+            ],
+            should: [
               {
                 wildcard: {
                   names: {
@@ -1169,7 +1171,16 @@ class EncounterStore {
                   },
                 },
               },
+              {
+                wildcard: {
+                  id: {
+                    value: `*${inputValue}*`,
+                    case_insensitive: true,
+                  },
+                },
+              },
             ],
+            minimum_should_match: 1,
           },
         },
       };


### PR DESCRIPTION
in identity section on encounter page, when users enter texts to search for existing individual, search on both individual name and individual id. the old code is only searching on name