### PR TITLE
Add opensearch restart config

### DIFF
--- a/devops/deploy/docker-compose.yml
+++ b/devops/deploy/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    restart: always
     labels:
       - autoheal=true
     user: postgres
@@ -122,6 +123,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    restart: always
     labels:
       - autoheal=true
     networks:
@@ -149,6 +151,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    restart: always
     labels:
       - autoheal=true
     volumes:


### PR DESCRIPTION
Add missing opensearch restart config to docker-compose to ensure it comes back up if crashes

