### PR TITLE
connect detection/embedding Task tree with identification Task tree(s)

### DIFF
--- a/src/main/java/org/ecocean/ia/Task.java
+++ b/src/main/java/org/ecocean/ia/Task.java
@@ -265,7 +265,7 @@ public class Task implements java.io.Serializable {
 
     public void setParent(Task t) {
         parent = t;
-        t.addChild(this);
+        if (t != null) t.addChild(this);
     }
 
     public Task getParent() {

--- a/src/main/java/org/ecocean/identity/IBEISIA.java
+++ b/src/main/java/org/ecocean/identity/IBEISIA.java
@@ -1477,6 +1477,7 @@ public class IBEISIA {
                     }
                 }
             }
+            System.out.println("needIdentifying=" + needIdentifying + "; parentTask=" + parentTask);
             if (needIdentifying.size() > 0) {
                 // split the results into encounters
                 HashMap<String, ArrayList<Annotation> > needIdentifyingMap = new HashMap<String,
@@ -1509,10 +1510,11 @@ public class IBEISIA {
                         mf.put("locationIds", matchTheseLocationIDs);
                     }
                     taskParameters.put("matchingSetFilter", mf);
-                    Task subParentTask = new Task();
+                    Task subParentTask = new Task(parentTask);
                     subParentTask.setParameters(taskParameters);
                     myShepherd2.storeNewTask(subParentTask);
                     myShepherd2.updateDBTransaction();
+                    System.out.println("[DEBUG] ID send: enc=" + encUUID + " created subParentTask=" + subParentTask + " on parentTask=" + parentTask);
 
                     Task childTask = IA.intakeAnnotations(myShepherd2, annots, subParentTask,
                         false);


### PR DESCRIPTION
PR fixes #1570 

after consideration, this is **being left in draft** until a later date. it is a small fix, but likely will have unintended consequences (e.g. due to jdo query depth of task data).