### PR TITLE
Fix legacy user accounts with email-as-UUID blocking project membership (#1545)

### DIFF
--- a/src/main/java/org/ecocean/User.java
+++ b/src/main/java/org/ecocean/User.java
@@ -115,6 +115,13 @@ public class User implements Serializable {
         this.lastLogin = -1;
     }
 
+    /**
+     * @deprecated GH-1545: Callers have historically misused this constructor by passing
+     * an email address where a UUID is expected, producing accounts whose primary key
+     * is the email. Prefer {@code new User(email, Util.generateUUID())} or another
+     * constructor when you do not already have a real UUID.
+     */
+    @Deprecated
     public User(String uuid) {
         this.uuid = uuid;
         setReceiveEmails(false);

--- a/src/main/java/org/ecocean/servlet/ProjectCreate.java
+++ b/src/main/java/org/ecocean/servlet/ProjectCreate.java
@@ -112,17 +112,24 @@ public class ProjectCreate extends HttpServlet {
                     }
                 }
                 if (projectUserIds != null && projectUserIds.length() > 0) {
+                    JSONArray unresolved = res.optJSONArray("unresolvedUserIds");
+                    if (unresolved == null) {
+                        unresolved = new JSONArray();
+                        res.put("unresolvedUserIds", unresolved);
+                    }
                     for (int i = 0; i < projectUserIds.length(); i++) {
                         String userIdentifier = projectUserIds.getString(i);
                         if (!Util.stringIsEmptyOrNull(userIdentifier)) {
-                            User user = null;
-                            if (Util.isUUID(userIdentifier)) {
-                                user = myShepherd.getUserByUUID(userIdentifier);
-                            } else {
-                                user = myShepherd.getUser(userIdentifier);
-                            }
+                            // GH-1545: use shared resolver with email-address fallback for
+                            // legacy accounts whose UUID primary key stores an email.
+                            User user = ProjectUpdate.resolveUser(myShepherd, userIdentifier);
                             if (user != null) {
                                 newProject.addUser(user);
+                            } else {
+                                unresolved.put(userIdentifier);
+                                System.out.println(
+                                    "ProjectCreate: could not resolve userIdentifier=" +
+                                    userIdentifier);
                             }
                         }
                     }

--- a/src/main/java/org/ecocean/servlet/ProjectUpdate.java
+++ b/src/main/java/org/ecocean/servlet/ProjectUpdate.java
@@ -213,22 +213,25 @@ public class ProjectUpdate extends HttpServlet {
         res.put("success", true);
     }
 
-    // GH-1545: Some legacy User accounts have an email stored in their UUID primary key
-    // (see UserCreate.java history and the deprecated User(String uuid) constructor).
-    // The autocomplete therefore posts an email-shaped identifier, Util.isUUID returns
-    // false, and the legacy getUser(username) lookup misses when username != email.
-    // Fall back to an email lookup so those accounts can still be added/removed until
-    // a data migration repairs the affected rows. Logs every fallback hit.
+    // GH-1545: Resolve a user from an autocomplete-supplied identifier.
+    //
+    // Ordering matters. Some legacy User accounts have an email stored in their UUID
+    // primary key (see UserCreate.java history and the deprecated User(String uuid)
+    // constructor). For those rows, the frontend posts `u.getId()` which is the email.
+    //
+    // We therefore try the PK lookup FIRST, not last — and regardless of whether the
+    // string looks UUID-shaped — because:
+    //   (1) for real UUIDs it's the direct, correct path; and
+    //   (2) for legacy email-as-UUID rows it still resolves via the literal PK
+    //       ("alice@example.org" IS that user's primary key), which avoids a wrong
+    //       match if some other account happens to have that email as their username.
+    //
+    // Only after the PK miss do we try username and then email-address lookups.
+    // Every email-fallback hit is logged so operators can gauge the migration backlog.
     static User resolveUser(Shepherd myShepherd, String userId) {
         if (StringUtils.isNullOrEmpty(userId)) return null;
-        User user = null;
-        if (Util.isUUID(userId)) {
-            user = myShepherd.getUserByUUID(userId);
-            if (user == null) {
-                return null;
-            }
-            return user;
-        }
+        User user = myShepherd.getUserByUUID(userId);
+        if (user != null) return user;
         user = myShepherd.getUser(userId);
         if (user != null) return user;
         user = myShepherd.getUserByEmailAddress(userId);

--- a/src/main/java/org/ecocean/servlet/ProjectUpdate.java
+++ b/src/main/java/org/ecocean/servlet/ProjectUpdate.java
@@ -187,25 +187,58 @@ public class ProjectUpdate extends HttpServlet {
 
     private void addOrRemoveUsersFromProject(Project project, Shepherd myShepherd,
         JSONArray usersToAddJSONArr, String action, JSONObject res) {
+        JSONArray unresolved = res.optJSONArray("unresolvedUserIds");
+        if (unresolved == null) {
+            unresolved = new JSONArray();
+            res.put("unresolvedUserIds", unresolved);
+        }
         for (int i = 0; i < usersToAddJSONArr.length(); i++) {
             String userId = usersToAddJSONArr.getString(i);
-            User user = null;
-            if (Util.isUUID(userId)) {
-                user = myShepherd.getUserByUUID(userId);
-            } else {
-                user = myShepherd.getUser(userId);
-            }
+            User user = resolveUser(myShepherd, userId);
             if (user != null && !StringUtils.isNullOrEmpty(action)) {
                 if ("add".equals(action)) {
                     project.addUser(user);
                 } else if ("remove".equals(action)) {
                     project.removeUser(user);
                 }
+            } else {
+                unresolved.put(userId);
+                System.out.println(
+                    "ProjectUpdate.addOrRemoveUsersFromProject: could not resolve userId=" +
+                    userId + " for action=" + action + " project=" + project.getId());
             }
         }
         myShepherd.updateDBTransaction();
         res.put("modified", true);
         res.put("success", true);
+    }
+
+    // GH-1545: Some legacy User accounts have an email stored in their UUID primary key
+    // (see UserCreate.java history and the deprecated User(String uuid) constructor).
+    // The autocomplete therefore posts an email-shaped identifier, Util.isUUID returns
+    // false, and the legacy getUser(username) lookup misses when username != email.
+    // Fall back to an email lookup so those accounts can still be added/removed until
+    // a data migration repairs the affected rows. Logs every fallback hit.
+    static User resolveUser(Shepherd myShepherd, String userId) {
+        if (StringUtils.isNullOrEmpty(userId)) return null;
+        User user = null;
+        if (Util.isUUID(userId)) {
+            user = myShepherd.getUserByUUID(userId);
+            if (user == null) {
+                return null;
+            }
+            return user;
+        }
+        user = myShepherd.getUser(userId);
+        if (user != null) return user;
+        user = myShepherd.getUserByEmailAddress(userId);
+        if (user != null) {
+            System.out.println(
+                "ProjectUpdate.resolveUser: resolved userId=" + userId +
+                " via email-address fallback (GH-1545 legacy uuid). user.uuid=" +
+                user.getUUID());
+        }
+        return user;
     }
 
     private JSONArray removeUnauthorizedEncounters(JSONArray encountersToAddJSONArr,

--- a/src/main/java/org/ecocean/servlet/UserCreate.java
+++ b/src/main/java/org/ecocean/servlet/UserCreate.java
@@ -100,7 +100,10 @@ public class UserCreate extends HttpServlet {
                                 salt);
                             newUser = new User(username, hashedPassword, salt);
                         } else {
-                            newUser = new User(email);
+                            // GH-1545: use the (email, uuid) ctor so the email is not stored as the UUID.
+                            // The single-arg User(String uuid) ctor was misused here, producing
+                            // accounts whose primary key is the email address.
+                            newUser = new User(email, Util.generateUUID());
                         }
                         myShepherd.getPM().makePersistent(newUser);
                         createThisUser = true;


### PR DESCRIPTION
Fixes #1545.

## Root cause

`UserCreate.java:103` was calling `new User(email)`, which resolves to the `User(String uuid)` constructor and stores the email address in the `uuid` field (which is the JDO primary key per `package.jdo:787`). A small number of accounts created via this path have `user.getUUID()` returning an email.

Downstream:
1. `UserGetSimpleJSON` serves `u.getUUID()` as the autocomplete `id`.
2. `editProject.jsp` / `createProject.jsp` push that email into `userIdsToAdd`.
3. `ProjectUpdate.addOrRemoveUsersFromProject` / `ProjectCreate` do `if (Util.isUUID(userId)) getUserByUUID else getUser(username)`. The email isn't a UUID, so it falls to the username lookup, which misses if username ≠ email.
4. Loop silently no-ops but `res.success = true` is still set. UI shows "Success updating project data." The user is never added.

## Changes

- **`UserCreate.java`**: switch to `new User(email, Util.generateUUID())` so no new accounts are created with email-as-UUID.
- **`User.java`**: `@Deprecated` on the single-arg `User(String uuid)` constructor with a Javadoc note pointing at this issue. Not removed — there are three legitimate callers (`SpotterConserveIO`, `BulkImporter`, `StandardImport`) that pass real UUIDs. Those will be migrated in follow-up tickets.
- **`ProjectUpdate.java`**: factor the user lookup into a shared `resolveUser()` that adds an `getUserByEmailAddress` fallback for legacy accounts. Every fallback hit is logged. Surface `unresolvedUserIds: [...]` in the response JSON so silent misses are visible to the frontend.
- **`ProjectCreate.java`**: use the same `resolveUser()` helper; same `unresolvedUserIds` surface. The bug was live in this path too.

## What this does NOT do

This is a code patch, not a data migration. Existing rows with email-as-UUID remain in the DB. The `resolveUser()` fallback keeps those users functional for project add/remove until a proper migration runs.

The migration is deliberately deferred to a separate ticket. It needs:
- Per-install execution with admin auth, dry-run preview, DB backup prompt
- Clone-and-swap (can't mutate a JDO primary key in place, and `USERS.username` is unique so it needs careful sequencing)
- Rewrite references across `Project.users`, `Project.ownerId` (plain string), `Organization.members`, `Encounter.submitters`/`photographers`/`informOthers`, `Occurrence.submitters`/`informOthers`, `ImportTask.creator`, `Collaboration`, audit trails
- **OpenSearch reindex** of affected `encounter` and `occurrence` docs (`submitterUserId` and `viewUsers` are stored as the raw id) — not just `OpenSearch.setPermissionsNeeded`

## Diagnostic SQL

```sql
SELECT COUNT(*) AS affected_count
FROM "USERS"
WHERE "UUID" !~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$';
```

## Test plan

- [ ] Login as project owner on ACW (where the bug was reported) and add a previously-broken user to a project. Confirm they persist after refresh.
- [ ] Confirm the resolution was logged: `grep "resolved userId=.*via email-address fallback" catalina.out`
- [ ] Confirm response JSON no longer includes that id in `unresolvedUserIds`.
- [ ] Create a new user via UserCreate with email-only path; confirm `USERS.UUID` is a proper UUID.
- [ ] Regress the non-buggy path: add a user with a real UUID to a project still works.
- [ ] Project creation with mixed valid/broken user ids: valid and email-matched users are added; truly unresolvable ids appear in `unresolvedUserIds`.
