### PR TITLE
fix version-stamping to work on BSD/MacOS and Windows

### DIFF
--- a/config/git-json-info.ps1
+++ b/config/git-json-info.ps1
@@ -1,0 +1,16 @@
+# Windows equivalent of git-json-info.sh
+$ErrorActionPreference = 'Stop'
+
+$date   = git log -1 --format='%ai'
+$hash   = git log -1 --format='%H'
+$branch = git name-rev --name-only HEAD
+$now    = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss+00:00")
+
+@"
+{
+   "date": "$date",
+   "built": "$now",
+   "hash": "$hash",
+   "branch": "$branch"
+}
+"@ | Out-File -FilePath "git-info.json" -Encoding utf8NoBOM

--- a/config/git-json-info.sh
+++ b/config/git-json-info.sh
@@ -1,13 +1,16 @@
 #!/bin/sh
+set -e
 
-date=`git log -1 --format='%ai'`
-hash=`git log -1 --format='%H'`
-branch=`git name-rev --name-only HEAD`
-now=`date --rfc-3339=seconds`
+date=$(git log -1 --format='%ai')
+hash=$(git log -1 --format='%H')
+branch=$(git name-rev --name-only HEAD)
+now=$(date -u '+%Y-%m-%d %H:%M:%S+00:00')
 
-echo "{
-   \"date\": \"$date\",
-   \"built\": \"$now\",
-   \"hash\": \"$hash\",
-   \"branch\": \"$branch\"
-}" > git-info.json
+cat > git-info.json << EOF
+{
+   "date": "$date",
+   "built": "$now",
+   "hash": "$hash",
+   "branch": "$branch"
+}
+EOF

--- a/pom.xml
+++ b/pom.xml
@@ -637,21 +637,44 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>Git Version Stamper</id>
             <phase>clean</phase>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
-            <configuration> <!-- note: this is unix-centric... so thats probably bad -->
-              <executable>${basedir}/config/git-json-info.sh</executable>
-              <workingDirectory>${basedir}/src/main/webapp/javascript</workingDirectory>
+            <configuration>
+              <target>
+                <exec executable="sh"
+                      dir="${basedir}/src/main/webapp/javascript"
+                      osfamily="unix"
+                      failonerror="true">
+                  <arg value="${basedir}/config/git-json-info.sh"/>
+                </exec>
+                <exec executable="powershell"
+                      dir="${basedir}/src/main/webapp/javascript"
+                      osfamily="windows"
+                      failonerror="true">
+                  <arg value="-ExecutionPolicy"/>
+                  <arg value="Bypass"/>
+                  <arg value="-File"/>
+                  <arg value="${basedir}/config/git-json-info.ps1"/>
+                </exec>
+              </target>
             </configuration>
           </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.2</version>
+        <executions>
           <execution>
             <id>Build React Directory</id>
             <phase>clean</phase>


### PR DESCRIPTION
This little version-stamping utility script would always fail on MAcOS (and presumably wouldn't run at all on Windows) since it relied on a Linux-specific 'date' function.   This was noted in the pom:  "<!-- note: this is unix-centric... so thats probably bad -->"  :)

This pr updates the script so it works on MacOS and adds a powershell script for Windoze.  The pom plugin will switch between them based on detected os.  

   