### PR TITLE
fix(devops): IA callback URL drops to HTTP behind TLS-terminating nginx

### DIFF
--- a/devops/deploy/.dockerfiles/nginx/nginx-https.conf
+++ b/devops/deploy/.dockerfiles/nginx/nginx-https.conf
@@ -15,6 +15,7 @@ server {
 
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     location / {
         proxy_read_timeout 1200;
         proxy_connect_timeout 1200;
@@ -38,6 +39,7 @@ server {
 
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     location / {
         proxy_read_timeout 1200;
         proxy_connect_timeout 1200;

--- a/devops/deploy/.dockerfiles/nginx/nginx.conf
+++ b/devops/deploy/.dockerfiles/nginx/nginx.conf
@@ -27,6 +27,7 @@ server {
 
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     location / {
         proxy_read_timeout 1200;
         proxy_connect_timeout 1200;
@@ -47,6 +48,7 @@ server {
 
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     location / {
         proxy_read_timeout 1200;
         proxy_connect_timeout 1200;

--- a/devops/deploy/.dockerfiles/tomcat/server.xml
+++ b/devops/deploy/.dockerfiles/tomcat/server.xml
@@ -165,6 +165,17 @@
 
 	      <Context docBase="/usr/local/tomcat/webapps/wildbook_data_dir" path="/wildbook_data_dir" />
 
+        <!-- Honor X-Forwarded-* headers from the front-end nginx so request.getScheme()
+             returns "https" (not "http") when the browser hit the HTTPS proxy. Without
+             this, absolute URLs Wildbook generates (notably the IA callback URL sent
+             to WBIA) use the wrong scheme, and any HTTP→HTTPS redirect in front of
+             the deployment silently drops POST callbacks. -->
+        <Valve className="org.apache.catalina.valves.RemoteIpValve"
+               remoteIpHeader="x-forwarded-for"
+               protocolHeader="x-forwarded-proto"
+               remoteIpProxiesHeader="x-forwarded-by"
+               internalProxies="172\.\d+\.\d+\.\d+|10\.\d+\.\d+\.\d+|127\.0\.0\.1|::1" />
+
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->
         <!--

--- a/devops/development/.dockerfiles/tomcat/server.xml
+++ b/devops/development/.dockerfiles/tomcat/server.xml
@@ -165,6 +165,16 @@
 
 	      <Context docBase="/usr/local/tomcat/webapps/wildbook_data_dir" path="/wildbook_data_dir" />
 
+        <!-- Honor X-Forwarded-* headers from a fronting nginx so request.getScheme()
+             returns "https" when the browser hit the HTTPS proxy. Mirrors the deploy
+             configuration; harmless when no proxy is in front (header absent → valve
+             is a no-op). -->
+        <Valve className="org.apache.catalina.valves.RemoteIpValve"
+               remoteIpHeader="x-forwarded-for"
+               protocolHeader="x-forwarded-proto"
+               remoteIpProxiesHeader="x-forwarded-by"
+               internalProxies="172\.\d+\.\d+\.\d+|10\.\d+\.\d+\.\d+|127\.0\.0\.1|::1" />
+
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->
         <!--


### PR DESCRIPTION
## Summary

Wildbook silently fails to receive WBIA match results on deployments where nginx terminates TLS in front of Tomcat (i.e. every production install using this repo's nginx templates). New IA tasks complete on the WBIA side but never get their results applied in Wildbook; the corresponding `Task` rows stay "in progress" indefinitely until someone manually re-POSTs to `/ia?callback` for each one.

This PR fixes the root cause with three small, coordinated config changes — no application code is touched.

## Root cause

Wildbook builds the IA callback URL it sends to WBIA from `request.getScheme() + request.getServerName()` (see `IAGateway.java:89` → `CommonConfiguration.getServerURL` → `new URI(req.getScheme(), …)`). Behind a TLS-terminating nginx, the proxy → Tomcat hop is HTTP, so `request.getScheme()` returns `"http"` and the callback URL stored on every WBIA job ends up `http://<host>/ia?callback`.

When the job finishes, WBIA POSTs to that URL. The public front returns `308 Permanent Redirect` to the HTTPS variant. WBIA's HTTP client does not re-issue the POST against the redirect target, so the callback payload is dropped:

```
$ curl -v -X POST -d "jobid=…" http://www.flukebook.org/ia?callback
< HTTP/1.1 308 Permanent Redirect
< Location: https://www.flukebook.org/ia?callback
[POST body dropped — WBIA does not follow]
```

`/var/spool/WildbookFileQueue/IACallback/` stays empty; nothing in catalina.out indicates a problem because Wildbook never sees the failed POST. Symptom is purely on the Wildbook side: match results never appear.

## What this PR changes

Three coordinated edits — the nginx and Tomcat changes are both required (neither is sufficient alone). The `nginx.conf` change is the substantive one for live deployments; `nginx-https.conf` gets the same treatment for consistency since it's a sibling template.

### 1. `devops/deploy/.dockerfiles/nginx/nginx.conf` — primary template

Adds `proxy_set_header X-Forwarded-Proto $scheme;` to both `server` blocks (port 80 and port 443). The port-443 block is where the real fix lands; the port-80 block gets the header for consistency (`$scheme` is `http` there — harmless, and future-proofs the file if TLS termination ever moves to a different layer).

### 2. `devops/deploy/.dockerfiles/nginx/nginx-https.conf` — alternative template

Same change applied to both `server` blocks (wildbook + wbia). This template is marked UNSUPPORTED in its own header but kept in the repo as a reference; we update it so the two templates stay in sync.

### 3. `devops/{deploy,development}/.dockerfiles/tomcat/server.xml`

Adds Tomcat's stock `RemoteIpValve` inside the `<Host>` block. This consumes `X-Forwarded-Proto` and rewrites `request.getScheme()`, `request.isSecure()`, and `request.getServerPort()` so all downstream Wildbook code sees the correct scheme — not just IA callbacks, but also email links, OAuth redirects, and any other absolute URL Wildbook generates.

```xml
<Valve className="org.apache.catalina.valves.RemoteIpValve"
       remoteIpHeader="x-forwarded-for"
       protocolHeader="x-forwarded-proto"
       remoteIpProxiesHeader="x-forwarded-by"
       internalProxies="172\.\d+\.\d+\.\d+|10\.\d+\.\d+\.\d+|127\.0\.0\.1|::1" />
```

The `internalProxies` regex covers the RFC1918 ranges Docker bridge networks use by default. If the proxy is on a non-standard subnet the regex should be tightened/widened to match.

The same valve is added to the development server.xml. When no proxy is in front (header absent) the valve is a no-op, so this is safe in dev environments.

## Verification

Tested live on Flukebook (`xxx.wildbook.org` deployment using these templates):

1. **Before:** `curl -v http://www.flukebook.org/ia?callback` → 308 redirect (the failure mode WBIA hit). WBIA's job metadata showed `callback_url: http://www.flukebook.org/ia?callback`.
2. **After applying both nginx + Tomcat changes + nginx reload + Tomcat restart:** submitted a fresh IA task; WBIA's job metadata showed `callback_url: https://www.flukebook.org/ia?callback`. Results flowed back through `/var/spool/WildbookFileQueue/IACallback/` and the Wildbook Task got its match results without manual intervention.

## Operator notes for affected deployments

After merging and deploying, **existing in-flight IA tasks still have their old `http://` callback URLs frozen into WBIA's job state.** They need a one-time manual replay:

```bash
# For each stuck task id:
docker compose exec wildbook bash -c \
  "curl -sX POST -d 'jobid=<task-id>' http://localhost:8080/ia?callback"
```

Identify candidates via the `TASK` table — anything with no `MATCHRESULT` rows that's older than the typical job duration. Future tasks (submitted after the fix is deployed) self-heal.

## What is NOT in this PR

- No Java code changes. `IBEISIA.callbackUrl()` and `CommonConfiguration.getServerURL` already do the right thing if `request.getScheme()` is correct — the bug is purely that Tomcat couldn't tell.
- No additional nginx hardening (e.g. an explicit HTTP→HTTPS server-side redirect). That's a separate config decision per-deployment.
- No retroactive callback replay script. A trivial bash loop suffices and the SQL to enumerate stuck tasks is install-specific.

## Test plan

- [ ] Apply on a staging Wildbook behind nginx.conf
- [ ] Submit a small IA matching task
- [ ] Confirm WBIA's `/api/engine/job/input/?jobid=<id>` returns a `callback_url` starting with `https://`
- [ ] Confirm `/var/spool/WildbookFileQueue/IACallback/` shows a `.complete` file for the job's UUID after WBIA finishes
- [ ] Confirm match results appear in the Wildbook UI without manual `/ia?callback` POST
- [ ] (Optional) Confirm password-reset emails and other absolute URLs now use `https://`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
