### PR TITLE
remove timeout limit

### DIFF
--- a/frontend/src/FrontDesk.jsx
+++ b/frontend/src/FrontDesk.jsx
@@ -29,7 +29,7 @@ export default function FrontDesk() {
   const showClassicEncounterSearch = data?.showClassicEncounters;
   const checkLoginStatus = () => {
     axios
-      .head("/api/v3/user", { timeout: 5000 })
+      .head("/api/v3/user")
       .then((response) => {
         if (response.status === 200) {
           setIsLoggedIn(true);
@@ -39,10 +39,10 @@ export default function FrontDesk() {
       .catch((error) => {
         if (error.response?.status === 401) {
           setIsLoggedIn(false);
+          setLoading(false);
         } else {
           console.warn("Login status check failed (non-401):", error.message);
         }
-        setLoading(false);
       });
   };
 


### PR DESCRIPTION
fix a false logout issue reported in flukebook

reduces false logouts during slow/unstable connections by removing the timeout on the /api/v3/user auth check and only treating 401 as logged out, non 401 failures no longer trigger the unauthenticated flow

PR fixes #1448 