### PR TITLE
Fix OpenSearch index staleness when encounters assigned to individuals

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -4997,6 +4997,9 @@ public class Encounter extends Base implements java.io.Serializable {
         this.setDWCDateLastModified();
         this._log(resArr);
         this.setSkipAutoIndexing(false);
+        // Explicitly reindex since postStore fired while skipAutoIndexing was true
+        IndexingManager im = IndexingManagerFactory.getIndexingManager();
+        if (im != null) im.addIndexingQueueEntry(this, false);
         return rtn;
     }
 

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -2596,9 +2596,12 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
 
     // Need request to record which user did it
     public void mergeIndividual(MarkedIndividual other, String username, Shepherd myShepherd) {
+        IndexingManager im = IndexingManagerFactory.getIndexingManager();
         for (Encounter enc : other.getEncounters()) {
             other.removeEncounter(enc);
             enc.setIndividual(this);
+            // Reindex each transferred encounter
+            if (im != null) im.addIndexingQueueEntry(enc, false);
         }
         this.names.merge(other.getNames());
         this.setComments(getMergedComments(other, username));
@@ -2643,6 +2646,11 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
             myShepherd.updateDBTransaction();
         }
         refreshDependentProperties();
+        // Reindex both individuals after merge
+        if (im != null) {
+            im.addIndexingQueueEntry(this, false);
+            im.addIndexingQueueEntry(other, false);
+        }
     }
 
     public String getMergedComments(MarkedIndividual other, HttpServletRequest request,

--- a/src/main/java/org/ecocean/servlet/IndividualAddEncounter.java
+++ b/src/main/java/org/ecocean/servlet/IndividualAddEncounter.java
@@ -109,6 +109,9 @@ public class IndividualAddEncounter extends HttpServlet {
                             addToMe.refreshDependentProperties();
                             myShepherd.updateDBTransaction();
                             System.out.println("Now adding the Encounter to the individual");
+                            // Reindex encounter after individual assignment
+                            IndexingManager im = IndexingManagerFactory.getIndexingManager();
+                            if (im != null) im.addIndexingQueueEntry(enc2add, false);
                         }
                         enc2add.setMatchedBy(request.getParameter("matchType"));
                         enc2add.addComments("<p><em>" + request.getRemoteUser() + " on " +

--- a/src/main/java/org/ecocean/servlet/IndividualCreateForProject.java
+++ b/src/main/java/org/ecocean/servlet/IndividualCreateForProject.java
@@ -79,6 +79,9 @@ public class IndividualCreateForProject extends HttpServlet {
                         myShepherd.updateDBTransaction();
                         enc.setIndividual(individual);
                         myShepherd.updateDBTransaction();
+                        // Reindex encounter after individual assignment
+                        IndexingManager im = IndexingManagerFactory.getIndexingManager();
+                        if (im != null) im.addIndexingQueueEntry(enc, false);
 
                         res.put("newIndividualId", individual.getId());
                         res.put("newIndividualName", individual.getName(projectId));

--- a/src/main/java/org/ecocean/servlet/IndividualRemoveEncounter.java
+++ b/src/main/java/org/ecocean/servlet/IndividualRemoveEncounter.java
@@ -2,6 +2,8 @@ package org.ecocean.servlet;
 
 import org.ecocean.CommonConfiguration;
 import org.ecocean.Encounter;
+import org.ecocean.IndexingManager;
+import org.ecocean.IndexingManagerFactory;
 import org.ecocean.MarkedIndividual;
 import org.ecocean.social.SocialUnit;
 import org.ecocean.shepherd.core.Shepherd;
@@ -107,7 +109,16 @@ public class IndividualRemoveEncounter extends HttpServlet {
                 }
                 if (!locked) {
                     myShepherd.commitDBTransaction();
-                    //if (enc2remove != null) enc2remove.opensearchIndexDeep();
+                    // Reindex encounter and old individual after assignment change
+                    IndexingManager im = IndexingManagerFactory.getIndexingManager();
+                    if (im != null) {
+                        if (enc2remove != null) {
+                            im.addIndexingQueueEntry(enc2remove, false);
+                        }
+                        if (!wasRemoved && removeFromMe != null) {
+                            im.addIndexingQueueEntry(removeFromMe, false);
+                        }
+                    }
                     out.println(ServletUtilities.getHeader(request));
                     response.setStatus(HttpServletResponse.SC_OK);
                     out.println("<strong>Success:</strong> Encounter #" +

--- a/src/main/webapp/iaResultsSetID.jsp
+++ b/src/main/webapp/iaResultsSetID.jsp
@@ -242,6 +242,15 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
                         setImportTaskComplete(myShepherd, oenc);
                     }
                     indiv.refreshNamesCache();
+                    // Reindex encounters and individual after ID assignment
+                    IndexingManager im = IndexingManagerFactory.getIndexingManager();
+                    if (im != null) {
+                        im.addIndexingQueueEntry(enc, false);
+                        for (Encounter oenc : otherEncs) {
+                            im.addIndexingQueueEntry(oenc, false);
+                        }
+                        im.addIndexingQueueEntry(indiv, false);
+                    }
 
                     if ((indiv != null) && (enc != null)) IndividualAddEncounter.executeEmails(myShepherd, request, indiv, isNewIndiv, enc, context, langCode);
 
@@ -270,6 +279,14 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
                                     IndividualAddEncounter.executeEmails(myShepherd, request, indiv, false, oenc, context, langCode);
                                     setImportTaskComplete(myShepherd, oenc);
                                 }
+                                // Reindex encounters and individual after ID assignment
+                                IndexingManager im2 = IndexingManagerFactory.getIndexingManager();
+                                if (im2 != null) {
+                                    for (Encounter oenc : otherEncs) {
+                                        im2.addIndexingQueueEntry(oenc, false);
+                                    }
+                                    im2.addIndexingQueueEntry(indiv, false);
+                                }
 			}
 
 			// target enc has indy
@@ -291,6 +308,12 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
 
 				IndividualAddEncounter.executeEmails(myShepherd, request, oindiv, false, enc, context, langCode);
                                 setImportTaskComplete(myShepherd, enc);
+                                // Reindex encounter and individual after ID assignment
+                                IndexingManager im3 = IndexingManagerFactory.getIndexingManager();
+                                if (im3 != null) {
+                                    im3.addIndexingQueueEntry(enc, false);
+                                    im3.addIndexingQueueEntry(oindiv, false);
+                                }
 			}
 
 


### PR DESCRIPTION
## Summary

- OpenSearch index was not being updated when encounters were assigned to/removed from individuals through various code paths
- Root cause: `skipAutoIndexing` flag in `Encounter.processPatch()` prevented auto-indexing, and several servlets/JSPs didn't trigger reindex after modifying encounter-individual relationships
- Added explicit `IndexingManager.addIndexingQueueEntry()` calls with null checks in all affected code paths

## Files Changed

- **Encounter.java**: Reset `skipAutoIndexing` and trigger reindex at end of `processPatch()`
- **IndividualAddEncounter.java**: Reindex encounter after adding to individual
- **IndividualRemoveEncounter.java**: Reindex encounter AND old individual after removal
- **IndividualCreateForProject.java**: Reindex encounter after creating new individual
- **MarkedIndividual.java**: Reindex all transferred encounters and both individuals in `mergeIndividual()`
- **iaResultsSetID.jsp**: Reindex encounter after ID confirmation in all 3 code paths

## Test plan

- [ ] Verify OpenSearch query results match JDOQL for `individualID IS NULL` filter
- [ ] Confirm encounter reindexes when assigned to individual via UI
- [ ] Confirm encounter reindexes when removed from individual
- [ ] Confirm encounters reindex when individuals are merged

🤖 Generated with [Claude Code](https://claude.ai/code)