### PR TITLE
Fix IA callback ingest skipping jobs in WBIA "publishing" state

### DIFF
--- a/src/main/java/org/ecocean/identity/IBEISIA.java
+++ b/src/main/java/org/ecocean/identity/IBEISIA.java
@@ -3494,8 +3494,8 @@ public class IBEISIA {
                 statusResponse.has("response") &&
                 statusResponse.getJSONObject("response").has("status") &&
                 "ok".equals(statusResponse.getJSONObject("response").getString("status")) &&
-                "completed".equals(statusResponse.getJSONObject("response").getString(
-                "jobstatus"))) {
+                ("completed".equals(statusResponse.getJSONObject("response").getString("jobstatus")) ||
+                "publishing".equals(statusResponse.getJSONObject("response").getString("jobstatus")))) {
                 System.out.println("HEYYYYYYY i am trying to getJobResult(" + jobId + ")");
                 JSONObject resultResponse = getJobResult(jobId, context);
                 JSONObject rlog = new JSONObject();


### PR DESCRIPTION
## Summary
- `IBEISIA.callbackFromQueue` only accepted `jobstatus="completed"` before fetching results. WBIA briefly transits `"publishing"` between `"working"` and `"completed"`; if the callback's `getJobStatus` check races into that window, the conditional silently falls through, Wildbook waits for a follow-up callback WBIA never sends, and the job is orphaned with no ingested results.
- In one observed bulk import this race orphaned ~25% of identification tasks (144 of 588). All stuck tasks had `last _action = "getJobStatus"` with `_response.response.jobstatus = "publishing"` in `IDENTITYSERVICELOG`. The match results were already computed WBIA-side; only the Wildbook ingest step was skipped.
- Fix: accept `"publishing"` alongside `"completed"` so the result fetch proceeds. Two-line change in the conditional at `IBEISIA.java:3497`.

## Recovery for already-orphaned tasks (informational)
Re-firing `/ia?callback&jobid=<jobid>` for each stuck task is sufficient — by the time the retry runs, WBIA is past `publishing` and the status check returns `completed`, so `getJobResult` proceeds and ingest completes normally. Verified on a real stuck task: re-fire produced `getJobStatus → getJobResult → processedCallbackIdentify` within ~700ms.

## Test plan
- [ ] Submit an identification job that runs long enough to ever transit `publishing` and confirm result ingest completes without the manual callback re-fire that's currently required.
- [ ] Spot-check `IDENTITYSERVICELOG` after a bulk import that previously orphaned a meaningful fraction of tasks; expect the `getJobStatus`-stuck bucket to drop to ~0.
- [ ] Sanity-check that jobs which finish via the existing `completed` path still ingest exactly as before (no regression on the happy path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)