### PR TITLE
display location name instead of id

### DIFF
--- a/frontend/src/__tests__/pages/Encounter/LocationSectionEdit.test.js
+++ b/frontend/src/__tests__/pages/Encounter/LocationSectionEdit.test.js
@@ -182,8 +182,8 @@ describe("LocationSectionEdit", () => {
   });
 
   test("Tree data is built from siteSettingsData.locationData", () => {
-    const convertToTreeData =
-      require("../../../utils/converToTreeData").default;
+    const convertToTreeDataWithName =
+      require("../../../utils/cconvertToTreeDataWithName").default;
     const store = makeStore({
       siteSettingsData: {
         locationData: { locationID: [{ id: 1, name: "X" }] },
@@ -197,7 +197,7 @@ describe("LocationSectionEdit", () => {
       </Suspense>,
     );
 
-    expect(convertToTreeData).toHaveBeenCalledWith(
+    expect(convertToTreeDataWithName).toHaveBeenCalledWith(
       store.siteSettingsData.locationData.locationID,
       "value",
       "label",

--- a/frontend/src/pages/Encounter/LocationSectionEdit.jsx
+++ b/frontend/src/pages/Encounter/LocationSectionEdit.jsx
@@ -5,15 +5,13 @@ import { Alert } from "react-bootstrap";
 import TextInput from "../../components/generalInputs/TextInput";
 import CoordinatesInput from "../../components/generalInputs/CoordinatesInput";
 import { Suspense, lazy } from "react";
-import convertToTreeData from "../../utils/converToTreeData";
+import convertToTreeDataWithName from "../../utils/convertToTreeDataWithName";
 import { FormattedMessage } from "react-intl";
 
 const TreeSelect = lazy(() => import("antd/es/tree-select"));
 export const LocationSectionEdit = observer(({ store }) => {
-  const locationOptions = convertToTreeData(
+  const locationOptions = convertToTreeDataWithName(
     store.siteSettingsData?.locationData?.locationID,
-    "value",
-    "label",
   );
 
   return (


### PR DESCRIPTION
on encounter page, locationID options should display name instead of id, so we should use function convertToTreeDataWithName

PR fixes #1430 