### PR TITLE
Make user collaborations visible in users.jsp

### DIFF
--- a/src/main/resources/bundles/de/users.properties
+++ b/src/main/resources/bundles/de/users.properties
@@ -64,3 +64,13 @@ deleteUser = Benutzer l\u00F6schen
 
 defaultProject = Standardprojekt
 noneSelected = Keiner ausgew\u00E4hlt
+
+# Collaborations table
+collaborations = Kollaborationen
+collaborator = Mitarbeiter
+type = Typ
+state = Status
+dateCreated = Erstellungsdatum
+noCollaborations = F\u00fcr diesen Benutzer wurden keine Kollaborationen gefunden.
+collabTypeEdit = Bearbeiten
+collabTypeView = Ansehen

--- a/src/main/resources/bundles/en/users.properties
+++ b/src/main/resources/bundles/en/users.properties
@@ -64,3 +64,13 @@ deleteUser = Delete User
 
 defaultProject = Default Project
 noneSelected = None Selected
+
+# Collaborations table
+collaborations = Collaborations
+collaborator = Collaborator
+type = Type
+state = State
+dateCreated = Date Created
+noCollaborations = No collaborations found for this user.
+collabTypeEdit = Edit
+collabTypeView = View

--- a/src/main/resources/bundles/es/users.properties
+++ b/src/main/resources/bundles/es/users.properties
@@ -64,3 +64,13 @@ deleteUser = Borrar usuario
 
 defaultProject = Proyecto Predeterminado
 noneSelected = Ninguna Seleccionada
+
+# Collaborations table
+collaborations = Colaboraciones
+collaborator = Colaborador
+type = Tipo
+state = Estado
+dateCreated = Fecha de creaci\u00f3n
+noCollaborations = No se encontraron colaboraciones para este usuario.
+collabTypeEdit = Editar
+collabTypeView = Ver

--- a/src/main/resources/bundles/fr/users.properties
+++ b/src/main/resources/bundles/fr/users.properties
@@ -64,3 +64,13 @@ deleteUser = Supprimer l'utilisateur
 
 defaultProject = Projet par Defaut
 noneSelected = Aucune Selection
+
+# Collaborations table
+collaborations = Collaborations
+collaborator = Collaborateur
+type = Type
+state = \u00c9tat
+dateCreated = Date de cr\u00e9ation
+noCollaborations = Aucune collaboration trouv\u00e9e pour cet utilisateur.
+collabTypeEdit = \u00c9diter
+collabTypeView = Voir

--- a/src/main/resources/bundles/it/users.properties
+++ b/src/main/resources/bundles/it/users.properties
@@ -64,3 +64,13 @@ deleteUser = Elimina utente
 
 defaultProject = Progetto predefinito
 noneSelected = Nessuno selezionato
+
+# Collaborations table
+collaborations = Collaborazioni
+collaborator = Collaboratore
+type = Tipo
+state = Stato
+dateCreated = Data di creazione
+noCollaborations = Nessuna collaborazione trovata per questo utente.
+collabTypeEdit = Modifica
+collabTypeView = Visualizza

--- a/src/main/webapp/appadmin/users.jsp
+++ b/src/main/webapp/appadmin/users.jsp
@@ -760,17 +760,22 @@ try {
     <table class="tissueSample" width="100%">
       <tr>
         <th><%=props.getProperty("collaborator") != null ? props.getProperty("collaborator") : "Collaborator"%></th>
+        <th><%=props.getProperty("type") != null ? props.getProperty("type") : "Type"%></th>
         <th><%=props.getProperty("state") != null ? props.getProperty("state") : "State"%></th>
         <th><%=props.getProperty("dateCreated") != null ? props.getProperty("dateCreated") : "Date Created"%></th>
       </tr>
       <%
+      String collabTypeEdit = props.getProperty("collabTypeEdit") != null ? props.getProperty("collabTypeEdit") : "Edit";
+      String collabTypeView = props.getProperty("collabTypeView") != null ? props.getProperty("collabTypeView") : "View";
       for(Collaboration collab : userCollabs){
           String otherUsername = collab.getOtherUsername(editUser.getUsername());
           String state = collab.getState() != null ? collab.getState() : "unknown";
+          String collabType = (Collaboration.STATE_EDIT_PRIV.equals(state) || Collaboration.STATE_EDIT_PENDING_PRIV.equals(state)) ? collabTypeEdit : collabTypeView;
           String dateCreated = collab.getDateStringCreated();
       %>
       <tr>
         <td><%=otherUsername%></td>
+        <td><%=collabType%></td>
         <td><%=state%></td>
         <td><%=dateCreated%></td>
       </tr>


### PR DESCRIPTION
Put user collabs on users.jsp for orgAdmins and admins

This is a bare minimum implementation until this page is replaced with a React version. 

If an admin or orgAdmin can see a user on users.jsp, they can now also see a list of collaborations for that user when they click on it.

PR fixes #1299 

No collaborations example.

<img width="3144" height="703" alt="image" src="https://github.com/user-attachments/assets/533ae3db-9813-41fe-ab82-6048e1c2093c" />

Collaboration example:

<img width="3411" height="643" alt="image" src="https://github.com/user-attachments/assets/badcfd5b-a26b-4935-8829-7c407416f1e8" />


