### PR TITLE
possible fix for empty bounding box (iot)

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -659,7 +659,6 @@ public class Annotation extends Base implements java.io.Serializable {
                 break;
             }
         }
-        System.out.println("getBbox() found=" + found);
         if (found == null) return null;
         int[] bbox = new int[4];
         if (found.isUnity()) {


### PR DESCRIPTION
a little hackery to get datanucleus to load features so bounding boxes show up.