### PR TITLE
Fix bounding box not appearing on /react/encounter after detection

### DIFF
--- a/frontend/src/pages/Encounter/Encounter.jsx
+++ b/frontend/src/pages/Encounter/Encounter.jsx
@@ -38,6 +38,11 @@ import { Divider } from "antd";
 import { get } from "lodash-es";
 import CollabModal from "./CollabModal";
 import Alert from "react-bootstrap/Alert";
+import {
+  shouldContinuePollingEncounter,
+  POLL_INTERVAL_MS,
+  MAX_POLL_CYCLES,
+} from "./pollingHelpers";
 
 const Encounter = observer(() => {
   const [store] = useState(() => new EncounterStore());
@@ -72,26 +77,7 @@ const Encounter = observer(() => {
   useEffect(() => {
     let cancelled = false;
     let timeoutId = null;
-
-    const isTerminalDetectionStatus = (status) =>
-      !status ||
-      status === "complete" ||
-      status === "error" ||
-      status === "pending";
-
-    const shouldContinuePolling = (encounterData) => {
-      const mediaAssets = Array.isArray(encounterData?.mediaAssets)
-        ? encounterData.mediaAssets
-        : [];
-
-      if (mediaAssets.length === 0) {
-        return false;
-      }
-
-      return mediaAssets.some(
-        (asset) => !isTerminalDetectionStatus(asset?.detectionStatus),
-      );
-    };
+    let pollCount = 0;
 
     const fetchEncounter = async () => {
       try {
@@ -108,8 +94,12 @@ const Encounter = observer(() => {
           store.setMediaAssets(res.data.mediaAssets);
         }
 
-        if (shouldContinuePolling(res.data)) {
-          timeoutId = window.setTimeout(fetchEncounter, 3000);
+        pollCount++;
+        if (
+          pollCount < MAX_POLL_CYCLES &&
+          shouldContinuePollingEncounter(res.data)
+        ) {
+          timeoutId = window.setTimeout(fetchEncounter, POLL_INTERVAL_MS);
         }
       } catch (_err) {
         if (!cancelled && isInitialLoad.current) {

--- a/frontend/src/pages/Encounter/ImageCard.jsx
+++ b/frontend/src/pages/Encounter/ImageCard.jsx
@@ -14,6 +14,7 @@ import Tooltip from "../../components/ToolTip";
 import axios from "axios";
 import { useIntl } from "react-intl";
 import SpotMappingIcon2 from "../../components/icons/SpotMappingIcon2";
+import { isAssetActivelyAwaitingDetection } from "./pollingHelpers";
 
 const ImageCard = observer(({ store = {} }) => {
   const imgRef = useRef(null);
@@ -67,17 +68,11 @@ const ImageCard = observer(({ store = {} }) => {
     JSON.stringify(editAnnotationParams),
   );
 
-  const isTerminalDetectionStatus = (status) =>
-    !status ||
-    status === "complete" ||
-    status === "error" ||
-    status === "pending";
-
   const selectedAsset =
     store.encounterData?.mediaAssets?.[store.selectedImageIndex];
-  const selectedAssetDetectionStatus = selectedAsset?.detectionStatus;
   const isDetectionInProgress =
-    !!selectedAsset && !isTerminalDetectionStatus(selectedAssetDetectionStatus);
+    !!selectedAsset &&
+    isAssetActivelyAwaitingDetection(selectedAsset, store.encounterData);
 
   const handleEnter = (text) => setTip((s) => ({ ...s, show: true, text }));
   const handleMove = (e) => {

--- a/frontend/src/pages/Encounter/pollingHelpers.js
+++ b/frontend/src/pages/Encounter/pollingHelpers.js
@@ -1,0 +1,43 @@
+// Shared detection-status predicates used by Encounter.jsx polling loop and
+// ImageCard.jsx "Detection in progress" indicator. Keeping them here avoids
+// the two files drifting out of sync.
+
+const POLL_INTERVAL_MS = 3000;
+const MAX_POLL_CYCLES = 100; // 100 cycles * 3s = ~5 minutes
+
+const isAnnotationTrivial = (a) => a?.isTrivial === true || a?.trivial === true;
+
+export const isTerminalDetectionStatus = (status) =>
+  !status ||
+  status === "complete" ||
+  status === "error" ||
+  status === "pending";
+
+// True when an asset is from a bulk import and detection has been queued
+// to WBIA but the callback hasn't returned yet. In this state the API
+// returns detectionStatus=null and only a trivial placeholder annotation.
+// Scoped to encounters that have an importTaskId so we don't poll forever
+// on legacy/manual encounters that intentionally never run detection.
+export const isAwaitingBulkImportDetection = (asset, encounterData) => {
+  if (!encounterData?.importTaskId) return false;
+  if (asset?.detectionStatus !== null && asset?.detectionStatus !== undefined)
+    return false;
+  const anns = Array.isArray(asset?.annotations) ? asset.annotations : [];
+  return anns.length > 0 && anns.every(isAnnotationTrivial);
+};
+
+export const isAssetActivelyAwaitingDetection = (asset, encounterData) =>
+  !isTerminalDetectionStatus(asset?.detectionStatus) ||
+  isAwaitingBulkImportDetection(asset, encounterData);
+
+export const shouldContinuePollingEncounter = (encounterData) => {
+  const mediaAssets = Array.isArray(encounterData?.mediaAssets)
+    ? encounterData.mediaAssets
+    : [];
+  if (mediaAssets.length === 0) return false;
+  return mediaAssets.some((asset) =>
+    isAssetActivelyAwaitingDetection(asset, encounterData),
+  );
+};
+
+export { POLL_INTERVAL_MS, MAX_POLL_CYCLES };

--- a/frontend/src/pages/Encounter/stores/EncounterStore.js
+++ b/frontend/src/pages/Encounter/stores/EncounterStore.js
@@ -162,7 +162,7 @@ class EncounterStore {
 
   setMediaAssets(mediaAssets) {
     if (this._encounterData) {
-      this._encounterData.mediaAssets = mediaAssets;
+      this._encounterData = { ...this._encounterData, mediaAssets };
     }
   }
 

--- a/frontend/src/service-worker.js
+++ b/frontend/src/service-worker.js
@@ -68,9 +68,10 @@ registerRoute(
   }),
 );
 
+// Never cache API endpoints — responses are not idempotent and stale data
+// (e.g. boundingBox, detectionStatus) breaks polling-driven UI updates.
 registerRoute(
-  // ({url}) => true,
-  () => true,
+  ({ url }) => !url.pathname.startsWith("/api/"),
   new NetworkFirst(),
 );
 

--- a/src/main/java/org/ecocean/media/Feature.java
+++ b/src/main/java/org/ecocean/media/Feature.java
@@ -23,6 +23,7 @@ public class Feature implements java.io.Serializable {
     protected FeatureType type;
 
     protected JSONObject parameters;
+    protected String parametersAsString;
 
     // this link back to the objs with .features that include us
     protected Annotation annotation;
@@ -52,6 +53,7 @@ public class Feature implements java.io.Serializable {
         this.id = id;
         this.type = type;
         this.parameters = params;
+        if (params != null) this.parametersAsString = params.toString();
         this.setRevision();
     }
 
@@ -90,31 +92,34 @@ public class Feature implements java.io.Serializable {
     }
 
     public JSONObject getParameters() {
-// System.out.println("getParameters() called -> " + parameters);
+        if (parameters != null) return parameters;
+        if (parametersAsString == null) return null;
+        try {
+            parameters = new JSONObject(parametersAsString);
+        } catch (JSONException je) {
+            System.out.println(this + " -- error parsing parameters json string (" +
+                parametersAsString + "): " + je.toString());
+            return null;
+        }
         return parameters;
     }
 
     public void setParameters(JSONObject p) {
-// System.out.println("setParameters(" + p + ") called");
         parameters = p;
+        parametersAsString = (p == null) ? null : p.toString();
     }
 
+    // only DataNucleus should be calling get/setParametersAsString. always use get/setParameters() instead.
     public String getParametersAsString() {
-// System.out.println("getParametersAsString() called -> " + parameters);
+        if (parametersAsString != null) return parametersAsString;
         if (parameters == null) return null;
-        return parameters.toString();
+        parametersAsString = parameters.toString();
+        return parametersAsString;
     }
 
     public void setParametersAsString(String p) {
-// System.out.println("setParametersAsString(" + p + ") called");
-        if (p == null) return;
-        try {
-            parameters = new JSONObject(p);
-        } catch (JSONException je) {
-            System.out.println(this + " -- error parsing parameters json string (" + p + "): " +
-                je.toString());
-            parameters = null;
-        }
+        parametersAsString = p;
+        parameters = null; // force lazy re-parse on next getParameters()
     }
 
     public long getRevision() {

--- a/src/main/resources/org/ecocean/media/package.jdo
+++ b/src/main/resources/org/ecocean/media/package.jdo
@@ -116,9 +116,9 @@
             	<field name="revision" persistence-modifier="persistent">
                 	<column jdbc-type="BIGINT" allows-null="false"/>
             	</field>
-		<property name="parametersAsString" persistence-modifier="persistent">
+		<field name="parametersAsString" persistence-modifier="persistent">
                 	<column jdbc-type="LONGVARCHAR" name="parameters" />
-		</property>
+		</field>
 
 		<field name="annotation" />
 		<field name="asset" />


### PR DESCRIPTION
## Summary

Three independent bugs combined to prevent bounding boxes from rendering on `/react/encounter` after detection completed. Each is fixed in its own commit on this branch.

1. **`Feature.parameters` returned null on cross-PM reads** — the JDO mapping used `<property>` with no backing String field, so DataNucleus' bytecode enhancement persisted the value without invoking the user-defined `setParametersAsString` on load. The in-memory `parameters` JSONObject stayed null, `getBbox()` returned null, and the encounter API serializer emitted `boundingBox: []` even though the DB row had correct `width`/`height`/`x`/`y` JSON.
2. **Service worker cached `/api/` polling responses** — the catchall `registerRoute(() => true, new NetworkFirst())` caches every fetch. NetworkFirst falls back to cache on slow/erroring network, so a brief empty-bbox response could be replayed to subsequent polls and even hard refreshes.
3. **React polling stopped too early on bulk imports** — the polling predicate treated `null detectionStatus` as terminal, but bulk-imported encounters arrive with `detectionStatus = null` plus a trivial placeholder annotation while detection is queued in WBIA. Polling stopped on the first poll, never noticed when detection actually completed, and the in-place `setMediaAssets` mutation prevented `useEffect`s from re-running anyway.

After all three fixes: backend correctly persists and serves bbox data, SW does not cache it, polling stays alive through the WBIA wait, React UI updates without a refresh.

Verified end-to-end by uploading bulk-import encounters on flakebook.wildme.org during this session: bounding boxes now appear automatically once WBIA returns, no manual refresh needed.

## Test plan

- [ ] Run `mvn clean install` — build succeeds with new JDO mapping. (Verified locally.)
- [ ] Run `npm run build` in `frontend/` — bundle compiles. (Verified locally — eslint clean on changed files.)
- [ ] Single-encounter submission: upload an image, observe yellow "Detection in progress" bar, observe red bbox appear automatically when detection completes (no refresh required).
- [ ] Bulk-import submission: same as above for each encounter in the import.
- [ ] Existing encounters' annotations still render correctly (no regression on already-detected data).
- [ ] Legacy/manual encounters without `importTaskId` and trivial-only annotations don't poll forever (max-poll cap of ~5 minutes serves as a safety net regardless).

## Out of scope (separate tickets recommended)

- `MediaAsset.derivationMethod` uses the same broken `<property>` pattern as old `Feature.parameters`. Likely silently broken; nothing user-visible currently depends on it.
- `IndexingManager.addIndexingQueueEntry` has a dedup race where late updates during a bg index runnable's lifetime are silently dropped.
- `BulkImport.doDelete` violates `MATCHRESULT_FK1` when deleting an import whose annotations are referenced from `MATCHRESULT`.
- `QueueUtil.background` halts the entire queue consumer on the first exception in `getNext()` — recommend catch-and-continue instead.
- Cleaner architectural fix for issue 3 above: have the bulk-import IA dispatch set `detectionStatus = "queued"`/`"sent"` server-side instead of leaving it `null`. Would let us drop the `isAwaitingBulkImportDetection` workaround.

