### PR TITLE
Switch to term matching for Encounter.alternateID in Encounter Search

### DIFF
--- a/frontend/src/components/filterFields/IdentityFilter.jsx
+++ b/frontend/src/components/filterFields/IdentityFilter.jsx
@@ -97,7 +97,7 @@ const IdentityFilter = observer(({ store }) => {
         label="FILTER_ALTERNATIVE_ID"
         noDesc={true}
         field={"otherCatalogNumbers"}
-        term={"match"}
+        term={"term"}
         filterId={"otherCatalogNumbers"}
         filterKey={"Alternative ID"}
         store={store}


### PR DESCRIPTION
Encounter.alternateID was not searchable despite a field for it in the new Encounter Search. It is now case-insensitive and matchable via exact values for Encounter.alternateID. 
