### PR TITLE
display individual name instead of uuid in header quick search

### DIFF
--- a/frontend/src/components/header/HeaderQuickSearch.jsx
+++ b/frontend/src/components/header/HeaderQuickSearch.jsx
@@ -89,7 +89,10 @@ export default function HeaderQuickSearch() {
           )}
           {!loading &&
             searchResults.map((result, index) => {
-              let value = result.displayName || result.id;
+              let value =
+                result.displayName ||
+                (result.names?.length ? result.names.join(" | ") : null) ||
+                result.id;
 
               return (
                 <React.Fragment key={index}>

--- a/src/main/webapp/header.jsp
+++ b/src/main/webapp/header.jsp
@@ -316,7 +316,9 @@ if(request.getUserPrincipal()!=null){
                     if (searchResults.length > 0) {
                         resultsDropdown.innerHTML = searchResults.map(data => {
                             const taxonomy = data.taxonomy ? data.taxonomy : " ";                            
-                            let value = data.displayName || data.id;                            
+                            let value = data.displayName || 
+                              (data.names?.length ? result.names.join(" | ") : null) || 
+                              data.id;                        
                           
                             return "<a href=\"" + "<%= urlLoc %>" + "/individuals.jsp?id=" + data.id + "\" target=\"_blank\">" +
                               "    <div class=\"quick-search-result\" style=\"height: 60px; font-size: 14px\">" +


### PR DESCRIPTION
remove uuid on header quick search result, only display individual names

PR fixes #1245 