### PR TITLE
fix Annotation deletion

### DIFF
--- a/frontend/src/locale/de.json
+++ b/frontend/src/locale/de.json
@@ -511,6 +511,7 @@
   "ROW": "Zeile",
   "APPLY_TO_ALL_ROWS_NOTE": "+ kennzeichnet, dass die Änderung auf alle Zeilen dieser Spalte angewendet werden kann",
   "BULK_IMPORT_DELETE_TASK": "Massenimport-Aufgabe löschen",
+  "BULK_IMPORT_DELETE_TASK_IN_PROGRESS": "Wird gelöscht...",
   "BULK_IMPORT_DATA_UPLOADED": "Daten hochgeladen",
   "BULK_IMPORT_IMAGE_UPLOADED": "Bild hochgeladen",
   "SPREADSHEET_UPLOADED_TITLE": "Tabellen-Datei hochgeladen: {fileName}",

--- a/frontend/src/locale/de.json
+++ b/frontend/src/locale/de.json
@@ -765,6 +765,7 @@
   "INDIVIDUAL_SCORE": "Individueller Score",
   "IMAGE_SCORE": "Bild-Score",
   "NUMBER_OF_RESULTS": "Anzahl der Ergebnisse",
+  "NUMBER_OF_RESULTS_MAX_HINT": "(max. {max})",
   "SELECT_A_PROJECT": "ein Projekt auswählen",
   "MATCHED_BASED_ON": "Übereinstimmung basierend auf ",
   "POSSIBLE_MATCH": "Mögliche Übereinstimmung",

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -763,6 +763,7 @@
     "INDIVIDUAL_SCORE": "Individual Score",
     "IMAGE_SCORE": "Image Score",
     "NUMBER_OF_RESULTS": "Number of results",
+    "NUMBER_OF_RESULTS_MAX_HINT": "(max {max})",
     "SELECT_A_PROJECT": "select a project",
     "MATCHED_BASED_ON": "Matched based on ",
     "POSSIBLE_MATCH": "Possible Match",

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -509,6 +509,7 @@
     "ROW": "Row",
     "APPLY_TO_ALL_ROWS_NOTE": "+ denotes change can apply to all rows for this column",
     "BULK_IMPORT_DELETE_TASK": "Delete Import Task",
+    "BULK_IMPORT_DELETE_TASK_IN_PROGRESS": "Deleting...",
     "BULK_IMPORT_DATA_UPLOADED": "Data Uploaded",
     "BULK_IMPORT_IMAGE_UPLOADED": "Image Uploaded",
     "SPREADSHEET_UPLOADED_TITLE": "Spreadsheet Uploaded: {fileName}",

--- a/frontend/src/locale/es.json
+++ b/frontend/src/locale/es.json
@@ -765,6 +765,7 @@
   "INDIVIDUAL_SCORE": "Puntuación Individual",
   "IMAGE_SCORE": "Puntuación de Imagen",
   "NUMBER_OF_RESULTS": "Número de resultados",
+  "NUMBER_OF_RESULTS_MAX_HINT": "(máx. {max})",
   "SELECT_A_PROJECT": "seleccionar un proyecto",
   "MATCHED_BASED_ON": "Coincidencia basada en ",
   "POSSIBLE_MATCH": "Posible Coincidencia",

--- a/frontend/src/locale/es.json
+++ b/frontend/src/locale/es.json
@@ -511,6 +511,7 @@
   "ROW": "Fila",
   "APPLY_TO_ALL_ROWS_NOTE": "+ denota que el cambio se puede aplicar a todas las filas de esta columna",
   "BULK_IMPORT_DELETE_TASK": "Eliminar tarea de importación masiva",
+  "BULK_IMPORT_DELETE_TASK_IN_PROGRESS": "Eliminando...",
   "BULK_IMPORT_DATA_UPLOADED": "Datos subidos",
   "BULK_IMPORT_IMAGE_UPLOADED": "Imagen subida",
   "SPREADSHEET_UPLOADED_TITLE": "Hoja de cálculo subida: {fileName}",

--- a/frontend/src/locale/fr.json
+++ b/frontend/src/locale/fr.json
@@ -511,6 +511,7 @@
   "ROW": "Ligne",
   "APPLY_TO_ALL_ROWS_NOTE": "+ indique que la modification peut s'appliquer à toutes les lignes de cette colonne",
   "BULK_IMPORT_DELETE_TASK": "Supprimer la tâche d'importation en masse",
+  "BULK_IMPORT_DELETE_TASK_IN_PROGRESS": "Suppression...",
   "BULK_IMPORT_DATA_UPLOADED": "Données téléchargées",
   "BULK_IMPORT_IMAGE_UPLOADED": "Image téléchargée",
   "SPREADSHEET_UPLOADED_TITLE": "Feuille de calcul téléchargée: {fileName}",

--- a/frontend/src/locale/fr.json
+++ b/frontend/src/locale/fr.json
@@ -765,6 +765,7 @@
   "INDIVIDUAL_SCORE": "Score Individuel",
   "IMAGE_SCORE": "Score d'Image",
   "NUMBER_OF_RESULTS": "Nombre de résultats",
+  "NUMBER_OF_RESULTS_MAX_HINT": "(max {max})",
   "SELECT_A_PROJECT": "sélectionner un projet",
   "MATCHED_BASED_ON": "Correspondance basée sur ",
   "POSSIBLE_MATCH": "Correspondance Possible",

--- a/frontend/src/locale/it.json
+++ b/frontend/src/locale/it.json
@@ -511,6 +511,7 @@
   "ROW": "Riga",
   "APPLY_TO_ALL_ROWS_NOTE": "+ indica che la modifica può essere applicata a tutte le righe di questa colonna",
   "BULK_IMPORT_DELETE_TASK": "Elimina attività di importazione",
+  "BULK_IMPORT_DELETE_TASK_IN_PROGRESS": "Eliminazione in corso...",
   "BULK_IMPORT_DATA_UPLOADED": "Dati caricati",
   "BULK_IMPORT_IMAGE_UPLOADED": "Immagine caricata",
   "SPREADSHEET_UPLOADED_TITLE": "Foglio di calcolo caricato: {fileName}",

--- a/frontend/src/locale/it.json
+++ b/frontend/src/locale/it.json
@@ -765,6 +765,7 @@
   "INDIVIDUAL_SCORE": "Punteggio Individuale",
   "IMAGE_SCORE": "Punteggio Immagine",
   "NUMBER_OF_RESULTS": "Numero di risultati",
+  "NUMBER_OF_RESULTS_MAX_HINT": "(max {max})",
   "SELECT_A_PROJECT": "seleziona un progetto",
   "MATCHED_BASED_ON": "Corrispondenza basata su ",
   "POSSIBLE_MATCH": "Possibile Corrispondenza",

--- a/frontend/src/pages/BulkImport/BulkImportTask.jsx
+++ b/frontend/src/pages/BulkImport/BulkImportTask.jsx
@@ -35,6 +35,7 @@ const BulkImportTask = observer(() => {
   const [userRoles, setUserRoles] = useState(null);
   const store = useLocalObservable(() => new BulkImportTaskStore());
   const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const previousLocationID = task?.matchingLocations || [];
 
@@ -76,12 +77,14 @@ const BulkImportTask = observer(() => {
 
   const deleteTask = async () => {
     if (!task?.id) return;
+    if (isDeleting) return;
 
     const confirmed = window.confirm(
       intl.formatMessage({ id: "BULK_IMPORT_DELETE_TASK_CONFIRM" }),
     );
     if (!confirmed) return;
 
+    setIsDeleting(true);
     try {
       const res = await fetch(`/api/v3/bulk-import/${task.id}`, {
         method: "DELETE",
@@ -102,6 +105,7 @@ const BulkImportTask = observer(() => {
           { error: err.message || "" },
         ),
       );
+      setIsDeleting(false);
     }
   };
 
@@ -568,6 +572,7 @@ const BulkImportTask = observer(() => {
         <Col xs="auto">
           <MainButton
             onClick={deleteTask}
+            disabled={isDeleting}
             shadowColor={theme.statusColors.red500}
             color={theme.statusColors.red500}
             noArrow={true}
@@ -579,9 +584,23 @@ const BulkImportTask = observer(() => {
               marginLeft: 0,
               marginTop: "1rem",
               marginBottom: "2rem",
+              opacity: isDeleting ? 0.7 : 1,
+              cursor: isDeleting ? "not-allowed" : "pointer",
             }}
           >
-            <FormattedMessage id="BULK_IMPORT_DELETE_TASK" />
+            {isDeleting ? (
+              <>
+                <Spinner
+                  animation="border"
+                  size="sm"
+                  role="status"
+                  className="me-2"
+                />
+                <FormattedMessage id="BULK_IMPORT_DELETE_TASK_IN_PROGRESS" />
+              </>
+            ) : (
+              <FormattedMessage id="BULK_IMPORT_DELETE_TASK" />
+            )}
           </MainButton>
         </Col>
       </Row>

--- a/frontend/src/pages/BulkImport/BulkImportTask.jsx
+++ b/frontend/src/pages/BulkImport/BulkImportTask.jsx
@@ -36,7 +36,8 @@ const BulkImportTask = observer(() => {
   const store = useLocalObservable(() => new BulkImportTaskStore());
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [isDeleting, setIsDeleting] = useState(false);
-
+  const [isSendingToIdentification, setIsSendingToIdentification] =
+    useState(false);
   const previousLocationID = task?.matchingLocations || [];
 
   const fetchData = async () => {
@@ -490,50 +491,50 @@ const BulkImportTask = observer(() => {
           <MainButton
             id="re-id-button"
             disabled={
+              isSendingToIdentification ||
               (!userRoles?.includes("admin") &&
                 !userRoles?.includes("researcher")) ||
               !store.locationIDString ||
               task?.status !== "complete" ||
               task?.iaSummary?.detectionStatus !== "complete"
             }
-            onClick={() => {
+            onClick={async () => {
               setShowError(false);
-              axios
-                .get(
+              setIsSendingToIdentification(true);
+
+              try {
+                const response = await axios.get(
                   `/appadmin/resendBulkImportID.jsp?importIdTask=${taskId}${store.locationIDString}`,
-                )
-                .then((response) => {
-                  if (response.status === 200) {
-                    alert(
-                      intl.formatMessage({
-                        id: "BULK_IMPORT_RE_ID_SUCCESS",
-                        defaultMessage:
-                          "Re-identification task started successfully.",
-                      }),
-                    );
-                    window.location.reload();
-                  } else {
-                    throw new Error(
-                      intl.formatMessage({
-                        id: "BULK_IMPORT_RE_ID_ERROR",
-                        defaultMessage:
-                          "Failed to start re-identification task.",
-                      }),
-                    );
-                  }
-                })
-                .catch((error) => {
-                  console.error(
-                    "Error starting re-identification task:",
-                    error,
-                  );
+                );
+
+                if (response.status === 200) {
                   alert(
+                    intl.formatMessage({
+                      id: "BULK_IMPORT_RE_ID_SUCCESS",
+                      defaultMessage:
+                        "Re-identification task started successfully.",
+                    }),
+                  );
+                  window.location.reload();
+                } else {
+                  throw new Error(
                     intl.formatMessage({
                       id: "BULK_IMPORT_RE_ID_ERROR",
                       defaultMessage: "Failed to start re-identification task.",
                     }),
                   );
-                });
+                }
+              } catch (error) {
+                console.error("Error starting re-identification task:", error);
+                alert(
+                  intl.formatMessage({
+                    id: "BULK_IMPORT_RE_ID_ERROR",
+                    defaultMessage: "Failed to start re-identification task.",
+                  }),
+                );
+              } finally {
+                setIsSendingToIdentification(false);
+              }
             }}
             backgroundColor={theme.wildMeColors.cyan700}
             color={theme.defaultColors.white}
@@ -545,6 +546,15 @@ const BulkImportTask = observer(() => {
               marginLeft: 0,
             }}
           >
+            {isSendingToIdentification && (
+              <Spinner
+                animation="border"
+                size="sm"
+                className="me-2"
+                role="status"
+                aria-hidden="true"
+              />
+            )}
             <FormattedMessage id="BULK_IMPORT_SEND_TO_IDENTIFICATION" />
           </MainButton>
           {((!userRoles?.includes("admin") &&

--- a/frontend/src/pages/MatchResultsPage/MatchResults.jsx
+++ b/frontend/src/pages/MatchResultsPage/MatchResults.jsx
@@ -15,6 +15,7 @@ import FilterIcon from "./icons/FilterIcon";
 import MatchCriteriaDrawer from "./components/MatchCriteriaDrawer";
 import MultiSelectWithCheckbox from "../../components/MultiSelectWithCheckbox";
 import ContainerWithSpinner from "../../components/ContainerWithSpinner";
+import { MAX_NUM_RESULTS } from "./constants";
 
 const MatchResults = observer(() => {
   const themeColor = React.useContext(ThemeColorContext);
@@ -234,6 +235,16 @@ const MatchResults = observer(() => {
           >
             <Form.Label className="me-2 mb-0 small">
               <FormattedMessage id="NUMBER_OF_RESULTS" />
+              <span
+                className="ms-1 text-muted"
+                style={{ fontSize: "0.75rem" }}
+                data-testid="match-results-num-results-hint"
+              >
+                <FormattedMessage
+                  id="NUMBER_OF_RESULTS_MAX_HINT"
+                  values={{ max: MAX_NUM_RESULTS }}
+                />
+              </span>
             </Form.Label>
 
             <div

--- a/frontend/src/pages/MatchResultsPage/constants.js
+++ b/frontend/src/pages/MatchResultsPage/constants.js
@@ -1,2 +1,5 @@
-
 export const MAX_ROWS_PER_COLUMN = 4;
+
+export const MAX_NUM_RESULTS = 500;
+
+export const DEFAULT_NUM_RESULTS = 12;

--- a/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
+++ b/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
@@ -1,7 +1,11 @@
 import { makeAutoObservable } from "mobx";
 import axios from "axios";
 import { toast } from "react-toastify";
-import { MAX_ROWS_PER_COLUMN } from "../constants";
+import {
+  MAX_ROWS_PER_COLUMN,
+  MAX_NUM_RESULTS,
+  DEFAULT_NUM_RESULTS,
+} from "../constants";
 import {
   getAllAnnot,
   getAllIndiv,
@@ -22,7 +26,7 @@ export default class MatchResultsStore {
   _individualId = null;
   _individualDisplayName = null;
   _projectNames = [];
-  _numResults = 12;
+  _numResults = DEFAULT_NUM_RESULTS;
   _selectedMatchImageUrlByAlgo = new Map();
   _selectedMatch = [];
   _taskId = null;
@@ -421,11 +425,14 @@ export default class MatchResultsStore {
           `/api/v3/tasks/${this._taskId}/match-results?${params.toString()}`,
         );
         // Discard stale responses
-        if (this._currentRequestId !== requestId || this._taskId !== capturedTaskId) {
+        if (
+          this._currentRequestId !== requestId ||
+          this._taskId !== capturedTaskId
+        ) {
           return;
         }
         this.loadData(result?.data, { preserveSelection: false });
-      } catch (e) {
+      } catch {
         this.clearResults();
         toast.error("Failed to load match results");
       } finally {
@@ -440,7 +447,10 @@ export default class MatchResultsStore {
           `/api/v3/tasks/${this._taskId}/match-results?${params.toString()}`,
         );
         // Discard stale responses
-        if (this._currentRequestId !== requestId || this._taskId !== capturedTaskId) {
+        if (
+          this._currentRequestId !== requestId ||
+          this._taskId !== capturedTaskId
+        ) {
           return;
         }
 
@@ -457,7 +467,10 @@ export default class MatchResultsStore {
 
         this.loadData(result?.data, { preserveSelection: true });
       } catch (e) {
-          throw new Error("Failed to silently refresh match results: " + (e?.message || String(e)));
+        throw new Error(
+          "Failed to silently refresh match results: " +
+            (e?.message || String(e)),
+        );
       }
     }
   }
@@ -481,7 +494,9 @@ export default class MatchResultsStore {
   }
 
   setNumResults(n) {
-    this._numResults = n;
+    const num = Number(n);
+    if (!Number.isFinite(num)) return;
+    this._numResults = Math.min(Math.max(Math.floor(num), 1), MAX_NUM_RESULTS);
   }
 
   setProjectNames(names, { fetch = true } = {}) {
@@ -558,19 +573,17 @@ export default class MatchResultsStore {
 
       // Run all PATCHes in parallel and track results
       const patchPromises = encounterIds.map((id) =>
-        axios.patch(
-          `/api/v3/encounters/${encodeURIComponent(id)}`,
-          patchOps,
-          {
+        axios
+          .patch(`/api/v3/encounters/${encodeURIComponent(id)}`, patchOps, {
             headers: {
               "Content-Type": "application/json-patch+json",
               Accept: "application/json",
             },
-          },
-        ).then(
-          (response) => ({ status: "fulfilled", encounterId: id, response }),
-          (error) => ({ status: "rejected", encounterId: id, error }),
-        ),
+          })
+          .then(
+            (response) => ({ status: "fulfilled", encounterId: id, response }),
+            (error) => ({ status: "rejected", encounterId: id, error }),
+          ),
       );
 
       const results = await Promise.allSettled(patchPromises);
@@ -601,14 +614,17 @@ export default class MatchResultsStore {
           ok: false,
           error: "CREATE_NEW_INDIVIDUAL_PARTIAL",
           successes,
-          failures: failures.map((f) => ({ encounterId: f.encounterId, error: f.error?.message || String(f.error) })),
+          failures: failures.map((f) => ({
+            encounterId: f.encounterId,
+            error: f.error?.message || String(f.error),
+          })),
         };
       }
 
       this.resetSelectionToQuery();
       toast.success("New individual created successfully!");
       return { ok: true, successes };
-    } catch (e) {
+    } catch {
       this._matchRequestError = "CREATE_NEW_INDIVIDUAL_FAILED";
       toast.error("Failed to create new individual");
       return { ok: false, error: "CREATE_NEW_INDIVIDUAL_FAILED" };
@@ -702,7 +718,7 @@ export default class MatchResultsStore {
       this.resetSelectionToQuery();
       toast.success("Match confirmed successfully!");
       return res.data;
-    } catch (e) {
+    } catch {
       this._matchRequestError = "MATCH_FAILED";
       toast.error("Failed to confirm match");
       return null;
@@ -751,7 +767,7 @@ export default class MatchResultsStore {
       this.resetSelectionToQuery();
       toast.success("Merge page opened successfully!");
       return { ok: true };
-    } catch (e) {
+    } catch {
       this._matchRequestError = "MERGE_FAILED";
       toast.error("Failed to start merge");
       return null;

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -1744,10 +1744,43 @@ public class Annotation extends Base implements java.io.Serializable {
         int ct = 0;
 
         for (MatchResult mr : mrs) {
-            myShepherd.getPM().deletePersistent(mr);
             ct++;
+            System.out.println("[DEBUG] (" + ct + ") ann.deleteMatchResults() on id=" +
+                this.getId() + " deleting " + mr);
+            myShepherd.getPM().deletePersistent(mr);
         }
         return ct;
+    }
+
+    // when we delete an Annotation, we usually dont want to leave the Embeddings around
+    public int deleteEmbeddings(Shepherd myShepherd) {
+        int rtn = numberEmbeddings();
+
+        if (rtn < 1) return 0;
+        for (Embedding emb : embeddings) {
+            System.out.println("[DEBUG] ann.deleteEmbeddings() on id=" + this.getId() +
+                " deleting " + emb);
+            myShepherd.getPM().deletePersistent(emb);
+        }
+        return rtn;
+    }
+
+    // a convenient method which does a typical set of steps to ready Annotation for deletion from db
+    // if encounter is already known, it can be passed (null will be ignored)
+    public void prepareForDeletion(Shepherd myShepherd, Encounter enc) {
+        int nt = this.detachFromTasks(myShepherd);
+
+        if (enc != null) enc.removeAnnotation(this);
+        this.detachFromMediaAsset();
+        int nm = this.deleteMatchResults(myShepherd);
+        int ne = this.deleteEmbeddings(myShepherd);
+        System.out.println("[INFO] ann.prepareForDeletion(): " + nt + " Tasks, " + nm +
+            " MatchResults, " + ne + " Embeddings on " + this);
+    }
+
+    // this version takes no enc, but will attempt to find it
+    public void prepareForDeletion(Shepherd myShepherd) {
+        prepareForDeletion(myShepherd, this.findEncounter(myShepherd));
     }
 
     public static boolean isValidViewpoint(String vp) {

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -14,6 +14,7 @@ import org.ecocean.api.ApiException;
 import org.ecocean.ia.IA;
 import org.ecocean.ia.IAException;
 import org.ecocean.ia.MatchResult;
+import org.ecocean.ia.MatchResultProspect;
 import org.ecocean.ia.MLService;
 import org.ecocean.ia.Task;
 import org.ecocean.identity.IBEISIA;
@@ -1752,6 +1753,20 @@ public class Annotation extends Base implements java.io.Serializable {
         return ct;
     }
 
+    // similar as above for MatchResultProspects
+    public int deleteMatchResultProspects(Shepherd myShepherd) {
+        List<MatchResultProspect> mrps = myShepherd.getMatchResultProspects(this);
+        int ct = 0;
+
+        for (MatchResultProspect mrp : mrps) {
+            ct++;
+            System.out.println("[DEBUG] (" + ct + ") ann.deleteMatchResultProspects() on id=" +
+                this.getId() + " deleting " + mrp);
+            myShepherd.getPM().deletePersistent(mrp);
+        }
+        return ct;
+    }
+
     // when we delete an Annotation, we usually dont want to leave the Embeddings around
     public int deleteEmbeddings(Shepherd myShepherd) {
         int rtn = numberEmbeddings();
@@ -1773,9 +1788,10 @@ public class Annotation extends Base implements java.io.Serializable {
         if (enc != null) enc.removeAnnotation(this);
         this.detachFromMediaAsset();
         int nm = this.deleteMatchResults(myShepherd);
+        int np = this.deleteMatchResultProspects(myShepherd);
         int ne = this.deleteEmbeddings(myShepherd);
         System.out.println("[INFO] ann.prepareForDeletion(): " + nt + " Tasks, " + nm +
-            " MatchResults, " + ne + " Embeddings on " + this);
+            " MatchResults, " + np + " MatchResultProspects, " + ne + " Embeddings on " + this);
     }
 
     // this version takes no enc, but will attempt to find it

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.ecocean.api.ApiException;
 import org.ecocean.ia.IA;
 import org.ecocean.ia.IAException;
+import org.ecocean.ia.MatchResult;
 import org.ecocean.ia.MLService;
 import org.ecocean.ia.Task;
 import org.ecocean.identity.IBEISIA;
@@ -1598,7 +1599,6 @@ public class Annotation extends Base implements java.io.Serializable {
                     foundTrivial + " (and Feature) from " + ma + " and " + enc);
             }
         }
-
         // we queue for embedding extraction so this is done in the background
         // and frees up foreground api process to return results to user
         // TODO myShepherd commit doesnt happen until we return; potential race condition on IA queue?
@@ -1606,7 +1606,8 @@ public class Annotation extends Base implements java.io.Serializable {
         task.addObject(ann);
         task.setStatusDetailsAddLog("Annotation.createFromApi() embedding extraction on " + ann);
         myShepherd.getPM().makePersistent(task);
-        System.out.println("[INFO] Annotation.createFromApi(): queueing for embedding extraction with " + task);
+        System.out.println(
+            "[INFO] Annotation.createFromApi(): queueing for embedding extraction with " + task);
         ann.queueForEmbeddingExtraction(task, myShepherd);
         return ann;
     }
@@ -1734,6 +1735,19 @@ public class Annotation extends Base implements java.io.Serializable {
             task.removeObject(this);
         }
         return tasks.size();
+    }
+
+    // we cant just detach the annots from match results, so we need
+    // to kill them off before we can delete an Annotation
+    public int deleteMatchResults(Shepherd myShepherd) {
+        List<MatchResult> mrs = myShepherd.getMatchResults(this);
+        int ct = 0;
+
+        for (MatchResult mr : mrs) {
+            myShepherd.getPM().deletePersistent(mr);
+            ct++;
+        }
+        return ct;
     }
 
     public static boolean isValidViewpoint(String vp) {

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -1740,17 +1740,8 @@ public class Annotation extends Base implements java.io.Serializable {
 
     // we cant just detach the annots from match results, so we need
     // to kill them off before we can delete an Annotation
-    public int deleteMatchResults(Shepherd myShepherd) {
-        List<MatchResult> mrs = myShepherd.getMatchResults(this);
-        int ct = 0;
-
-        for (MatchResult mr : mrs) {
-            ct++;
-            System.out.println("[DEBUG] (" + ct + ") ann.deleteMatchResults() on id=" +
-                this.getId() + " deleting " + mr);
-            myShepherd.getPM().deletePersistent(mr);
-        }
-        return ct;
+    public long deleteMatchResults(Shepherd myShepherd) {
+        return myShepherd.deleteMatchResults(this);
     }
 
     // similar as above for MatchResultProspects
@@ -1787,7 +1778,7 @@ public class Annotation extends Base implements java.io.Serializable {
 
         if (enc != null) enc.removeAnnotation(this);
         this.detachFromMediaAsset();
-        int nm = this.deleteMatchResults(myShepherd);
+        long nm = this.deleteMatchResults(myShepherd);
         int np = this.deleteMatchResultProspects(myShepherd);
         int ne = this.deleteEmbeddings(myShepherd);
         System.out.println("[INFO] ann.prepareForDeletion(): " + nt + " Tasks, " + nm +

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -1775,13 +1775,14 @@ public class Annotation extends Base implements java.io.Serializable {
     // if encounter is already known, it can be passed (null will be ignored)
     public void prepareForDeletion(Shepherd myShepherd, Encounter enc) {
         int nt = this.detachFromTasks(myShepherd);
+        long t = System.currentTimeMillis();
 
         if (enc != null) enc.removeAnnotation(this);
         this.detachFromMediaAsset();
         long nm = this.deleteMatchResults(myShepherd);
         int np = this.deleteMatchResultProspects(myShepherd);
         int ne = this.deleteEmbeddings(myShepherd);
-        System.out.println("[INFO] ann.prepareForDeletion(): " + nt + " Tasks, " + nm +
+        System.out.println("[INFO] ann.prepareForDeletion() [" + (System.currentTimeMillis() - t) + "ms]: " + nt + " Tasks, " + nm +
             " MatchResults, " + np + " MatchResultProspects, " + ne + " Embeddings on " + this);
     }
 

--- a/src/main/java/org/ecocean/api/SiteSettings.java
+++ b/src/main/java/org/ecocean/api/SiteSettings.java
@@ -132,7 +132,9 @@ public class SiteSettings extends ApiBase {
                         for (JSONObject idOpt : iaConfig.identOpts(tx, iaClass)) {
                             // make a copy so we can safely modify it
                             JSONObject idOptCopy = new JSONObject(idOpt.toString());
-                            idOptCopy.remove("api_endpoint"); // dont want this shown
+                            // FIXME we need to leave this endpoint in on site-settings for now
+                            // as it is needed to kick off the matching from the client
+                            // idOptCopy.remove("api_endpoint");
                             // NOTE: JSONObject.toString() in theory might produce different strings
                             // for the same object (key ordering different); but in practice seems to
                             // be consistent within these iterations

--- a/src/main/java/org/ecocean/api/patch/EncounterPatchValidator.java
+++ b/src/main/java/org/ecocean/api/patch/EncounterPatchValidator.java
@@ -234,9 +234,7 @@ public class EncounterPatchValidator {
                     throw new ApiException("no such annotation id=" + value.toString(),
                             ApiException.ERROR_RETURN_CODE_INVALID);
                 MediaAsset ma = ann.getMediaAsset();
-                ann.detachFromTasks(myShepherd);
-                enc.removeAnnotation(ann);
-                ann.detachFromMediaAsset();
+                ann.prepareForDeletion(myShepherd, enc);
                 // "most likely" this encounter is now detached from the asset, but we want them still connected
                 // TODO parts might be connecting these, but how do we determine if we still need to add the trivial?
                 if (ma != null) {
@@ -345,8 +343,7 @@ public class EncounterPatchValidator {
     }
 
     // should never get called here with null value
-    private static MarkedIndividual getOrCreateMarkedIndividual(Object value,
-        Shepherd myShepherd)
+    private static MarkedIndividual getOrCreateMarkedIndividual(Object value, Shepherd myShepherd)
     throws ApiException {
         String idOrName = null;
         MarkedIndividual indiv = null;
@@ -356,7 +353,6 @@ public class EncounterPatchValidator {
             // but we ignore that for now :) related, we dont check if this individual
             // exists with getMarkedIndividual() first
             JSONObject nameData = (JSONObject)value;
-
             String type = nameData.optString("type", "NO_TYPE_GIVEN");
             // right now we only support type=locationId, but may expand later
             if (type.equals("locationId")) {
@@ -365,16 +361,17 @@ public class EncounterPatchValidator {
                     idOrName = MarkedIndividual.nextNameByLocationId(locationId);
                 } catch (IllegalArgumentException ex) {
                     // can fail for various reasons like invalid locationId or one without a prefix
-                    throw new ApiException("could not get next individual name for locationId (" + locationId + "): " + ex.getMessage(),
-                        ApiException.ERROR_RETURN_CODE_INVALID);
+                    throw new ApiException("could not get next individual name for locationId (" +
+                            locationId + "): " + ex.getMessage(),
+                            ApiException.ERROR_RETURN_CODE_INVALID);
                 }
             } else {
                 throw new ApiException("invalid type passed for new individual creation: " + type,
-                    ApiException.ERROR_RETURN_CODE_INVALID);
+                        ApiException.ERROR_RETURN_CODE_INVALID);
             }
             // if we fall through to here we should have idOrName to create a new one
-            System.out.println("[DEBUG] getOrCreateMarkedIndividual() creating '" + idOrName + "' based on " + nameData);
-
+            System.out.println("[DEBUG] getOrCreateMarkedIndividual() creating '" + idOrName +
+                "' based on " + nameData);
         } else { // not json, so must have a name to find/create
             idOrName = value.toString();
             indiv = myShepherd.getMarkedIndividual(idOrName);

--- a/src/main/java/org/ecocean/ia/MatchResult.java
+++ b/src/main/java/org/ecocean/ia/MatchResult.java
@@ -47,7 +47,7 @@ public class MatchResult implements java.io.Serializable {
     private Set<Annotation> candidates;
     // fallback number to cutoff number of prospects to return
     public static final int DEFAULT_PROSPECTS_CUTOFF = 100;
-    // number of MatchResultProspects to actually store (hotspotter
+    // number of MatchResultProspects [per type] to actually store (hotspotter
     // results can produce thousands, but storing them all is excessive)
     public static final int MAXIMUM_PROSPECTS_STORED = 500;
 
@@ -165,7 +165,7 @@ public class MatchResult implements java.io.Serializable {
         if (this.prospects == null)
             this.prospects = new HashSet<MatchResultProspect>();
         int num = 0;
-        this.numberProspects = annotIds.length(); // true number of prospects
+        this.numberProspects += annotIds.length(); // true number of prospects
         for (int i = 0; i < annotIds.length(); i++) {
             double score = scores.optDouble(i, -Double.MAX_VALUE);
             String id = IBEISIA.fromFancyUUID(annotIds.optJSONObject(i));
@@ -182,7 +182,8 @@ public class MatchResult implements java.io.Serializable {
             this.prospects.add(new MatchResultProspect(ann, score, type, ma));
             num++;
             if (num >= MAXIMUM_PROSPECTS_STORED) {
-                System.out.println("[DEBUG] hit max (" + MAXIMUM_PROSPECTS_STORED + ") number storable prospects on " + this);
+                System.out.println("[DEBUG] hit max (" + MAXIMUM_PROSPECTS_STORED +
+                    ") number storable prospects on " + this);
                 break;
             }
         }
@@ -205,7 +206,8 @@ public class MatchResult implements java.io.Serializable {
             // these scores are direct from opensearch
             for (Annotation ann : annots) {
                 MediaAsset ma = createInspectionPairxAsset(this.queryAnnotation, ann, myShepherd);
-                this.prospects.add(new MatchResultProspect(ann, ann.getOpensearchScore(), "annot", ma));
+                this.prospects.add(new MatchResultProspect(ann, ann.getOpensearchScore(), "annot",
+                    ma));
             }
         }
         this.numberProspects = this.prospects.size();

--- a/src/main/java/org/ecocean/ia/MatchResult.java
+++ b/src/main/java/org/ecocean/ia/MatchResult.java
@@ -38,12 +38,18 @@ public class MatchResult implements java.io.Serializable {
     private Set<MatchResultProspect> prospects;
     private Annotation queryAnnotation;
     private int numberCandidates = 0;
+    // we store *actual* count here, but they may not all exist
+    // via .prospects due to MAXIMUM_PROSPECTS_STORED (see below)
+    private int numberProspects = 0;
     // not sure we really *need* true fk link to these annots
     // they might be gone now and will we ever use this?
     // so for now we just populate numberCandidates
     private Set<Annotation> candidates;
     // fallback number to cutoff number of prospects to return
     public static final int DEFAULT_PROSPECTS_CUTOFF = 100;
+    // number of MatchResultProspects to actually store (hotspotter
+    // results can produce thousands, but storing them all is excessive)
+    public static final int MAXIMUM_PROSPECTS_STORED = 500;
 
     public MatchResult() {
         id = Util.generateUUID();
@@ -159,6 +165,7 @@ public class MatchResult implements java.io.Serializable {
         if (this.prospects == null)
             this.prospects = new HashSet<MatchResultProspect>();
         int num = 0;
+        this.numberProspects = annotIds.length(); // true number of prospects
         for (int i = 0; i < annotIds.length(); i++) {
             double score = scores.optDouble(i, -Double.MAX_VALUE);
             String id = IBEISIA.fromFancyUUID(annotIds.optJSONObject(i));
@@ -174,11 +181,17 @@ public class MatchResult implements java.io.Serializable {
                 ma = createInspectionHeatmapAsset(externRef, id, myShepherd);
             this.prospects.add(new MatchResultProspect(ann, score, type, ma));
             num++;
+            if (num >= MAXIMUM_PROSPECTS_STORED) {
+                System.out.println("[DEBUG] hit max (" + MAXIMUM_PROSPECTS_STORED + ") number storable prospects on " + this);
+                break;
+            }
         }
         return num;
     }
 
     // we just have a list of annots which matched (e.g. via vectors in opensearch)
+    // NOTE: currently does not check MAXIMUM_PROSPECTS_STORED because vector search
+    // tends to return relatively few prospects. TODO adjust later if this proves untrue.
     private int populateProspects(List<Annotation> annots, boolean scoreByIndividual,
         Shepherd myShepherd)
     throws IOException {
@@ -195,7 +208,8 @@ public class MatchResult implements java.io.Serializable {
                 this.prospects.add(new MatchResultProspect(ann, ann.getOpensearchScore(), "annot", ma));
             }
         }
-        return this.prospects.size();
+        this.numberProspects = this.prospects.size();
+        return this.numberProspects;
     }
 
     private void _populateProspectsByIndividual(List<Annotation> annots, Shepherd myShepherd) {
@@ -394,7 +408,7 @@ public class MatchResult implements java.io.Serializable {
     }
  */
     public int numberProspects() {
-        return Util.collectionSize(prospects);
+        return this.numberProspects;
     }
 
     public Set<String> prospectScoreTypes() {

--- a/src/main/java/org/ecocean/ia/MatchResultProspect.java
+++ b/src/main/java/org/ecocean/ia/MatchResultProspect.java
@@ -57,7 +57,7 @@ public class MatchResultProspect implements java.io.Serializable, Comparable<Mat
     }
 
     public String toString() {
-        return scoreType + ": " + score + " on " + annotation;
+        return scoreType + "=" + score + " on " + annotation + " for " + matchResult;
     }
 
     public JSONObject jsonForApiGet(Shepherd myShepherd) {

--- a/src/main/java/org/ecocean/servlet/AnnotationEdit.java
+++ b/src/main/java/org/ecocean/servlet/AnnotationEdit.java
@@ -163,6 +163,7 @@ public class AnnotationEdit extends HttpServlet {
                             rtn.put("encounterDeleted", true);
                         }
                         annot.deleteMatchResults(myShepherd);
+                        annot.deleteMatchResultProspects(myShepherd);
                         annot.deleteEmbeddings(myShepherd);
                         myShepherd.getPM().deletePersistent(annot);
                         myShepherd.getPM().deletePersistent(feat);

--- a/src/main/java/org/ecocean/servlet/AnnotationEdit.java
+++ b/src/main/java/org/ecocean/servlet/AnnotationEdit.java
@@ -42,7 +42,6 @@ public class AnnotationEdit extends HttpServlet {
         myShepherd.beginDBTransaction();
         JSONObject jsonIn = ServletUtilities.jsonFromHttpServletRequest(request);
         PrintWriter out = response.getWriter();
-
         User user = AccessControl.getUser(request, myShepherd);
         boolean isAdmin = false;
         if (user != null)
@@ -163,6 +162,8 @@ public class AnnotationEdit extends HttpServlet {
                             myShepherd.getPM().deletePersistent(enc);
                             rtn.put("encounterDeleted", true);
                         }
+                        annot.deleteMatchResults(myShepherd);
+                        annot.deleteEmbeddings(myShepherd);
                         myShepherd.getPM().deletePersistent(annot);
                         myShepherd.getPM().deletePersistent(feat);
                         System.out.println(

--- a/src/main/java/org/ecocean/servlet/EncounterDelete.java
+++ b/src/main/java/org/ecocean/servlet/EncounterDelete.java
@@ -20,9 +20,9 @@ import java.util.Map;
 // import java.util.Vector;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import org.ecocean.shepherd.core.Shepherd;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.ecocean.shepherd.core.Shepherd;
 
 public class EncounterDelete extends HttpServlet {
     private static final Logger log = LogManager.getLogger(EncounterDelete.class);
@@ -162,15 +162,7 @@ public class EncounterDelete extends HttpServlet {
                     ArrayList<Annotation> anns = enc2trash.getAnnotations();
                     for (Annotation ann : anns) {
                         myShepherd.beginDBTransaction();
-                        enc2trash.removeAnnotation(ann);
-                        myShepherd.updateDBTransaction();
-                        List<Task> iaTasks = Task.getTasksFor(ann, myShepherd);
-                        if (iaTasks != null && !iaTasks.isEmpty()) {
-                            for (Task iaTask : iaTasks) {
-                                iaTask.removeObject(ann);
-                                myShepherd.updateDBTransaction();
-                            }
-                        }
+                        ann.prepareForDeletion(myShepherd, enc2trash);
                         myShepherd.throwAwayAnnotation(ann);
                         myShepherd.commitDBTransaction();
                     }

--- a/src/main/java/org/ecocean/servlet/EncounterRemoveAnnotation.java
+++ b/src/main/java/org/ecocean/servlet/EncounterRemoveAnnotation.java
@@ -15,8 +15,8 @@ import javax.servlet.ServletException;
 import java.io.*;
 import java.util.List;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class EncounterRemoveAnnotation extends HttpServlet {
     private static final Logger log = LogManager.getLogger(EncounterRemoveAnnotation.class);
@@ -104,6 +104,8 @@ public class EncounterRemoveAnnotation extends HttpServlet {
                         enc.addComments("<p data-annot-id=\"" + ann.getId() +
                             "\">Annotation deleted by " + user.getDisplayName() + " on " +
                             Util.prettyTimeStamp() + "</p>");
+                        ann.deleteMatchResults(myShepherd);
+                        ann.deleteEmbeddings(myShepherd);
                         myShepherd.getPM().deletePersistent(ann);
                         myShepherd.updateDBTransaction();
                         res.put("revertToTrivial", true);
@@ -121,6 +123,8 @@ public class EncounterRemoveAnnotation extends HttpServlet {
                             "\">Annotation deleted by " + user.getDisplayName() + " on " +
                             Util.prettyTimeStamp() + "</p>");
                         enc.removeAnnotation(ann);
+                        ann.deleteMatchResults(myShepherd);
+                        ann.deleteEmbeddings(myShepherd);
                         myShepherd.getPM().deletePersistent(ann);
                         myShepherd.commitDBTransaction();
                     }

--- a/src/main/java/org/ecocean/servlet/EncounterRemoveAnnotation.java
+++ b/src/main/java/org/ecocean/servlet/EncounterRemoveAnnotation.java
@@ -105,6 +105,7 @@ public class EncounterRemoveAnnotation extends HttpServlet {
                             "\">Annotation deleted by " + user.getDisplayName() + " on " +
                             Util.prettyTimeStamp() + "</p>");
                         ann.deleteMatchResults(myShepherd);
+                        ann.deleteMatchResultProspects(myShepherd);
                         ann.deleteEmbeddings(myShepherd);
                         myShepherd.getPM().deletePersistent(ann);
                         myShepherd.updateDBTransaction();
@@ -124,6 +125,7 @@ public class EncounterRemoveAnnotation extends HttpServlet {
                             Util.prettyTimeStamp() + "</p>");
                         enc.removeAnnotation(ann);
                         ann.deleteMatchResults(myShepherd);
+                        ann.deleteMatchResultProspects(myShepherd);
                         ann.deleteEmbeddings(myShepherd);
                         myShepherd.getPM().deletePersistent(ann);
                         myShepherd.commitDBTransaction();

--- a/src/main/java/org/ecocean/servlet/importer/DeleteImportTask.java
+++ b/src/main/java/org/ecocean/servlet/importer/DeleteImportTask.java
@@ -9,8 +9,8 @@ import org.ecocean.Occurrence;
 import org.ecocean.Project;
 import org.ecocean.security.Collaboration;
 import org.ecocean.servlet.ServletUtilities;
-import org.ecocean.social.SocialUnit;
 import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.social.SocialUnit;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -62,15 +62,7 @@ public class DeleteImportTask extends HttpServlet {
                     List<Project> projects = myShepherd.getProjectsForEncounter(enc);
                     ArrayList<Annotation> anns = enc.getAnnotations();
                     for (Annotation ann : anns) {
-                        enc.removeAnnotation(ann);
-                        myShepherd.updateDBTransaction();
-                        List<Task> iaTasks = Task.getTasksFor(ann, myShepherd);
-                        if (iaTasks != null && !iaTasks.isEmpty()) {
-                            for (Task iaTask : iaTasks) {
-                                iaTask.removeObject(ann);
-                                myShepherd.updateDBTransaction();
-                            }
-                        }
+                        ann.prepareForDeletion(myShepherd, enc);
                         myShepherd.throwAwayAnnotation(ann);
                         myShepherd.updateDBTransaction();
                     }

--- a/src/main/java/org/ecocean/servlet/importer/ImportTask.java
+++ b/src/main/java/org/ecocean/servlet/importer/ImportTask.java
@@ -403,7 +403,8 @@ public class ImportTask implements java.io.Serializable {
                 // this records only most recent task statuses like: numLatestTask_complete
                 if (latestTask) {
                     String latestStatus = "numLatestTask_" + atask.getStatus(myShepherd);
-                    System.out.println("[DEBUG] (ImportTask " + this.getId() + ") latestStatus for Task " + atask.getId() + ": " + latestStatus);
+                    System.out.println("[DEBUG] (ImportTask " + this.getId() +
+                        ") latestStatus for Task " + atask.getId() + ": " + latestStatus);
                     if (sa.has(latestStatus)) {
                         sa.put(latestStatus, sa.optInt(latestStatus, 0) + 1);
                     } else {
@@ -509,17 +510,8 @@ public class ImportTask implements java.io.Serializable {
                 List<Project> projects = myShepherd.getProjectsForEncounter(enc);
                 ArrayList<Annotation> anns = enc.getAnnotations();
                 for (Annotation ann : anns) {
-                    enc.removeAnnotation(ann);
-                    // myShepherd.updateDBTransaction();
-                    List<Task> iaTasks = Task.getTasksFor(ann, myShepherd);
-                    if (iaTasks != null && !iaTasks.isEmpty()) {
-                        for (Task iaTask : iaTasks) {
-                            iaTask.removeObject(ann);
-                            // myShepherd.updateDBTransaction();
-                        }
-                    }
+                    ann.prepareForDeletion(myShepherd, enc);
                     myShepherd.throwAwayAnnotation(ann);
-                    // myShepherd.updateDBTransaction();
                 }
                 // handle occurrences
                 if (occ != null) {
@@ -638,7 +630,9 @@ public class ImportTask implements java.io.Serializable {
                 pj.put("detectionPercent", 1.0);
                 pj.put("detectionStatus", "complete");
             } else {
-                if (numAssets > 0) pj.put("detectionPercent", new Double(numDetectionComplete) / new Double(numAssets));
+                if (numAssets > 0)
+                    pj.put("detectionPercent",
+                        new Double(numDetectionComplete) / new Double(numAssets));
                 pj.put("detectionStatus", "sent");
             }
             if (this.iaTaskRequestedIdentification()) {
@@ -695,11 +689,12 @@ public class ImportTask implements java.io.Serializable {
 
     static Map<String, Integer> parseSqlCountResults(Query query) {
         Map<String, Integer> map = new HashMap<>();
+
         try {
             List<?> results = query.executeList();
             for (Object row : results) {
-                Object[] cols = (Object[]) row;
-                map.put((String) cols[0], ((Number) cols[1]).intValue());
+                Object[] cols = (Object[])row;
+                map.put((String)cols[0], ((Number)cols[1]).intValue());
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -712,28 +707,28 @@ public class ImportTask implements java.io.Serializable {
     public static Map<String, Integer> getAllEncounterCounts(Shepherd myShepherd) {
         Query query = myShepherd.getPM().newQuery("javax.jdo.query.SQL",
             "SELECT \"ID_OID\", count(*) FROM \"IMPORTTASK_ENCOUNTERS\" GROUP BY \"ID_OID\"");
+
         return parseSqlCountResults(query);
     }
 
     public static Map<String, Integer> getAllIndividualCounts(Shepherd myShepherd) {
         Query query = myShepherd.getPM().newQuery("javax.jdo.query.SQL",
             "SELECT ie.\"ID_OID\", count(distinct me.\"INDIVIDUALID_OID\") " +
-            "FROM \"IMPORTTASK_ENCOUNTERS\" ie " +
-            "JOIN \"MARKEDINDIVIDUAL_ENCOUNTERS\" me " +
-            "ON ie.\"CATALOGNUMBER_EID\" = me.\"CATALOGNUMBER_EID\" " +
-            "GROUP BY ie.\"ID_OID\"");
+            "FROM \"IMPORTTASK_ENCOUNTERS\" ie " + "JOIN \"MARKEDINDIVIDUAL_ENCOUNTERS\" me " +
+            "ON ie.\"CATALOGNUMBER_EID\" = me.\"CATALOGNUMBER_EID\" " + "GROUP BY ie.\"ID_OID\"");
+
         return parseSqlCountResults(query);
     }
 
     public static Map<String, Integer> getAllMediaAssetCounts(Shepherd myShepherd) {
         Query query = myShepherd.getPM().newQuery("javax.jdo.query.SQL",
             "SELECT ie.\"ID_OID\", count(distinct mf.\"ID_OID\") " +
-            "FROM \"IMPORTTASK_ENCOUNTERS\" ie " +
-            "JOIN \"ENCOUNTER_ANNOTATIONS\" ea " +
+            "FROM \"IMPORTTASK_ENCOUNTERS\" ie " + "JOIN \"ENCOUNTER_ANNOTATIONS\" ea " +
             "ON ie.\"CATALOGNUMBER_EID\" = ea.\"CATALOGNUMBER_OID\" " +
             "JOIN \"ANNOTATION_FEATURES\" af ON ea.\"ID_EID\" = af.\"ID_OID\" " +
             "JOIN \"MEDIAASSET_FEATURES\" mf ON af.\"ID_EID\" = mf.\"ID_EID\" " +
             "GROUP BY ie.\"ID_OID\"");
+
         return parseSqlCountResults(query);
     }
 }

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -17,6 +17,7 @@ import org.ecocean.genetics.*;
 import org.ecocean.grid.ScanTask;
 import org.ecocean.grid.ScanWorkItem;
 import org.ecocean.ia.MatchResult;
+import org.ecocean.ia.MatchResultProspect;
 import org.ecocean.ia.Task;
 import org.ecocean.media.*;
 import org.ecocean.movement.Path;
@@ -2840,6 +2841,19 @@ public class Shepherd {
         query.setOrdering("created DESC");
         Collection c = (Collection)query.execute();
         if (c != null) all = new ArrayList<MatchResult>(c);
+        query.closeAll();
+        return all;
+    }
+
+    public List<MatchResultProspect> getMatchResultProspects(Annotation ann) {
+        List<MatchResultProspect> all = new ArrayList<MatchResultProspect>();
+
+        if (ann == null) return all;
+        String filter = "SELECT FROM org.ecocean.ia.MatchResultProspect WHERE annotation.id == '" +
+            ann.getId() + "'";
+        Query query = pm.newQuery(filter);
+        Collection c = (Collection)query.execute();
+        if (c != null) all = new ArrayList<MatchResultProspect>(c);
         query.closeAll();
         return all;
     }

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -2845,6 +2845,19 @@ public class Shepherd {
         return all;
     }
 
+    // faster deletion of all MatchResults associated with Annotation
+    public long deleteMatchResults(Annotation ann) {
+        if (ann == null) return 0l;
+        long t = System.currentTimeMillis();
+        String filter = "SELECT FROM org.ecocean.ia.MatchResult WHERE queryAnnotation.id == '" +
+            ann.getId() + "'";
+        Query query = pm.newQuery(filter);
+        long ct = query.deletePersistentAll(); 
+        query.closeAll();
+        System.out.println("[DEBUG] deleteMatchResults() deleted " + ct + " [" + (System.currentTimeMillis() - t) + "ms] on " + ann);
+        return ct;
+    }
+
     public List<MatchResultProspect> getMatchResultProspects(Annotation ann) {
         List<MatchResultProspect> all = new ArrayList<MatchResultProspect>();
 

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -2830,6 +2830,20 @@ public class Shepherd {
         return all;
     }
 
+    public List<MatchResult> getMatchResults(Annotation ann) {
+        List<MatchResult> all = new ArrayList<MatchResult>();
+
+        if (ann == null) return all;
+        String filter = "SELECT FROM org.ecocean.ia.MatchResult WHERE queryAnnotation.id == '" +
+            ann.getId() + "'";
+        Query query = pm.newQuery(filter);
+        query.setOrdering("created DESC");
+        Collection c = (Collection)query.execute();
+        if (c != null) all = new ArrayList<MatchResult>(c);
+        query.closeAll();
+        return all;
+    }
+
     public MarkedIndividual getMarkedIndividualQuiet(String name) {
         MarkedIndividual indiv = null;
 

--- a/src/main/resources/org/ecocean/ia/package.jdo
+++ b/src/main/resources/org/ecocean/ia/package.jdo
@@ -86,7 +86,7 @@ alter table "TASK" alter column "PARAMETERS" type text;
 		</field>
 
 		<field name="prospects" default-fetch-group="false" mapped-by="matchResult">
-			<collection element-type="org.ecocean.ia.MatchResultProspect" dependent-element="false" />
+			<collection element-type="org.ecocean.ia.MatchResultProspect" dependent-element="true" />
 		</field>
 
       		<field name="queryAnnotation" persistence-modifier="persistent" element-type="org.ecocean.Annotation">


### PR DESCRIPTION
Annotations which have MatchResults and/or Embeddings cannot be deleted without first resolving these foreign-key constrained objects

PR fixes #1562 

- `ann.deleteMatchResults()` and `ann.deleteEmbeddings()` created
- `ann.prepareForDeletion()` helper method to combine above methods with other pre-delete functionality (e.g. remove from Tasks, etc)
- insert above methods where needed in servlets and api code
- jdo tweak to make MatchResultProspects dependent on MatchResults (for deletion cascade)
- front end changes to progress spinner during deletion

**Note:** also contains a couple bug fixes, one related, another not so much:
- `numberProspects` as property on MatchResult so the we can max out number we actually _store_ on the object; this is to prevent 10s of thousands(!) of prospects being stored in the db, which rendered deletion much too slow and ate up unnecessary db/disk
- small but powerful SiteSettings bug that accidentally disabled vector/embedding search