### PR TITLE
Fix FK violations when deleting annotations (bulk import delete + others)

### DIFF
--- a/frontend/src/locale/de.json
+++ b/frontend/src/locale/de.json
@@ -511,6 +511,7 @@
   "ROW": "Zeile",
   "APPLY_TO_ALL_ROWS_NOTE": "+ kennzeichnet, dass die Änderung auf alle Zeilen dieser Spalte angewendet werden kann",
   "BULK_IMPORT_DELETE_TASK": "Massenimport-Aufgabe löschen",
+  "BULK_IMPORT_DELETE_TASK_IN_PROGRESS": "Wird gelöscht...",
   "BULK_IMPORT_DATA_UPLOADED": "Daten hochgeladen",
   "BULK_IMPORT_IMAGE_UPLOADED": "Bild hochgeladen",
   "SPREADSHEET_UPLOADED_TITLE": "Tabellen-Datei hochgeladen: {fileName}",

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -509,6 +509,7 @@
     "ROW": "Row",
     "APPLY_TO_ALL_ROWS_NOTE": "+ denotes change can apply to all rows for this column",
     "BULK_IMPORT_DELETE_TASK": "Delete Import Task",
+    "BULK_IMPORT_DELETE_TASK_IN_PROGRESS": "Deleting...",
     "BULK_IMPORT_DATA_UPLOADED": "Data Uploaded",
     "BULK_IMPORT_IMAGE_UPLOADED": "Image Uploaded",
     "SPREADSHEET_UPLOADED_TITLE": "Spreadsheet Uploaded: {fileName}",

--- a/frontend/src/locale/es.json
+++ b/frontend/src/locale/es.json
@@ -511,6 +511,7 @@
   "ROW": "Fila",
   "APPLY_TO_ALL_ROWS_NOTE": "+ denota que el cambio se puede aplicar a todas las filas de esta columna",
   "BULK_IMPORT_DELETE_TASK": "Eliminar tarea de importación masiva",
+  "BULK_IMPORT_DELETE_TASK_IN_PROGRESS": "Eliminando...",
   "BULK_IMPORT_DATA_UPLOADED": "Datos subidos",
   "BULK_IMPORT_IMAGE_UPLOADED": "Imagen subida",
   "SPREADSHEET_UPLOADED_TITLE": "Hoja de cálculo subida: {fileName}",

--- a/frontend/src/locale/fr.json
+++ b/frontend/src/locale/fr.json
@@ -511,6 +511,7 @@
   "ROW": "Ligne",
   "APPLY_TO_ALL_ROWS_NOTE": "+ indique que la modification peut s'appliquer à toutes les lignes de cette colonne",
   "BULK_IMPORT_DELETE_TASK": "Supprimer la tâche d'importation en masse",
+  "BULK_IMPORT_DELETE_TASK_IN_PROGRESS": "Suppression...",
   "BULK_IMPORT_DATA_UPLOADED": "Données téléchargées",
   "BULK_IMPORT_IMAGE_UPLOADED": "Image téléchargée",
   "SPREADSHEET_UPLOADED_TITLE": "Feuille de calcul téléchargée: {fileName}",

--- a/frontend/src/locale/it.json
+++ b/frontend/src/locale/it.json
@@ -511,6 +511,7 @@
   "ROW": "Riga",
   "APPLY_TO_ALL_ROWS_NOTE": "+ indica che la modifica può essere applicata a tutte le righe di questa colonna",
   "BULK_IMPORT_DELETE_TASK": "Elimina attività di importazione",
+  "BULK_IMPORT_DELETE_TASK_IN_PROGRESS": "Eliminazione in corso...",
   "BULK_IMPORT_DATA_UPLOADED": "Dati caricati",
   "BULK_IMPORT_IMAGE_UPLOADED": "Immagine caricata",
   "SPREADSHEET_UPLOADED_TITLE": "Foglio di calcolo caricato: {fileName}",

--- a/frontend/src/pages/BulkImport/BulkImportTask.jsx
+++ b/frontend/src/pages/BulkImport/BulkImportTask.jsx
@@ -35,6 +35,7 @@ const BulkImportTask = observer(() => {
   const [userRoles, setUserRoles] = useState(null);
   const store = useLocalObservable(() => new BulkImportTaskStore());
   const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const previousLocationID = task?.matchingLocations || [];
 
@@ -76,12 +77,14 @@ const BulkImportTask = observer(() => {
 
   const deleteTask = async () => {
     if (!task?.id) return;
+    if (isDeleting) return;
 
     const confirmed = window.confirm(
       intl.formatMessage({ id: "BULK_IMPORT_DELETE_TASK_CONFIRM" }),
     );
     if (!confirmed) return;
 
+    setIsDeleting(true);
     try {
       const res = await fetch(`/api/v3/bulk-import/${task.id}`, {
         method: "DELETE",
@@ -102,6 +105,7 @@ const BulkImportTask = observer(() => {
           { error: err.message || "" },
         ),
       );
+      setIsDeleting(false);
     }
   };
 
@@ -568,6 +572,7 @@ const BulkImportTask = observer(() => {
         <Col xs="auto">
           <MainButton
             onClick={deleteTask}
+            disabled={isDeleting}
             shadowColor={theme.statusColors.red500}
             color={theme.statusColors.red500}
             noArrow={true}
@@ -579,9 +584,23 @@ const BulkImportTask = observer(() => {
               marginLeft: 0,
               marginTop: "1rem",
               marginBottom: "2rem",
+              opacity: isDeleting ? 0.7 : 1,
+              cursor: isDeleting ? "not-allowed" : "pointer",
             }}
           >
-            <FormattedMessage id="BULK_IMPORT_DELETE_TASK" />
+            {isDeleting ? (
+              <>
+                <Spinner
+                  animation="border"
+                  size="sm"
+                  role="status"
+                  className="me-2"
+                />
+                <FormattedMessage id="BULK_IMPORT_DELETE_TASK_IN_PROGRESS" />
+              </>
+            ) : (
+              <FormattedMessage id="BULK_IMPORT_DELETE_TASK" />
+            )}
           </MainButton>
         </Col>
       </Row>

--- a/src/main/java/org/ecocean/api/patch/EncounterPatchValidator.java
+++ b/src/main/java/org/ecocean/api/patch/EncounterPatchValidator.java
@@ -248,7 +248,7 @@ public class EncounterPatchValidator {
                     enc.addAnnotation(triv);
                     myShepherd.getPM().makePersistent(triv);
                 }
-                myShepherd.getPM().deletePersistent(ann);
+                myShepherd.throwAwayAnnotation(ann);
                 value = ann;
             } else if (path.equals("occurrenceId")) {
                 // this may be overkill. *technically* an Encounter should be contained in (at most) ONE Occurrence

--- a/src/main/java/org/ecocean/ia/MatchResult.java
+++ b/src/main/java/org/ecocean/ia/MatchResult.java
@@ -397,6 +397,10 @@ public class MatchResult implements java.io.Serializable {
         return Util.collectionSize(prospects);
     }
 
+    public Set<Annotation> getCandidates() {
+        return candidates;
+    }
+
     public Set<String> prospectScoreTypes() {
         Set<String> types = new HashSet<String>();
 

--- a/src/main/java/org/ecocean/servlet/AnnotationEdit.java
+++ b/src/main/java/org/ecocean/servlet/AnnotationEdit.java
@@ -163,7 +163,7 @@ public class AnnotationEdit extends HttpServlet {
                             myShepherd.getPM().deletePersistent(enc);
                             rtn.put("encounterDeleted", true);
                         }
-                        myShepherd.getPM().deletePersistent(annot);
+                        myShepherd.throwAwayAnnotation(annot);
                         myShepherd.getPM().deletePersistent(feat);
                         System.out.println(
                             "INFO: AnnotationEdit.remove deleted [enc,annot,feat]=[" +

--- a/src/main/java/org/ecocean/servlet/EncounterRemoveAnnotation.java
+++ b/src/main/java/org/ecocean/servlet/EncounterRemoveAnnotation.java
@@ -104,7 +104,7 @@ public class EncounterRemoveAnnotation extends HttpServlet {
                         enc.addComments("<p data-annot-id=\"" + ann.getId() +
                             "\">Annotation deleted by " + user.getDisplayName() + " on " +
                             Util.prettyTimeStamp() + "</p>");
-                        myShepherd.getPM().deletePersistent(ann);
+                        myShepherd.throwAwayAnnotation(ann);
                         myShepherd.updateDBTransaction();
                         res.put("revertToTrivial", true);
                     }
@@ -121,7 +121,7 @@ public class EncounterRemoveAnnotation extends HttpServlet {
                             "\">Annotation deleted by " + user.getDisplayName() + " on " +
                             Util.prettyTimeStamp() + "</p>");
                         enc.removeAnnotation(ann);
-                        myShepherd.getPM().deletePersistent(ann);
+                        myShepherd.throwAwayAnnotation(ann);
                         myShepherd.commitDBTransaction();
                     }
                     response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/org/ecocean/servlet/importer/ImportTask.java
+++ b/src/main/java/org/ecocean/servlet/importer/ImportTask.java
@@ -498,44 +498,36 @@ public class ImportTask implements java.io.Serializable {
         if (!user.isAdmin(myShepherd) && !Collaboration.canUserAccessImportTask(itask,
             myShepherd.getContext(), user.getUsername()))
             throw new IOException("user does not have privileges to delete task");
+        long startedAt = System.currentTimeMillis();
         Util.mark("ImportTask.deleteWithRelated(" + id + ") started");
         try {
             List<Encounter> allEncs = new ArrayList<Encounter>(itask.getEncounters());
-            int total = allEncs.size();
-            for (int i = 0; i < allEncs.size(); i++) {
-                Encounter enc = allEncs.get(i);
+            // First pass: detach annotations from encounters and collect them for a single
+            // batched FK-cleanup at the end. The previous per-annotation throwAwayAnnotation
+            // ran ~6 unindexed JDOQL queries per annotation, which becomes catastrophic for
+            // large imports. The batch path collapses that to a constant number of queries.
+            List<Annotation> allAnns = new ArrayList<Annotation>();
+            long phaseStart = System.currentTimeMillis();
+            for (Encounter enc : allEncs) {
                 Occurrence occ = myShepherd.getOccurrence(enc);
                 MarkedIndividual mark = myShepherd.getMarkedIndividualQuiet(enc.getIndividualID());
                 List<Project> projects = myShepherd.getProjectsForEncounter(enc);
                 ArrayList<Annotation> anns = enc.getAnnotations();
-                for (Annotation ann : anns) {
-                    enc.removeAnnotation(ann);
-                    // myShepherd.updateDBTransaction();
-                    List<Task> iaTasks = Task.getTasksFor(ann, myShepherd);
-                    if (iaTasks != null && !iaTasks.isEmpty()) {
-                        for (Task iaTask : iaTasks) {
-                            iaTask.removeObject(ann);
-                            // myShepherd.updateDBTransaction();
-                        }
+                if (anns != null) {
+                    for (Annotation ann : new ArrayList<Annotation>(anns)) {
+                        enc.removeAnnotation(ann);
+                        if (ann != null) allAnns.add(ann);
                     }
-                    myShepherd.throwAwayAnnotation(ann);
-                    // myShepherd.updateDBTransaction();
                 }
-                // handle occurrences
                 if (occ != null) {
                     occ.removeEncounter(enc);
-                    // myShepherd.updateDBTransaction();
                     if (occ.getEncounters().size() == 0) {
                         myShepherd.throwAwayOccurrence(occ);
-                        // myShepherd.updateDBTransaction();
                     }
                 }
-                // handle markedindividual
                 if (mark != null) {
                     mark.removeEncounter(enc);
-                    // myShepherd.updateDBTransaction();
                     if (mark.getEncounters().size() == 0) {
-                        // remove scheduled tasks referencing this individual
                         List<ScheduledIndividualMerge> mergeTasks =
                             myShepherd.getAllIncompleteScheduledIndividualMerges();
                         if (mergeTasks != null) {
@@ -546,44 +538,43 @@ public class ImportTask implements java.io.Serializable {
                                 }
                             }
                         }
-                        // check for social unit membership and remove
                         List<SocialUnit> units = myShepherd.getAllSocialUnitsForMarkedIndividual(
                             mark);
                         if (units != null && units.size() > 0) {
                             for (SocialUnit unit : units) {
-                                boolean worked = unit.removeMember(mark, myShepherd);
-                                // if (worked) myShepherd.updateDBTransaction();
+                                unit.removeMember(mark, myShepherd);
                             }
                         }
                         myShepherd.throwAwayMarkedIndividual(mark);
-                        // myShepherd.updateDBTransaction();
                     }
                 }
-                // handle projects
                 if (projects != null && projects.size() > 0) {
                     for (Project project : projects) {
                         project.removeEncounter(enc);
-                        // myShepherd.updateDBTransaction();
                     }
                 }
                 itask.removeEncounter(enc);
                 itask.addLog("Servlet DeleteImportTask removed Encounter: " +
                     enc.getCatalogNumber());
-                // myShepherd.updateDBTransaction();
                 try {
                     myShepherd.throwAwayEncounter(enc);
                 } catch (Exception e) {
                     System.out.println("Exception on throwAwayEncounter!!");
                     e.printStackTrace();
                 }
-                // myShepherd.updateDBTransaction();
             }
+            Util.mark("ImportTask.deleteWithRelated(" + id + ") encounter loop done (" +
+                allEncs.size() + " encs, " + allAnns.size() + " anns)", phaseStart);
+            // Single batched FK cleanup + delete for all annotations across the import.
+            phaseStart = System.currentTimeMillis();
+            myShepherd.throwAwayAnnotations(allAnns);
+            Util.mark("ImportTask.deleteWithRelated(" + id +
+                ") batched annotation cleanup done", phaseStart);
             myShepherd.getPM().deletePersistent(itask);
-            // myShepherd.commitDBTransaction();
         } catch (Exception ex) {
             throw new IOException("general exception on ImportTask delete: " + ex);
         }
-        Util.mark("ImportTask.deleteWithRelated(" + id + ") completed");
+        Util.mark("ImportTask.deleteWithRelated(" + id + ") completed", startedAt);
     }
 
     // this is hobbled together from some complex code in import.jsp

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -17,6 +17,7 @@ import org.ecocean.genetics.*;
 import org.ecocean.grid.ScanTask;
 import org.ecocean.grid.ScanWorkItem;
 import org.ecocean.ia.MatchResult;
+import org.ecocean.ia.MatchResultProspect;
 import org.ecocean.ia.Task;
 import org.ecocean.media.*;
 import org.ecocean.movement.Path;
@@ -467,8 +468,120 @@ public class Shepherd {
         pm.deletePersistent(analysis);
     }
 
+    // Caller must detach this Annotation from its owning Encounter (Encounter.removeAnnotation)
+    // before calling — that's a business decision about which encounter the annotation
+    // belongs to. This method handles the FK-constrained dependents that JDO mapping cascades
+    // do not reach: MatchResult, MatchResultProspect, Embedding, and the Task.objectAnnotations
+    // join collection. Without this cleanup, the JDO commit fails with constraints like
+    // MATCHRESULT_FK1 (MatchResult.queryAnnotation), the FKs on MatchResultProspect.annotation,
+    // EMBEDDING.ANNOTATION_ID, and the Task↔Annotation join table.
     public void throwAwayAnnotation(Annotation ad) {
+        if (ad == null) return;
+        cleanUpAnnotationReferences(ad);
+        pm.flush(); // make sure all dependent deletes hit the DB before the annotation row is removed
         pm.deletePersistent(ad);
+    }
+
+    private void cleanUpAnnotationReferences(Annotation ann) {
+        String annId = ann.getId();
+        if (annId == null) return; // not persisted
+
+        // 1. Delete every MatchResultProspect that references this annotation OR belongs to a
+        //    MatchResult whose queryAnnotation is this annotation. One query covers both cases
+        //    (avoids double-deleting via separate steps). Prospect.annotation is allows-null=false
+        //    so we cannot null it out — must delete the row.
+        Query qProspects = pm.newQuery(
+            "SELECT FROM org.ecocean.ia.MatchResultProspect WHERE annotation.id == :annId" +
+            " || matchResult.queryAnnotation.id == :annId");
+        try {
+            @SuppressWarnings("unchecked")
+            Collection<MatchResultProspect> prospects =
+                (Collection<MatchResultProspect>)qProspects.execute(annId);
+            if (prospects != null) {
+                for (MatchResultProspect p : new ArrayList<MatchResultProspect>(prospects)) {
+                    pm.deletePersistent(p);
+                }
+            }
+        } finally {
+            qProspects.closeAll();
+        }
+        pm.flush(); // flush prospect deletes before we delete their parent MatchResults
+
+        // 2. Delete MatchResults whose queryAnnotation is this annotation. queryAnnotation is
+        //    allows-null=false so we cannot null it out. Prospects are now declared
+        //    dependent-element=true on the prospects collection, but step 1 already removed
+        //    them, so this is just the MR rows.
+        Query qMRs = pm.newQuery(
+            "SELECT FROM org.ecocean.ia.MatchResult WHERE queryAnnotation.id == :annId");
+        try {
+            @SuppressWarnings("unchecked")
+            Collection<MatchResult> mrs = (Collection<MatchResult>)qMRs.execute(annId);
+            if (mrs != null) {
+                for (MatchResult mr : new ArrayList<MatchResult>(mrs)) {
+                    pm.deletePersistent(mr);
+                }
+            }
+        } finally {
+            qMRs.closeAll();
+        }
+        pm.flush();
+
+        // 3. Remove this annotation from any surviving MatchResult.candidates collection.
+        //    Defensive — the field is rarely populated in practice (see MatchResult.java
+        //    comment) but the join-table FK would still block annotation delete if any row
+        //    referenced this annotation.
+        Query qCand = pm.newQuery(
+            "SELECT FROM org.ecocean.ia.MatchResult" +
+            " WHERE candidates.contains(c) && c.id == :annId");
+        qCand.declareVariables("org.ecocean.Annotation c");
+        try {
+            @SuppressWarnings("unchecked")
+            Collection<MatchResult> mrsWithCandidate =
+                (Collection<MatchResult>)qCand.execute(annId);
+            if (mrsWithCandidate != null) {
+                for (MatchResult mr : new ArrayList<MatchResult>(mrsWithCandidate)) {
+                    if (mr.getCandidates() != null) mr.getCandidates().remove(ann);
+                }
+            }
+        } finally {
+            qCand.closeAll();
+        }
+
+        // 4. Delete Embedding rows that reference this annotation. Annotation.embeddings is
+        //    mapped-by="annotation" with dependent-element="false", so JDO does not cascade
+        //    on annotation delete. The FK on EMBEDDING.ANNOTATION_ID blocks deletion.
+        Query qEmb = pm.newQuery(
+            "SELECT FROM org.ecocean.Embedding WHERE annotation.id == :annId");
+        try {
+            @SuppressWarnings("unchecked")
+            Collection<Embedding> embs = (Collection<Embedding>)qEmb.execute(annId);
+            if (embs != null) {
+                for (Embedding e : new ArrayList<Embedding>(embs)) {
+                    pm.deletePersistent(e);
+                }
+            }
+        } finally {
+            qEmb.closeAll();
+        }
+
+        // 5. Remove this annotation from any Task.objectAnnotations join collection. The
+        //    Task↔Annotation join table has an FK on the Annotation column that blocks
+        //    deletion of the annotation while any join row references it.
+        Query qTasks = pm.newQuery(
+            "SELECT FROM org.ecocean.ia.Task" +
+            " WHERE objectAnnotations.contains(a) && a.id == :annId");
+        qTasks.declareVariables("org.ecocean.Annotation a");
+        try {
+            @SuppressWarnings("unchecked")
+            Collection<Task> tasks = (Collection<Task>)qTasks.execute(annId);
+            if (tasks != null) {
+                for (Task t : new ArrayList<Task>(tasks)) {
+                    t.removeObject(ann);
+                }
+            }
+        } finally {
+            qTasks.closeAll();
+        }
     }
 
     public void throwAwayOccurrence(Occurrence occ) {

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -477,26 +477,36 @@ public class Shepherd {
     // EMBEDDING.ANNOTATION_ID, and the Task↔Annotation join table.
     public void throwAwayAnnotation(Annotation ad) {
         if (ad == null) return;
-        cleanUpAnnotationReferences(ad);
-        pm.flush(); // make sure all dependent deletes hit the DB before the annotation row is removed
-        pm.deletePersistent(ad);
+        throwAwayAnnotations(java.util.Collections.singletonList(ad));
     }
 
-    private void cleanUpAnnotationReferences(Annotation ann) {
-        String annId = ann.getId();
-        if (annId == null) return; // not persisted
+    // Batch version: collects all FK-bound dependents in a single pass per dependent table
+    // (one JDOQL query per table instead of N). Used by ImportTask.deleteWithRelated for
+    // bulk-import deletion which can otherwise be O(N) queries × seq scans of large IA tables.
+    public void throwAwayAnnotations(Collection<Annotation> anns) {
+        if (anns == null || anns.isEmpty()) return;
+        List<String> annIds = new ArrayList<String>();
+        for (Annotation a : anns) {
+            if (a != null && a.getId() != null) annIds.add(a.getId());
+        }
+        if (annIds.isEmpty()) return;
+        cleanUpAnnotationReferencesBatch(annIds);
+        pm.flush(); // ensure dependent deletes hit the DB before the annotation rows go
+        for (Annotation a : anns) {
+            if (a != null) pm.deletePersistent(a);
+        }
+    }
 
-        // 1. Delete every MatchResultProspect that references this annotation OR belongs to a
-        //    MatchResult whose queryAnnotation is this annotation. One query covers both cases
-        //    (avoids double-deleting via separate steps). Prospect.annotation is allows-null=false
-        //    so we cannot null it out — must delete the row.
-        Query qProspects = pm.newQuery(
-            "SELECT FROM org.ecocean.ia.MatchResultProspect WHERE annotation.id == :annId" +
-            " || matchResult.queryAnnotation.id == :annId");
+    private void cleanUpAnnotationReferencesBatch(Collection<String> annIds) {
+        // 1. Delete every MatchResultProspect whose annotation OR whose parent MR's
+        //    queryAnnotation is in the doomed set. Single query covers both cases.
+        Query qProspects = pm.newQuery(MatchResultProspect.class);
+        qProspects.setFilter(
+            ":ids.contains(annotation.id) || :ids.contains(matchResult.queryAnnotation.id)");
         try {
             @SuppressWarnings("unchecked")
             Collection<MatchResultProspect> prospects =
-                (Collection<MatchResultProspect>)qProspects.execute(annId);
+                (Collection<MatchResultProspect>)qProspects.execute(annIds);
             if (prospects != null) {
                 for (MatchResultProspect p : new ArrayList<MatchResultProspect>(prospects)) {
                     pm.deletePersistent(p);
@@ -505,17 +515,14 @@ public class Shepherd {
         } finally {
             qProspects.closeAll();
         }
-        pm.flush(); // flush prospect deletes before we delete their parent MatchResults
+        pm.flush(); // commit prospect deletes before MR FK check
 
-        // 2. Delete MatchResults whose queryAnnotation is this annotation. queryAnnotation is
-        //    allows-null=false so we cannot null it out. Prospects are now declared
-        //    dependent-element=true on the prospects collection, but step 1 already removed
-        //    them, so this is just the MR rows.
-        Query qMRs = pm.newQuery(
-            "SELECT FROM org.ecocean.ia.MatchResult WHERE queryAnnotation.id == :annId");
+        // 2. Delete MatchResults whose queryAnnotation is in the doomed set.
+        Query qMRs = pm.newQuery(MatchResult.class);
+        qMRs.setFilter(":ids.contains(queryAnnotation.id)");
         try {
             @SuppressWarnings("unchecked")
-            Collection<MatchResult> mrs = (Collection<MatchResult>)qMRs.execute(annId);
+            Collection<MatchResult> mrs = (Collection<MatchResult>)qMRs.execute(annIds);
             if (mrs != null) {
                 for (MatchResult mr : new ArrayList<MatchResult>(mrs)) {
                     pm.deletePersistent(mr);
@@ -526,35 +533,35 @@ public class Shepherd {
         }
         pm.flush();
 
-        // 3. Remove this annotation from any surviving MatchResult.candidates collection.
-        //    Defensive — the field is rarely populated in practice (see MatchResult.java
-        //    comment) but the join-table FK would still block annotation delete if any row
-        //    referenced this annotation.
-        Query qCand = pm.newQuery(
-            "SELECT FROM org.ecocean.ia.MatchResult" +
-            " WHERE candidates.contains(c) && c.id == :annId");
+        // 3. Remove all doomed annotations from any surviving MatchResult.candidates collection.
+        //    Defensive — the field is rarely populated (see MatchResult.java comment) but the
+        //    join-table FK would still block deletion if any row referenced these annotations.
+        Query qCand = pm.newQuery(MatchResult.class);
+        qCand.setFilter("candidates.contains(c) && :ids.contains(c.id)");
         qCand.declareVariables("org.ecocean.Annotation c");
         try {
             @SuppressWarnings("unchecked")
-            Collection<MatchResult> mrsWithCandidate =
-                (Collection<MatchResult>)qCand.execute(annId);
-            if (mrsWithCandidate != null) {
-                for (MatchResult mr : new ArrayList<MatchResult>(mrsWithCandidate)) {
-                    if (mr.getCandidates() != null) mr.getCandidates().remove(ann);
+            Collection<MatchResult> mrsWithCand = (Collection<MatchResult>)qCand.execute(annIds);
+            if (mrsWithCand != null) {
+                for (MatchResult mr : new ArrayList<MatchResult>(mrsWithCand)) {
+                    if (mr.getCandidates() == null) continue;
+                    Iterator<Annotation> it = mr.getCandidates().iterator();
+                    while (it.hasNext()) {
+                        Annotation cAnn = it.next();
+                        if (cAnn != null && annIds.contains(cAnn.getId())) it.remove();
+                    }
                 }
             }
         } finally {
             qCand.closeAll();
         }
 
-        // 4. Delete Embedding rows that reference this annotation. Annotation.embeddings is
-        //    mapped-by="annotation" with dependent-element="false", so JDO does not cascade
-        //    on annotation delete. The FK on EMBEDDING.ANNOTATION_ID blocks deletion.
-        Query qEmb = pm.newQuery(
-            "SELECT FROM org.ecocean.Embedding WHERE annotation.id == :annId");
+        // 4. Delete Embeddings whose annotation is in the doomed set.
+        Query qEmb = pm.newQuery(Embedding.class);
+        qEmb.setFilter(":ids.contains(annotation.id)");
         try {
             @SuppressWarnings("unchecked")
-            Collection<Embedding> embs = (Collection<Embedding>)qEmb.execute(annId);
+            Collection<Embedding> embs = (Collection<Embedding>)qEmb.execute(annIds);
             if (embs != null) {
                 for (Embedding e : new ArrayList<Embedding>(embs)) {
                     pm.deletePersistent(e);
@@ -564,19 +571,21 @@ public class Shepherd {
             qEmb.closeAll();
         }
 
-        // 5. Remove this annotation from any Task.objectAnnotations join collection. The
-        //    Task↔Annotation join table has an FK on the Annotation column that blocks
-        //    deletion of the annotation while any join row references it.
-        Query qTasks = pm.newQuery(
-            "SELECT FROM org.ecocean.ia.Task" +
-            " WHERE objectAnnotations.contains(a) && a.id == :annId");
+        // 5. Remove all doomed annotations from any Task.objectAnnotations join collection.
+        Query qTasks = pm.newQuery(Task.class);
+        qTasks.setFilter("objectAnnotations.contains(a) && :ids.contains(a.id)");
         qTasks.declareVariables("org.ecocean.Annotation a");
         try {
             @SuppressWarnings("unchecked")
-            Collection<Task> tasks = (Collection<Task>)qTasks.execute(annId);
+            Collection<Task> tasks = (Collection<Task>)qTasks.execute(annIds);
             if (tasks != null) {
                 for (Task t : new ArrayList<Task>(tasks)) {
-                    t.removeObject(ann);
+                    if (t.getObjectAnnotations() == null) continue;
+                    List<Annotation> toRemove = new ArrayList<Annotation>();
+                    for (Annotation a : t.getObjectAnnotations()) {
+                        if (a != null && annIds.contains(a.getId())) toRemove.add(a);
+                    }
+                    for (Annotation a : toRemove) t.removeObject(a);
                 }
             }
         } finally {

--- a/src/main/resources/org/ecocean/ia/package.jdo
+++ b/src/main/resources/org/ecocean/ia/package.jdo
@@ -91,6 +91,7 @@ alter table "TASK" alter column "PARAMETERS" type text;
 
       		<field name="queryAnnotation" persistence-modifier="persistent" element-type="org.ecocean.Annotation">
 			<column allows-null="false" />
+			<index name="MATCHRESULT_QUERYANNOTATION_idx" />
 		</field>
 
 		<field name="candidates">
@@ -102,6 +103,7 @@ alter table "TASK" alter column "PARAMETERS" type text;
 	<class name="MatchResultProspect">
       		<field name="annotation" persistence-modifier="persistent" element-type="org.ecocean.Annotation">
 			<column allows-null="false" />
+			<index name="MATCHRESULTPROSPECT_ANNOTATION_idx" />
 		</field>
       		<field name="asset" persistence-modifier="persistent" element-type="org.ecocean.media.MediaAsset" />
 		<field name="matchResult" dependent-element="false" >

--- a/src/main/resources/org/ecocean/ia/package.jdo
+++ b/src/main/resources/org/ecocean/ia/package.jdo
@@ -86,7 +86,7 @@ alter table "TASK" alter column "PARAMETERS" type text;
 		</field>
 
 		<field name="prospects" default-fetch-group="false" mapped-by="matchResult">
-			<collection element-type="org.ecocean.ia.MatchResultProspect" dependent-element="false" />
+			<collection element-type="org.ecocean.ia.MatchResultProspect" dependent-element="true" />
 		</field>
 
       		<field name="queryAnnotation" persistence-modifier="persistent" element-type="org.ecocean.Annotation">

--- a/src/main/resources/org/ecocean/package.jdo
+++ b/src/main/resources/org/ecocean/package.jdo
@@ -1023,6 +1023,7 @@
 
 		<field name="annotation" dependent-element="false" >
 			<column name="ANNOTATION_ID" />
+			<index name="EMBEDDING_ANNOTATION_idx" />
 		</field>
 
 		<field name="vectorFloatArray" persistence-modifier="persistent" />


### PR DESCRIPTION
## Summary

Two related fixes for `BulkImport.doDelete` in one PR:

1. **FK violation fix** (commit 1) — bulk import deletion was throwing `MATCHRESULT_FK1` because annotations were deleted while still referenced from `MATCHRESULT` and other IA tables.
2. **Performance + UX fix** (commit 2) — even after #1, a 4-encounter import took 2-3 minutes to delete (200 encounters → hours). Combined with no UI feedback, deletion was effectively unusable on real-world imports.

After both fixes: deletion is functionally correct AND fast (4-encounter import should drop from 2-3 minutes to seconds), and users get a spinner while it runs.

---

## Commit 1 — Fix FK violations when deleting annotations

Five tables hold FK references to `ANNOTATION.ID` and JDO mappings do **not** cascade-delete on any of them:

| Reference | Constraint | Cleanup |
|---|---|---|
| `MatchResult.queryAnnotation` | `MATCHRESULT_FK1` (`allows-null=false`) | Delete the MR row |
| `MatchResultProspect.annotation` | `allows-null=false` | Delete the prospect row |
| `Embedding.annotation` | `EMBEDDING.ANNOTATION_ID` FK | Delete the embedding row |
| `Task.objectAnnotations` | `TASK_OBJECTANNOTATIONS` join FK | Remove join row |
| `MatchResult.candidates` | `MATCHRESULT_CANDIDATES` join FK (rarely populated) | Remove join row |

`Shepherd.throwAwayAnnotation` now cleans all five before deleting the annotation, with `pm.flush()` between groups so dependent rows commit to the DB before the annotation FK check.

Five direct callers that bypassed `throwAwayAnnotation` and called `pm.deletePersistent(ann)` directly are migrated:
- `EncounterPatchValidator.java:251`
- `EncounterRemoveAnnotation.java:107` and `:124`
- `AnnotationEdit.java:166`

`MatchResult.prospects` is also declared `dependent-element="true"` defensively so future code that deletes a `MatchResult` cascades correctly.

**Caller contract**: caller is still responsible for detaching from `Encounter.annotations` (`enc.removeAnnotation(ann)`). Everything else is handled.

---

## Commit 2 — Speed up bulk-import deletion + add UI feedback

### Backend (B+C)

**Batched cleanup** (`Shepherd.throwAwayAnnotations(Collection<Annotation>)`): one JDOQL query per dependent table for an entire import, instead of N×6 per-annotation queries. `throwAwayAnnotation(Annotation)` now delegates to this with a singleton list.

**Refactored `ImportTask.deleteWithRelated`**: collects all annotations across all encounters in the encounter loop, does per-encounter cleanup (occurrence/individual/project/throwAwayEncounter) inside the same loop, then calls `throwAwayAnnotations` once at the end. Removed the redundant per-annotation `Task.removeObject` loop now that the batch helper handles it. `Util.mark` timing logs added around the encounter loop and the batch cleanup phase so future slowness can be diagnosed quickly.

**JDO indexes** on the FK columns the batch queries filter by:
- `MATCHRESULT.queryAnnotation` → `MATCHRESULT_QUERYANNOTATION_idx`
- `MATCHRESULTPROSPECT.annotation` → `MATCHRESULTPROSPECT_ANNOTATION_idx`
- `EMBEDDING.annotation` → `EMBEDDING_ANNOTATION_idx`

PostgreSQL does not auto-index FK columns. Without these, every cleanup query was a sequential scan of (potentially huge) IA tables. With batching + indexes, query count and per-query cost both drop dramatically.

### Frontend (A)

Spinner + disabled state on the Delete Import Task button while delete is in flight. New i18n key `BULK_IMPORT_DELETE_TASK_IN_PROGRESS` in all 5 locale files (en/de/fr/es/it).

---

## :warning: Deployment note for large existing databases

`datanucleus.schema.autoCreateAll=true` is enabled in `jdoconfig.properties`, so the three new indexes will be created on next startup automatically. **The default `CREATE INDEX` statement is blocking** — on very large existing IA tables (millions of rows in `MATCHRESULT`/`MATCHRESULTPROSPECT`/`EMBEDDING`) this can lock the tables for the duration of the build, blocking writes (and detection callbacks).

For large deployments, run these once before the deploy, then deploy normally:

```sql
CREATE INDEX CONCURRENTLY "MATCHRESULT_QUERYANNOTATION_idx"
  ON "MATCHRESULT" ("QUERYANNOTATION_ID_OID");
CREATE INDEX CONCURRENTLY "MATCHRESULTPROSPECT_ANNOTATION_idx"
  ON "MATCHRESULTPROSPECT" ("ANNOTATION_ID_OID");
CREATE INDEX CONCURRENTLY "EMBEDDING_ANNOTATION_idx"
  ON "EMBEDDING" ("ANNOTATION_ID");
```

Verify column names against the actual schema first (DataNucleus generates them; sample query: `\d "MATCHRESULT"` in psql). If indexes already exist with the same name, DataNucleus' auto-create will be a no-op on startup and there's no further action needed.

For small/staging deployments, just deploy and let `autoCreateAll` create them on startup.

---

## Test plan

- [x] `mvn compile -DskipTests` succeeds with the new JDO mappings.
- [x] Lint clean on the changed JS file.
- [x] Locale JSON validates parse-able.
- [ ] Delete a 4-encounter bulk import that has been through identification → completes in seconds (was 2-3 minutes).
- [ ] Delete a 200-encounter bulk import → completes in tens of seconds at most (was effectively impossible).
- [ ] During delete: UI shows spinner with "Deleting..." label, button is disabled, no double-submit possible.
- [ ] Catalina log shows `Util.mark` lines for the encounter loop and batched cleanup phases, with reasonable durations.
- [ ] Delete a single encounter (`EncounterDelete` servlet) and an annotation via React encounter page (`EncounterPatchValidator` patch remove) — both should still work, no FK regressions.
- [ ] Verify after each deletion that orphan rows aren't left in `MATCHRESULT`, `MATCHRESULTPROSPECT`, `EMBEDDING`, or `TASK_OBJECTANNOTATIONS`.

## Codex review trail

This PR was developed with Codex peer review at the diagnosis, design, implementation, and final-QA stages. Codex caught (and we addressed): a missed direct deletion caller in `AnnotationEdit.java`, the latent `Embedding.annotation` FK that would FK-fail next, the need for `Task.objectAnnotations` cleanup inside `throwAwayAnnotation` itself, the need to verify the `:ids.contains(...)` JDOQL syntax (verified — already used in `EncounterExport.java:114`), and the `CREATE INDEX CONCURRENTLY` note for large prod tables. Final response on the perf + UX iteration: "ship it".

🤖 Generated with [Claude Code](https://claude.com/claude-code)