### PR TITLE
Added locationID "Brequigny" for France

### DIFF
--- a/src/main/resources/bundles/locationID.json
+++ b/src/main/resources/bundles/locationID.json
@@ -25,6 +25,11 @@
 									"locationID": []
 								},
 								{
+									"name": "Brequigny",
+									"id": "Brequigny",
+									"locationID": []
+								},
+								{
 									"name": "Mateloueres",
 									"id": "Mateloueres",
 									"locationID": []


### PR DESCRIPTION
Added supplementary locationID "Brequigny" for France, sorted alphabetically
