### PR TITLE
1568 persist values in the react encounter search filter form

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5583,17 +5583,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@types/react-dom": {
-      "version": "18.2.19",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
-      "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/react-reconciler": {
       "version": "0.28.9",
       "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
@@ -27161,17 +27150,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-dom": {
-      "version": "18.2.19",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
-      "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@types/react": "*"
       }
     },
     "@types/react-reconciler": {

--- a/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/EncounterFormStore.test.js
+++ b/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/EncounterFormStore.test.js
@@ -1,5 +1,22 @@
 import EncounterFormStore from "../../../pages/SearchPages/stores/EncounterFormStore";
 
+const mockSessionStorage = (() => {
+  let store = {};
+  return {
+    getItem: jest.fn((key) => store[key] || null),
+    setItem: jest.fn((key, value) => {
+      store[key] = value.toString();
+    }),
+    removeItem: jest.fn((key) => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    }),
+  };
+})();
+Object.defineProperty(window, "sessionStorage", { value: mockSessionStorage });
+
 describe("EncounterFormStore", () => {
   let store;
 
@@ -72,5 +89,53 @@ describe("EncounterFormStore", () => {
     store.resetFilters();
 
     expect(store.formFilters).toEqual([]);
+    expect(store.appliedFilters).toEqual([]);
+  });
+
+  test("applyFilters deep copies formFilters to appliedFilters and saves to storage", () => {
+    const mockFilter = {
+      filterId: "f1",
+      clause: "AND",
+      query: "q1",
+      filterKey: "k1",
+      path: "",
+    };
+    store.addFilter(
+      mockFilter.filterId,
+      mockFilter.clause,
+      mockFilter.query,
+      mockFilter.filterKey,
+    );
+
+    store.applyFilters();
+
+    expect(store.appliedFilters).toHaveLength(1);
+    expect(store.appliedFilters[0]).toEqual(mockFilter);
+
+    expect(store.appliedFilters).not.toBe(store.formFilters);
+
+    expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
+      store.FILTER_STORAGE_KEY,
+      JSON.stringify([mockFilter]),
+    );
+  });
+
+  test("getFiltersFromStorage loads valid JSON into formFilters and appliedFilters", () => {
+    const mockFilter = {
+      filterId: "f1",
+      clause: "AND",
+      query: "q1",
+      filterKey: "k1",
+      path: "",
+    };
+    const savedData = JSON.stringify([mockFilter]);
+    mockSessionStorage.getItem = jest.fn(() => savedData);
+
+    store.getFiltersFromStorage();
+
+    expect(window.sessionStorage.getItem).toHaveBeenCalledTimes(1);
+
+    expect(store.formFilters).toHaveLength(1);
+    expect(store.appliedFilters).toHaveLength(1);
   });
 });

--- a/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/EncounterFormStore.test.js
+++ b/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/EncounterFormStore.test.js
@@ -1,27 +1,34 @@
 import EncounterFormStore from "../../../pages/SearchPages/stores/EncounterFormStore";
 
-const mockSessionStorage = (() => {
-  let store = {};
-  return {
-    getItem: jest.fn((key) => store[key] || null),
-    setItem: jest.fn((key, value) => {
-      store[key] = value.toString();
-    }),
-    removeItem: jest.fn((key) => {
-      delete store[key];
-    }),
-    clear: jest.fn(() => {
-      store = {};
-    }),
-  };
-})();
-Object.defineProperty(window, "sessionStorage", { value: mockSessionStorage });
-
 describe("EncounterFormStore", () => {
   let store;
+  let mockStorage = {};
+
+  beforeAll(() => {
+    jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation((key) => mockStorage[key] || null);
+    jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation((key, value) => {
+        mockStorage[key] = value ? value.toString() : "";
+      });
+    jest.spyOn(Storage.prototype, "removeItem").mockImplementation((key) => {
+      delete mockStorage[key];
+    });
+    jest.spyOn(Storage.prototype, "clear").mockImplementation(() => {
+      mockStorage = {};
+    });
+  });
 
   beforeEach(() => {
     store = new EncounterFormStore();
+    mockStorage = {};
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
   });
 
   test("initializes with empty formFilters", () => {
@@ -90,6 +97,7 @@ describe("EncounterFormStore", () => {
 
     expect(store.formFilters).toEqual([]);
     expect(store.appliedFilters).toEqual([]);
+    expect(window.sessionStorage.removeItem).toHaveBeenCalledWith("formData");
   });
 
   test("applyFilters deep copies formFilters to appliedFilters and saves to storage", () => {
@@ -129,7 +137,7 @@ describe("EncounterFormStore", () => {
       path: "",
     };
     const savedData = JSON.stringify([mockFilter]);
-    mockSessionStorage.getItem = jest.fn(() => savedData);
+    window.sessionStorage.setItem("formData", savedData);
 
     store.getFiltersFromStorage();
 
@@ -137,5 +145,43 @@ describe("EncounterFormStore", () => {
 
     expect(store.formFilters).toHaveLength(1);
     expect(store.appliedFilters).toHaveLength(1);
+  });
+
+  test("getFiltersFromStorage ignores strings/non-arrays and clears storage", () => {
+    window.sessionStorage.setItem("formData", JSON.stringify("abc"));
+    store.getFiltersFromStorage();
+
+    expect(store.formFilters).toEqual([]);
+    expect(window.sessionStorage.removeItem).toHaveBeenCalledWith("formData");
+  });
+
+  test("setFiltersInSessionStorage clears the storage data when called with no data", () => {
+    const mockFilter = {
+      filterId: "f1",
+      clause: "AND",
+      query: "q1",
+      filterKey: "k1",
+      path: "",
+    };
+    window.sessionStorage.setItem("formData", JSON.stringify(mockFilter));
+    store.setFiltersInSessionStorage();
+
+    expect(store.formFilters).toEqual([]);
+    expect(window.sessionStorage.removeItem).toHaveBeenCalledWith("formData");
+  });
+
+  test("getFiltersFromStorage handles malformed JSON gracefully and clears storage", () => {
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    window.sessionStorage.setItem("formData", "{ bad_json ]");
+
+    store.getFiltersFromStorage();
+
+    expect(store.formFilters).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(window.sessionStorage.removeItem).toHaveBeenCalledWith("formData");
+
+    consoleSpy.mockRestore();
   });
 });

--- a/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/EncounterSearch.test.js
+++ b/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/EncounterSearch.test.js
@@ -8,7 +8,7 @@ import {
 } from "@testing-library/react";
 import EncounterSearch from "../../../pages/SearchPages/EncounterSearch";
 import { MemoryRouter } from "react-router-dom";
-import * as useFilterEncountersHook from "../../../models/encounters/useFilterEncounters";
+import useFilterEncounters, * as useFilterEncountersHook from "../../../models/encounters/useFilterEncounters";
 import * as useFilterEncountersWithMediaAssetsHook from "../../../models/encounters/useFilterEncountersWithMediaAssets";
 import * as useEncounterSearchSchemasHook from "../../../models/encounters/useEncounterSearchSchemas";
 import * as getAllSearchParams from "../../../pages/SearchPages/getAllSearchParamsAndParse";
@@ -682,11 +682,33 @@ describe("EncounterSearch", () => {
   });
 
   it("calls getFiltersFromStorage on mount if no queryID is present", () => {
+    const params = {
+      from: 0,
+      size: 20,
+      sort: "date",
+      sortOrder: "desc",
+    };
+    const mockFilter = [
+      {
+        filterId: "f1",
+        clause: "AND",
+        query: "q1",
+        filterKey: "k1",
+        path: "",
+      },
+    ];
+
+    globalEncounterFormStore.appliedFilters = mockFilter;
+
     renderWithProviders("/search");
 
     expect(
       globalEncounterFormStore.getFiltersFromStorage,
     ).toHaveBeenCalledTimes(1);
+    expect(useFilterEncounters).toHaveBeenCalledWith({
+      queries: mockFilter,
+      params: params,
+    });
   });
 
   it("does NOT call getFiltersFromStorage if a queryID is present in the URL", () => {

--- a/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/EncounterSearch.test.js
+++ b/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/EncounterSearch.test.js
@@ -18,6 +18,7 @@ import axios from "axios";
 jest.mock("../../../pages/SearchPages/stores/EncounterFormStore", () => ({
   globalEncounterFormStore: {
     formFilters: [],
+    appliedFilters: [],
     mediaAssetsSearchQuery: [],
     pageSize: 20,
     start: 0,
@@ -32,6 +33,7 @@ jest.mock("../../../pages/SearchPages/stores/EncounterFormStore", () => ({
     setGalleryLoading: jest.fn(),
     setLoadingAll: jest.fn(),
     setGalleryExhausted: jest.fn(),
+    getFiltersFromStorage: jest.fn(),
   },
 }));
 
@@ -120,6 +122,7 @@ describe("EncounterSearch", () => {
     jest.clearAllMocks();
 
     globalEncounterFormStore.formFilters = [];
+    globalEncounterFormStore.appliedFilters = [];
     globalEncounterFormStore.mediaAssetsSearchQuery = [];
     globalEncounterFormStore.pageSize = 20;
     globalEncounterFormStore.start = 0;
@@ -676,5 +679,21 @@ describe("EncounterSearch", () => {
       expect(items[0]).toMatchObject({ id: "asset1", encounterId: "enc1" });
       expect(globalEncounterFormStore.setAssetOffset).toHaveBeenCalled();
     });
+  });
+
+  it("calls getFiltersFromStorage on mount if no queryID is present", () => {
+    renderWithProviders("/search");
+
+    expect(
+      globalEncounterFormStore.getFiltersFromStorage,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call getFiltersFromStorage if a queryID is present in the URL", () => {
+    renderWithProviders("/search?searchQueryId=abc123");
+
+    expect(
+      globalEncounterFormStore.getFiltersFromStorage,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/FilterPanel.jsx
+++ b/frontend/src/components/FilterPanel.jsx
@@ -15,7 +15,6 @@ export default function FilterPanel({
   style = {},
   handleSearch = () => {},
   refetch = () => {},
-  setTempFormFilters = () => {},
   store,
 }) {
   const { data } = useSiteSettings();
@@ -143,7 +142,7 @@ export default function FilterPanel({
                 backgroundColor={theme.primaryColors.primary700}
                 borderColor={theme.primaryColors.primary700}
                 onClick={() => {
-                  setTempFormFilters([...store.formFilters]);
+                  // setTempFormFilters([...store.formFilters]);
                   refetch().then(({ data }) => {
                     console.log("Refetched data:", data);
                   });

--- a/frontend/src/components/FilterPanel.jsx
+++ b/frontend/src/components/FilterPanel.jsx
@@ -142,16 +142,12 @@ export default function FilterPanel({
                 backgroundColor={theme.primaryColors.primary700}
                 borderColor={theme.primaryColors.primary700}
                 onClick={() => {
-                  // setTempFormFilters([...store.formFilters]);
                   refetch().then(({ data }) => {
                     console.log("Refetched data:", data);
                   });
                   store.resetGallery();
                   setSearchParams(new URLSearchParams());
-                  sessionStorage.setItem(
-                    "formData",
-                    JSON.stringify(store.formFilters),
-                  );
+                  store.applyFilters();
                   setFilterPanel(false);
                   handleSearch();
                   store.setActiveStep(0);

--- a/frontend/src/components/filterFields/SideBar.jsx
+++ b/frontend/src/components/filterFields/SideBar.jsx
@@ -9,7 +9,7 @@ import { useSearchParams } from "react-router-dom";
 import { observer } from "mobx-react-lite";
 
 const Sidebar = observer(
-  ({ setFilterPanel, searchQueryId, queryID = [], store }) => {
+  ({ setFilterPanel, searchQueryId, queryID = false, store }) => {
     const theme = React.useContext(ThemeContext);
     const [show, setShow] = useState(false);
     const sidebarWidth = 400;

--- a/frontend/src/components/filterFields/SideBar.jsx
+++ b/frontend/src/components/filterFields/SideBar.jsx
@@ -21,11 +21,14 @@ const Sidebar = observer(
     const num = () => (queryID ? 1 : store.appliedFilters.length);
 
     const handleCopy = () => {
+      // When viewing a result loaded from a shared query ID, copy that ID;
+      // otherwise copy the ID freshly generated for the current filter search.
+      const idToCopy = queryID || searchQueryId;
       if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard
-          .writeText(searchQueryId)
+          .writeText(idToCopy)
           .then(() => {
-            alert(`Query ID: ${searchQueryId} copied to clipboard!`);
+            alert(`Query ID: ${idToCopy} copied to clipboard!`);
           })
           .catch((err) => {
             console.error("Failed to copy text: ", err);

--- a/frontend/src/components/filterFields/SideBar.jsx
+++ b/frontend/src/components/filterFields/SideBar.jsx
@@ -18,7 +18,7 @@ const Sidebar = observer(
     const handleShow = () => setShow(true);
     const [, setSearchParams] = useSearchParams();
 
-    const num = () => (queryID ? 1 : store.formFilters.length);
+    const num = () => (queryID ? 1 : store.appliedFilters.length);
 
     const handleCopy = () => {
       if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -111,7 +111,7 @@ const Sidebar = observer(
               </div>
             ) : (
               <div style={{ overflowY: "auto" }}>
-                {store.formFilters.map((filter, index) => (
+                {store.appliedFilters.map((filter, index) => (
                   <Chip key={index}>{filter}</Chip>
                 ))}
               </div>

--- a/frontend/src/components/filterFields/SideBar.jsx
+++ b/frontend/src/components/filterFields/SideBar.jsx
@@ -135,21 +135,25 @@ const Sidebar = observer(
               >
                 <FormattedMessage id="FILTER_COPY" defaultMessage={"Copy"} />
               </BrutalismButton>
-              <BrutalismButton
-                onClick={() => {
-                  setFilterPanel(true);
-                  handleClose();
-                }}
-                backgroundColor={theme.primaryColors.primary700}
-                borderColor={theme.primaryColors.primary700}
-                color="white"
-                noArrow={true}
-              >
-                <FormattedMessage
-                  id="FILTER_EDIT_FILTER"
-                  defaultMessage={"Edit"}
-                />
-              </BrutalismButton>
+
+              {!queryID && (
+                <BrutalismButton
+                  onClick={() => {
+                    setFilterPanel(true);
+                    handleClose();
+                  }}
+                  backgroundColor={theme.primaryColors.primary700}
+                  borderColor={theme.primaryColors.primary700}
+                  color="white"
+                  noArrow={true}
+                >
+                  <FormattedMessage
+                    id="FILTER_EDIT_FILTER"
+                    defaultMessage={"Edit"}
+                  />
+                </BrutalismButton>
+              )}
+
               <BrutalismButton
                 borderColor={theme.primaryColors.primary700}
                 color={theme.primaryColors.primary700}

--- a/frontend/src/components/filterFields/SideBar.jsx
+++ b/frontend/src/components/filterFields/SideBar.jsx
@@ -9,7 +9,7 @@ import { useSearchParams } from "react-router-dom";
 import { observer } from "mobx-react-lite";
 
 const Sidebar = observer(
-  ({ setFilterPanel, searchQueryId, queryID, tempFormFilters = [], store }) => {
+  ({ setFilterPanel, searchQueryId, queryID = [], store }) => {
     const theme = React.useContext(ThemeContext);
     const [show, setShow] = useState(false);
     const sidebarWidth = 400;
@@ -18,7 +18,7 @@ const Sidebar = observer(
     const handleShow = () => setShow(true);
     const [, setSearchParams] = useSearchParams();
 
-    const num = () => (queryID ? 1 : tempFormFilters.length);
+    const num = () => (queryID ? 1 : store.formFilters.length);
 
     const handleCopy = () => {
       if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -111,7 +111,7 @@ const Sidebar = observer(
               </div>
             ) : (
               <div style={{ overflowY: "auto" }}>
-                {tempFormFilters.map((filter, index) => (
+                {store.formFilters.map((filter, index) => (
                   <Chip key={index}>{filter}</Chip>
                 ))}
               </div>

--- a/frontend/src/pages/SearchPages/EncounterSearch.jsx
+++ b/frontend/src/pages/SearchPages/EncounterSearch.jsx
@@ -259,6 +259,10 @@ const EncounterSearch = observer(() => {
         })
         .catch((error) => {
           console.error("Error fetching search data:", error);
+          alert(`Query ID: ${queryID} could not be found!`);
+          setQueryID(false);
+          setSearchParams(new URLSearchParams());
+          setFilterPanel(true);
         });
     }
   }, [
@@ -358,7 +362,7 @@ const EncounterSearch = observer(() => {
       <SideBar
         setFilterPanel={setFilterPanel}
         searchQueryId={searchQueryId}
-        queryID={false}
+        queryID={queryID}
         store={store}
       />
       <ExportModal

--- a/frontend/src/pages/SearchPages/EncounterSearch.jsx
+++ b/frontend/src/pages/SearchPages/EncounterSearch.jsx
@@ -42,7 +42,6 @@ const EncounterSearch = observer(() => {
   const [encounterSortOrder, setEncounterSortOrder] = useState("desc");
   const [searchIdSortName, setSearchIdSortName] = useState("date");
   const [searchIdSortOrder, setSearchIdSortOrder] = useState("desc");
-  const [tempFormFilters, setTempFormFilters] = useState([]);
   const [exportModalOpen, setExportModalOpen] = useState(false);
 
   useEffect(() => {
@@ -50,10 +49,26 @@ const EncounterSearch = observer(() => {
       searchParams,
       store,
       setFilterPanel,
-      setTempFormFilters,
+      // setTempFormFilters,
       encounterData,
     );
   }, [searchParams]);
+
+  useEffect(() => {
+    if (!queryID) {
+      const savedFiltersJson = sessionStorage.getItem("formData");
+      if (savedFiltersJson) {
+        try {
+          const parsedFilters = JSON.parse(savedFiltersJson);
+          if (parsedFilters && parsedFilters.length > 0) {
+            store.setFormFilters(parsedFilters);
+          }
+        } catch (e) {
+          console.error("Failed to parse formData from session storage", e);
+        }
+      }
+    }
+  }, [queryID, store]);
 
   useEffect(() => {
     if (!queryID) {
@@ -309,7 +324,7 @@ const EncounterSearch = observer(() => {
         handleSearch={handleSearch}
         setQueryID={setQueryID}
         refetch={refetch}
-        setTempFormFilters={setTempFormFilters}
+        // setTempFormFilters={setTempFormFilters}
         store={store}
       />
       <DataTable
@@ -362,7 +377,6 @@ const EncounterSearch = observer(() => {
         searchQueryId={searchQueryId}
         queryID={false}
         store={store}
-        tempFormFilters={tempFormFilters}
       />
       <ExportModal
         open={exportModalOpen}

--- a/frontend/src/pages/SearchPages/EncounterSearch.jsx
+++ b/frontend/src/pages/SearchPages/EncounterSearch.jsx
@@ -45,28 +45,12 @@ const EncounterSearch = observer(() => {
   const [exportModalOpen, setExportModalOpen] = useState(false);
 
   useEffect(() => {
-    helperFunction(
-      searchParams,
-      store,
-      setFilterPanel,
-      // setTempFormFilters,
-      encounterData,
-    );
+    helperFunction(searchParams, store, setFilterPanel, encounterData);
   }, [searchParams]);
 
   useEffect(() => {
     if (!queryID) {
-      const savedFiltersJson = sessionStorage.getItem("formData");
-      if (savedFiltersJson) {
-        try {
-          const parsedFilters = JSON.parse(savedFiltersJson);
-          if (parsedFilters && parsedFilters.length > 0) {
-            store.setFormFilters(parsedFilters);
-          }
-        } catch (e) {
-          console.error("Failed to parse formData from session storage", e);
-        }
-      }
+      store.getFiltersFromStorage();
     }
   }, [queryID, store]);
 
@@ -85,7 +69,7 @@ const EncounterSearch = observer(() => {
     loading,
     refetch,
   } = useFilterEncounters({
-    queries: store.formFilters,
+    queries: store.appliedFilters,
     params: {
       sort: encounterSortName,
       sortOrder: encounterSortOrder,
@@ -324,7 +308,6 @@ const EncounterSearch = observer(() => {
         handleSearch={handleSearch}
         setQueryID={setQueryID}
         refetch={refetch}
-        // setTempFormFilters={setTempFormFilters}
         store={store}
       />
       <DataTable

--- a/frontend/src/pages/SearchPages/getAllSearchParamsAndParse.js
+++ b/frontend/src/pages/SearchPages/getAllSearchParamsAndParse.js
@@ -4,6 +4,8 @@ const helperFunction = async (searchParams, store, setFilterPanel) => {
     return;
   }
 
+  let didAddFilter = false;
+
   for (const [key, _] of Object.entries(params)) {
     if (key === "username") {
       store.addFilter(
@@ -16,6 +18,7 @@ const helperFunction = async (searchParams, store, setFilterPanel) => {
         },
         "Assigned User",
       );
+      didAddFilter = true;
     }
     if (key === "state") {
       store.addFilter(
@@ -28,6 +31,7 @@ const helperFunction = async (searchParams, store, setFilterPanel) => {
         },
         "Encounter State",
       );
+      didAddFilter = true;
     }
     if (key === "searchQueryId") {
       store.getFiltersFromStorage();
@@ -43,10 +47,14 @@ const helperFunction = async (searchParams, store, setFilterPanel) => {
         },
         "Individual ID",
       );
+      didAddFilter = true;
     }
   }
-  store.applyFilters();
-  setFilterPanel(false);
+  if (didAddFilter) {
+    store.applyFilters();
+    setFilterPanel(false);
+  }
+
   return;
 };
 

--- a/frontend/src/pages/SearchPages/getAllSearchParamsAndParse.js
+++ b/frontend/src/pages/SearchPages/getAllSearchParamsAndParse.js
@@ -1,9 +1,4 @@
-const helperFunction = async (
-  searchParams,
-  store,
-  setFilterPanel,
-  setTempFormFilters = () => {},
-) => {
+const helperFunction = async (searchParams, store, setFilterPanel) => {
   const params = Object.fromEntries(searchParams.entries()) || {};
   if (Object.keys(params).length === 0) {
     return;
@@ -50,7 +45,6 @@ const helperFunction = async (
       );
     }
   }
-  setTempFormFilters([...store.formFilters]);
   setFilterPanel(false);
   return;
 };

--- a/frontend/src/pages/SearchPages/getAllSearchParamsAndParse.js
+++ b/frontend/src/pages/SearchPages/getAllSearchParamsAndParse.js
@@ -30,7 +30,7 @@ const helperFunction = async (searchParams, store, setFilterPanel) => {
       );
     }
     if (key === "searchQueryId") {
-      store.formFilters = JSON.parse(sessionStorage.getItem("formData")) || [];
+      store.getFiltersFromStorage();
     }
     if (key === "individualIDExact") {
       store.addFilter(
@@ -45,6 +45,7 @@ const helperFunction = async (searchParams, store, setFilterPanel) => {
       );
     }
   }
+  store.applyFilters();
   setFilterPanel(false);
   return;
 };

--- a/frontend/src/pages/SearchPages/stores/EncounterFormStore.js
+++ b/frontend/src/pages/SearchPages/stores/EncounterFormStore.js
@@ -238,6 +238,10 @@ class EncounterFormStore {
     }
   }
 
+  setFormFilters(filters) {
+    this._formFilters = filters;
+  }
+
   removeFilter(filterId) {
     this.formFilters = this.formFilters.filter((f) => f.filterId !== filterId);
   }
@@ -250,6 +254,7 @@ class EncounterFormStore {
 
   resetFilters() {
     this.formFilters = [];
+    sessionStorage.removeItem("formData");
   }
 
   async addEncountersToProject() {

--- a/frontend/src/pages/SearchPages/stores/EncounterFormStore.js
+++ b/frontend/src/pages/SearchPages/stores/EncounterFormStore.js
@@ -6,6 +6,7 @@ import { action } from "mobx";
 
 class EncounterFormStore {
   _formFilters;
+  _appliedFilters;
   _activeStep = 0;
 
   _siteSettingsData = null;
@@ -33,8 +34,11 @@ class EncounterFormStore {
 
   imageModalStore;
 
+  FILTER_STORAGE_KEY = "formData";
+
   constructor() {
     this.formFilters = [];
+    this.appliedFilters = [];
     this.imageModalStore = new ImageModalStore(this);
 
     makeAutoObservable(
@@ -65,6 +69,13 @@ class EncounterFormStore {
   }
   set formFilters(newFilters) {
     this._formFilters = newFilters;
+  }
+
+  get appliedFilters() {
+    return this._appliedFilters;
+  }
+  set appliedFilters(filters) {
+    this._appliedFilters = filters;
   }
 
   get activeStep() {
@@ -166,7 +177,7 @@ class EncounterFormStore {
       filterKey: "Number Media Assets",
       path: "",
     };
-    const base = this.formFilters || [];
+    const base = this.appliedFilters || [];
     const has = base.some((f) => f.filterId === "numberMediaAssets");
     if (!has) {
       return [...base, filterOnMediaAssets];
@@ -252,9 +263,39 @@ class EncounterFormStore {
     );
   }
 
+  setFiltersInSessionStorage() {
+    if (this.appliedFilters.length > 0) {
+      sessionStorage.setItem(
+        this.FILTER_STORAGE_KEY,
+        JSON.stringify(this.appliedFilters),
+      );
+    }
+  }
+
+  applyFilters() {
+    this.appliedFilters = toJS(this.formFilters);
+    this.setFiltersInSessionStorage();
+  }
+
+  getFiltersFromStorage() {
+    const savedJson = sessionStorage.getItem(this.FILTER_STORAGE_KEY);
+    if (savedJson) {
+      try {
+        const parsed = JSON.parse(savedJson);
+        if (parsed && parsed.length > 0) {
+          this.formFilters = parsed;
+          this.appliedFilters = parsed;
+        }
+      } catch (e) {
+        console.error("Failed to load filters:", e);
+      }
+    }
+  }
+
   resetFilters() {
     this.formFilters = [];
-    sessionStorage.removeItem("formData");
+    this.appliedFilters = [];
+    sessionStorage.removeItem(this.FILTER_STORAGE_KEY);
   }
 
   async addEncountersToProject() {

--- a/frontend/src/pages/SearchPages/stores/EncounterFormStore.js
+++ b/frontend/src/pages/SearchPages/stores/EncounterFormStore.js
@@ -269,6 +269,8 @@ class EncounterFormStore {
         this.FILTER_STORAGE_KEY,
         JSON.stringify(this.appliedFilters),
       );
+    } else {
+      sessionStorage.removeItem(this.FILTER_STORAGE_KEY);
     }
   }
 
@@ -282,12 +284,15 @@ class EncounterFormStore {
     if (savedJson) {
       try {
         const parsed = JSON.parse(savedJson);
-        if (parsed && parsed.length > 0) {
+        if (Array.isArray(parsed) && parsed.length > 0) {
           this.formFilters = parsed;
           this.appliedFilters = parsed;
+        } else {
+          sessionStorage.removeItem(this.FILTER_STORAGE_KEY);
         }
       } catch (e) {
         console.error("Failed to load filters:", e);
+        sessionStorage.removeItem(this.FILTER_STORAGE_KEY);
       }
     }
   }


### PR DESCRIPTION
I updated the filter, table, and "Applied Filters" sidebar to manage state across page refreshes and reloads.

Values for the applied filters are now stored in session storage to preserve them after the filters are applied, and refreshes the current mobX handling of filter values on reload. I also added a few unit tests to verify the functionality. If a user wants a clear set of filters, then the reset button still works as expected and clears values from storage, so they will not go back to the old values if the page reloads. Filter values will still be lost if the page is closed though.

PR fixes #1568

