### PR TITLE
fix lock file, allow dynamic imports

### DIFF
--- a/frontend/config-overrides.js
+++ b/frontend/config-overrides.js
@@ -10,5 +10,14 @@ module.exports = function override(config, env) {
       "process.env.SITE_NAME": JSON.stringify(process.env.SITE_NAME),
     }),
   );
+
+  // TEMP: allow dynamic import for external ESM URL (procaptcha prosopo bundle)
+  // Follow-up: remove URL import from app code and load via script instead.
+  config.output = config.output || {};
+  config.output.environment = {
+    ...(config.output.environment || {}),
+    dynamicImport: true,
+  };
+
   return config;
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17694,6 +17694,15 @@
         "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-big-calendar/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-bootstrap": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.1.tgz",
@@ -20156,9 +20165,10 @@
       }
     },
     "node_modules/swiper": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.0.1.tgz",
-      "integrity": "sha512-Fi+gNw/tfc4hsGowQU5tRC/f1HFknkh4Vz8PaDI4JTinLUMTwhZyaovcH/va+iXq98BNUHN5ok0c2lEI82Fsgw==",
+      "version": "11.2.10",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.10.tgz",
+      "integrity": "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==",
+      "dev": true,
       "funding": [
         {
           "type": "patreon",
@@ -34573,6 +34583,13 @@
         "prop-types": "^15.8.1",
         "react-overlays": "^5.2.1",
         "uncontrollable": "^7.2.1"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+        }
       }
     },
     "react-bootstrap": {
@@ -36336,9 +36353,10 @@
       }
     },
     "swiper": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.0.1.tgz",
-      "integrity": "sha512-Fi+gNw/tfc4hsGowQU5tRC/f1HFknkh4Vz8PaDI4JTinLUMTwhZyaovcH/va+iXq98BNUHN5ok0c2lEI82Fsgw=="
+      "version": "11.2.10",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.10.tgz",
+      "integrity": "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.4",


### PR DESCRIPTION
fix frontend build issues in prod:

1. package.json and package-lock.json are out of sync
2. a few dependency upgrades caused webpack to treat the procaptcha URL import ("https://js.prosopo.io/js/procaptcha.bundle.js") as an ESM external, and the build now fails on the dynamic import() requirement.

this PR is a quick unblock: add a small webpack/rewired workaround (output.environment.dynamicImport = true) so build passes; we will do the clean fix in another PR