### PR TITLE
fix individual gallery issue

### DIFF
--- a/frontend/src/pages/SearchPages/EncounterSearch.jsx
+++ b/frontend/src/pages/SearchPages/EncounterSearch.jsx
@@ -109,6 +109,7 @@ const EncounterSearch = observer(() => {
       if (encounter?.access === "none") {
         rawOffset++;
         assetOffset = 0;
+        store.setAssetOffset(0);
         continue;
       }
 


### PR DESCRIPTION
fix an individual gallery issue:
Filter out inaccessible encounters (access: "none") from gallery media results so restricted records do not prevent images from rendering.
