### PR TITLE
Surface sendIdentify failures as error, not completed

### DIFF
--- a/src/main/java/org/ecocean/servlet/IAGateway.java
+++ b/src/main/java/org/ecocean/servlet/IAGateway.java
@@ -447,9 +447,14 @@ public class IAGateway extends HttpServlet {
                 String errorMsg = sent.optString("error", "(unknown error)");
                 System.out.println("beginIdentifyAnnotations() was unsuccessful due to " +
                     errorMsg + "; hopefully we requeue");
-                // set the status as complete as we faithfully completed the query but nothing to match against
+                // sendIdentify failed before WBIA accepted the job; surface this as an
+                // error rather than "completed" so the import page doesn't falsely
+                // report the task as done. (Mirrors the sibling error path ~30 lines
+                // below that already sets status="error" on a different failure mode.)
                 if (task != null) {
-                    task.setStatus("completed");
+                    task.setStatus("error");
+                    task.setStatusDetailsAddError("SEND_FAILED",
+                        "beginIdentifyAnnotations() failed: " + errorMsg);
                     task.setCompletionDateInMilliseconds(Long.valueOf(System.currentTimeMillis()));
                     myShepherd.updateDBTransaction();
                 }


### PR DESCRIPTION
## Summary
- When `IBEISIA.beginIdentifyAnnotations()` returns `success=false` and the error isn't specifically `"emptyTargetAnnotations"`, `IAGateway._sendIdentificationTask` previously set `task.status = "completed"` with a comment claiming "we faithfully completed the query." That's misleading: the send failed *before WBIA ever accepted the job* — there is no result to display.
- The import page reads `Task.getStatus()` to drive its identification counters, so these tasks were being counted as complete on a bulk import even though they had never actually run. The page reports "identification complete" for the import as a whole, but `iaResults.jsp` for the same tasks shows nothing because no result was ever computed.
- **In one observed bulk import, 200 of 588 tasks were in this state** — invisible to the operator without database introspection. Triggered by upstream failures like `iaAnnotIds is empty; possible IA problems` and `SocketTimeoutException` during the initial `sendIdentify`.

## Fix
- Set `task.status = "error"` (already a recognized terminal state in `Task.statusInEndState()`).
- Record the underlying error message via `setStatusDetailsAddError("SEND_FAILED", ...)` so operators can see *why* the task failed without diving into logs.
- This mirrors the sibling error path ~30 lines below that already handles a different `sendIdentify` failure mode with `status = "error"` — making the two failure branches consistent.

## Test plan
- [ ] Trigger a `beginIdentifyAnnotations()` failure (e.g., point at an unreachable WBIA so `sendIdentify` times out) and verify the resulting Task has `status="error"` and a populated `statusDetails.errors[].SEND_FAILED` entry.
- [ ] Confirm the bulk import detail page no longer reports the failed task as complete in `identificationStatus` / `numLatestTask_completed`.
- [ ] Sanity-check the happy path: successful identifications still set `status="completed"` via the normal callback chain (no behavior change there).

## Recovery for already-affected tasks
For environments already carrying the false-completed state, a one-shot SQL update will flip them back to honest:
```sql
UPDATE "TASK"
SET "STATUS" = 'error'
WHERE "STATUS" = 'completed'
  AND NOT EXISTS (
    SELECT 1 FROM "IDENTITYSERVICELOG" l
    WHERE l."TASKID" = "TASK"."ID"
      AND l."SERVICENAME" = 'IBEISIA'
      AND l."STATUS"::json->>'_action' = 'processedCallbackIdentify'
  );
```
(Scope to a specific import task as needed via `TASK_OBJECTANNOTATIONS` → `ENCOUNTER_ANNOTATIONS` → `IMPORTTASK_ENCOUNTERS`.)

## Related
- Companion PR #1583 (`fix/ia-callback-accept-publishing-jobstatus`) fixes a *different* failure mode where the callback handler ignored WBIA's transient `"publishing"` state. Together these cover the two largest invisible-failure paths observed in the same import (200 lying-completed + 144 stuck-at-publishing out of 588).

🤖 Generated with [Claude Code](https://claude.com/claude-code)