### PR TITLE
feat(api): scoped-access integration endpoints — token issuance + live canUserAccess (Artifact B)

### DIFF
--- a/docs/superpowers/plans/2026-05-29-integration-endpoints-b.md
+++ b/docs/superpowers/plans/2026-05-29-integration-endpoints-b.md
@@ -140,11 +140,23 @@ class JwtServiceTest {
     }
 
     @Test void wrongAudienceOrIssuer_rejected() throws Exception {
-        JwtService a = serviceWithFreshKeys();
-        String token = a.sign("u", "context0", 60_000L);
-        // a different service (different keys) cannot verify a's token
-        JwtService b = serviceWithFreshKeys();
-        assertThrows(JwtException.class, () -> b.verify(token), "token signed by other key must fail");
+        // SAME keypair (valid signature), but the verifier requires a different
+        // issuer/audience — this genuinely exercises requireIssuer/requireAudience
+        // (a different-key test would pass even if those checks were removed).
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+
+        JwtService signer = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+        String token = signer.sign("u", "context0", 60_000L);
+
+        JwtService wrongIssuer = JwtService.fromBase64Keys(privB64, pubB64, "evil-issuer", "wildbook-scoped-api");
+        assertThrows(JwtException.class, () -> wrongIssuer.verify(token), "mismatched issuer must be rejected");
+
+        JwtService wrongAudience = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "some-other-aud");
+        assertThrows(JwtException.class, () -> wrongAudience.verify(token), "mismatched audience must be rejected");
     }
 
     @Test void disabledWhenKeysMissing() {
@@ -202,16 +214,25 @@ public class JwtService {
     private final PublicKey publicKey;
     private final String issuer;
     private final String audience;
+    private final String keyId; // JWT header 'kid' for key rotation (Codex Medium); may be null
 
-    private JwtService(PrivateKey priv, PublicKey pub, String issuer, String audience) {
+    private JwtService(PrivateKey priv, PublicKey pub, String issuer, String audience,
+        String keyId) {
         this.privateKey = priv;
         this.publicKey = pub;
         this.issuer = issuer;
         this.audience = audience;
+        this.keyId = keyId;
+    }
+
+    // test/explicit overload without a keyId
+    public static JwtService fromBase64Keys(String privB64, String pubB64, String issuer,
+        String audience) {
+        return fromBase64Keys(privB64, pubB64, issuer, audience, null);
     }
 
     public static JwtService fromBase64Keys(String privB64, String pubB64, String issuer,
-        String audience) {
+        String audience, String keyId) {
         PrivateKey priv = null;
         PublicKey pub = null;
         try {
@@ -227,7 +248,7 @@ public class JwtService {
         } catch (Exception ex) {
             System.out.println("JwtService: failed to load keys: " + ex);
         }
-        return new JwtService(priv, pub, issuer, audience);
+        return new JwtService(priv, pub, issuer, audience, keyId);
     }
 
     public static JwtService fromConfig(String context) {
@@ -236,7 +257,8 @@ public class JwtService {
             CommonConfiguration.getProperty("jwtPublicKeyBase64", context),
             orDefault(CommonConfiguration.getProperty("jwtIssuer", context), "wildbook"),
             orDefault(CommonConfiguration.getProperty("jwtAudience", context),
-                "wildbook-scoped-api"));
+                "wildbook-scoped-api"),
+            CommonConfiguration.getProperty("jwtKeyId", context)); // may be null
     }
 
     private static String orDefault(String v, String d) {
@@ -250,16 +272,16 @@ public class JwtService {
     public String sign(String userUuid, String context, long ttlMillis) {
         if (!isEnabled()) throw new IllegalStateException("JwtService not enabled (no private key)");
         long now = System.currentTimeMillis();
-        return Jwts.builder()
+        io.jsonwebtoken.JwtBuilder b = Jwts.builder()
             .issuer(issuer)
             .audience().add(audience).and()
             .subject(userUuid)
             .claim("context", context)
             .id(Util.generateUUID())
             .issuedAt(new Date(now))
-            .expiration(new Date(now + ttlMillis))
-            .signWith(privateKey, Jwts.SIG.RS256)
-            .compact();
+            .expiration(new Date(now + ttlMillis));
+        if (Util.stringExists(keyId)) b.header().keyId(keyId).and(); // 'kid' for rotation
+        return b.signWith(privateKey, Jwts.SIG.RS256).compact();
     }
 
     public Jws<Claims> verify(String token) {
@@ -332,13 +354,20 @@ public class AuthToken extends ApiBase {
                 writeError(response, 401, "unauthenticated");
                 return;
             }
-            JwtService jwt = JwtService.fromConfig(context);
+            // SECURITY (Codex High #1): pin the token context SERVER-SIDE. Do NOT
+            // sign ServletUtilities.getContext(request) — it honors a caller's
+            // ?context=, while Basic auth authenticates only against context0, so a
+            // caller-influenced context claim would let a user mint a token for a
+            // context they didn't authenticate in. v1 is single-context.
+            String tokenContext = org.ecocean.CommonConfiguration.getProperty("jwtContext", context);
+            if (!Util.stringExists(tokenContext)) tokenContext = "context0";
+            JwtService jwt = JwtService.fromConfig(tokenContext);
             if (!jwt.isEnabled()) {
                 writeError(response, 503, "token issuance not configured");
                 return;
             }
-            long ttl = ttlFromConfig(context);
-            String token = jwt.sign(user.getId(), context, ttl);
+            long ttl = ttlFromConfig(tokenContext);
+            String token = jwt.sign(user.getId(), tokenContext, ttl);
             JSONObject out = new JSONObject();
             out.put("token", token);
             out.put("tokenType", "Bearer");
@@ -357,7 +386,12 @@ public class AuthToken extends ApiBase {
     private long ttlFromConfig(String context) {
         String v = org.ecocean.CommonConfiguration.getProperty("jwtTtlSeconds", context);
         if (Util.stringExists(v)) {
-            try { return Long.parseLong(v.trim()) * 1000L; } catch (NumberFormatException ignore) {}
+            try {
+                long secs = Long.parseLong(v.trim());
+                // Codex Low: clamp to a sane range (1 min .. 24 h)
+                secs = Math.max(60L, Math.min(secs, 24L * 3600L));
+                return secs * 1000L;
+            } catch (NumberFormatException ignore) {}
         }
         return DEFAULT_TTL_MILLIS;
     }
@@ -444,6 +478,7 @@ import org.json.JSONObject;
  */
 public class CanUserAccess extends ApiBase {
     private static final int MAX_IDS = 200;
+    private static final long MAX_BODY_BYTES = 64L * 1024L; // cap request body (Codex Medium)
 
     @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
@@ -459,6 +494,16 @@ public class CanUserAccess extends ApiBase {
             }
             if (!caller.isAdmin(myShepherd)) {
                 writeError(response, 403, "admin required");
+                return;
+            }
+            // Codex Medium: validate content-type + cap body size BEFORE reading/parsing.
+            String ctype = request.getContentType();
+            if (ctype == null || !ctype.toLowerCase().contains("application/json")) {
+                writeError(response, 415, "Content-Type must be application/json");
+                return;
+            }
+            if (request.getContentLengthLong() > MAX_BODY_BYTES) {
+                writeError(response, 413, "request body too large");
                 return;
             }
             JSONObject body = readBody(request);
@@ -504,7 +549,10 @@ public class CanUserAccess extends ApiBase {
             StringBuilder sb = new StringBuilder();
             BufferedReader r = request.getReader();
             String line;
-            while ((line = r.readLine()) != null) sb.append(line);
+            while ((line = r.readLine()) != null) {
+                sb.append(line);
+                if (sb.length() > MAX_BODY_BYTES) return null; // cap even if Content-Length lied
+            }
             return new JSONObject(sb.toString());
         } catch (Exception ex) {
             return null;
@@ -571,18 +619,19 @@ Create `docs/superpowers/runbooks/jwt-keypair-setup.md` documenting:
   openssl pkcs8 -topk8 -nocrypt -in jwt_private.pem -outform DER | base64 -w0   # -> jwtPrivateKeyBase64
   openssl rsa -in jwt_private.pem -pubout -outform DER | base64 -w0             # -> jwtPublicKeyBase64
   ```
-- The `commonConfiguration.properties` keys: `jwtPrivateKeyBase64`, `jwtPublicKeyBase64`, `jwtIssuer` (default `wildbook`), `jwtAudience` (default `wildbook-scoped-api`), `jwtTtlSeconds` (default 1800).
+- The `commonConfiguration.properties` keys: `jwtPrivateKeyBase64`, `jwtPublicKeyBase64`, `jwtIssuer` (default `wildbook`), `jwtAudience` (default `wildbook-scoped-api`), `jwtTtlSeconds` (default 1800, clamped to [60, 86400]), `jwtKeyId` (optional, sets the JWT `kid` header for rotation), `jwtContext` (optional, default `context0` — the single context tokens are pinned to; do NOT derive from the request).
 - Wildbook needs the PRIVATE key (to sign); the external kernel is given the PUBLIC key only. If `jwtPrivateKeyBase64` is unset, `/api/v3/auth/token` returns 503.
-- Key rotation note (swap keys; old tokens expire within TTL).
+- **Key rotation:** set a distinct `jwtKeyId` per key. To rotate: deploy the new private key + bump `jwtKeyId`; the kernel keeps BOTH old and new public keys (selected by `kid`) for at least one TTL so in-flight tokens keep verifying, then drops the old one.
+- **Secret hygiene (Codex Low):** the private key (and any `.pem`/Base64 form) must NEVER be committed to git or written to logs. If stored as a file, restrict perms (`chmod 600`). The Base64 value lives only in the Docker-mounted `commonConfiguration.properties`. Never log token strings.
 
 - [ ] **Step 2: Add test auth rules**
 
-In `src/test/resources/shiro.ini` `[urls]`, add (matching the file's style) so tests exercise the auth gates:
+In `src/test/resources/shiro.ini` `[urls]`, add these — **and they MUST be inserted BEFORE the `/** = anon` catch-all** (Shiro `[urls]` is first-match-wins; rules placed after `/**` are dead, Codex Medium):
 ```
 /api/v3/auth/token = authcBasicWildbook
 /api/v3/can-user-access = authcBasicWildbook, roles[admin]
 ```
-(Read the existing test shiro.ini to use the exact filter names defined there; if `authcBasicWildbook` isn't defined in the test ini, use the test ini's available auth filter equivalent.)
+Read the existing test shiro.ini to (a) use the exact filter names defined there (if `authcBasicWildbook` isn't defined in the test ini, use the test ini's available auth filter equivalent), and (b) place these lines physically above the `/** = anon` line. After editing, eyeball the ordering to confirm the catch-all is last.
 
 - [ ] **Step 3: Normalize + commit**
 
@@ -611,7 +660,14 @@ Expected: BUILD SUCCESS.
 Run: `cd /mnt/c/Wildbook-integration-b && for f in $(git diff --name-only main); do n=$(grep -cP '\r$' "$f" 2>/dev/null||echo 0); [ "$n" != "0" ] && echo "CRLF: $f"; done; echo done`
 Expected: only "done".
 
-- [ ] **Step 4: Confirm no stray files staged across commits**
+- [ ] **Step 4: Wiring-assertion test (Codex High #2 — Mockito can't prove the gate)**
+
+Because new paths are OPEN unless matched by a Shiro `[urls]` rule, and the unit tests do not load `web.xml`, add a guard test `src/test/java/org/ecocean/api/EndpointAuthWiringTest.java` that reads `src/main/webapp/WEB-INF/web.xml` and asserts: (a) both servlets + mappings exist for `/api/v3/auth/token` and `/api/v3/can-user-access`; (b) the Shiro `[urls]` section contains a non-`anon` constraint for each, with `roles[admin]` on can-user-access, positioned before any `/** ` catch-all. This is a cheap regression guard against the open-by-default footgun. (The PRIMARY enforcement is the in-code check in each endpoint — B1 returns 401 when `getUser(request)==null`, B2 returns 403 unless `caller.isAdmin` — so the endpoints are self-protecting even if Shiro is misconfigured; this test guards the defense-in-depth layer.)
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=EndpointAuthWiringTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS.
+
+- [ ] **Step 5: Confirm no stray files staged across commits**
 
 Run: `cd /mnt/c/Wildbook-integration-b && git diff --name-only main..HEAD`
 Expected: only the intended source/test/doc/pom/web.xml files; NO logs/ or runtime artifacts.

--- a/docs/superpowers/plans/2026-05-29-integration-endpoints-b.md
+++ b/docs/superpowers/plans/2026-05-29-integration-endpoints-b.md
@@ -1,0 +1,632 @@
+# Artifact B — Integration Endpoints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add the two Wildbook-side endpoints the external scoped-query kernel depends on: (B1) short-lived asymmetric-signed token issuance, and (B2) a live `canUserAccess` check computed from live Collaboration/role objects.
+
+**Architecture:** A pure, unit-testable `JwtService` (RSA keypair load + sign + verify) underpins a thin `AuthToken` servlet (`POST /api/v3/auth/token`) gated by existing Shiro Basic auth that mints a token carrying only identity (uuid + context + iss/aud/jti/exp). A separate `CanUserAccess` servlet (`POST /api/v3/can-user-access`), admin-gated, resolves a target user UUID + encounter IDs and returns the subset that user may view via `Encounter.canUserView`. Both follow the existing manual-servlet + web.xml pattern.
+
+**Tech Stack:** Java 17, Apache Shiro (existing), **jjwt 0.12.6** (new, locked), `java.security` RSA. JUnit5 + Mockito (mockito-inline present); JwtService gets pure unit tests, endpoints get Mockito unit tests.
+
+**Branch/worktree:** `integration-token-canaccess` at `/mnt/c/Wildbook-integration-b` (off `main`). Independent of Artifact A.
+
+**Design source:** `docs/superpowers/specs/2026-05-29-wildbook-acl-prereqs-design.md` (Artifact B section).
+
+---
+
+## Key facts (verified in this worktree)
+- Endpoints are manual servlets extending `org.ecocean.api.ApiBase` (only dispatches PATCH; **no** response/error helpers — each endpoint defines its own `writeError`, see `MatchInspection.java:145-153`). URIs are parsed by hand from `request.getRequestURI().split("/")`.
+- Registration: explicit `<servlet>` + `<servlet-mapping>` in `web.xml`. **A new path is OPEN unless added to the Shiro `[urls]` section** (`web.xml` ~lines 101-106). `authcBasicWildbook` = Basic auth; `authc` = session; `roles[...]` adds role gating.
+- Current user inside an endpoint: `myShepherd.getUser(request)` → `User` or null (uses `request.getUserPrincipal()`).
+- `Shepherd.getUserByUUID(String)` (Shepherd.java:1184), `Shepherd.getUser(String username)`, `Shepherd.getEncounter(String)` (Shepherd.java:495).
+- `Encounter.canUserView(User, Shepherd)` (Encounter.java:3316) = `user != null && (user.isAdmin(shepherd) || canUserAccess(user, context))`.
+- Config: `CommonConfiguration.getProperty(name, context)`. Per-deploy props in the Docker-mounted `commonConfiguration.properties`.
+- No JWT lib in pom.xml. Tests: pure Mockito unit (`EncounterApiTest`) or Testcontainers+Jetty+RestAssured integration (`EncounterExportImagesTest`).
+
+## File structure
+- **Modify** `pom.xml` — add jjwt 0.12.6 (api/impl/jackson), locked.
+- **Create** `src/main/java/org/ecocean/api/auth/JwtService.java` — keypair load (from config), `String sign(claims)`, `Jws<Claims> verify(token)`, helpers; isEnabled() when keys present.
+- **Create** `src/main/java/org/ecocean/api/AuthToken.java` — B1 servlet.
+- **Create** `src/main/java/org/ecocean/api/CanUserAccess.java` — B2 servlet.
+- **Modify** `src/main/webapp/WEB-INF/web.xml` — 2 servlet defs + mappings + 2 Shiro url constraints.
+- **Create** `src/test/java/org/ecocean/api/auth/JwtServiceTest.java` — pure unit tests.
+- **Create** `src/test/java/org/ecocean/api/AuthTokenTest.java`, `CanUserAccessTest.java` — Mockito unit tests.
+- **Create** `docs/superpowers/runbooks/jwt-keypair-setup.md` — keypair generation + config.
+- **Modify** `src/test/resources/shiro.ini` — add test auth rules for the two paths.
+
+---
+
+## Task 1: Add jjwt dependency
+
+**Files:** Modify `pom.xml`
+
+- [ ] **Step 1: Add the three jjwt artifacts (locked 0.12.6)**
+
+In `pom.xml` `<dependencies>`, add:
+```xml
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.12.6</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.12.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.12.6</version>
+      <scope>runtime</scope>
+    </dependency>
+```
+(Match the file's existing indentation/version-property conventions; if the project pins versions in `<properties>`, follow that convention with a `jjwt.version` property instead.)
+
+- [ ] **Step 2: Resolve dependencies**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn -q -DskipTests dependency:resolve 2>&1 | tail -5; mvn -q -DskipTests compile`
+Expected: BUILD SUCCESS (jjwt downloaded; project still compiles).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /mnt/c/Wildbook-integration-b add pom.xml
+git -C /mnt/c/Wildbook-integration-b commit -m "build: add jjwt 0.12.6 (JWT signing for scoped-access tokens)"
+```
+
+---
+
+## Task 2: JwtService (keypair load + sign + verify) — pure unit-tested core
+
+**Files:** Create `src/main/java/org/ecocean/api/auth/JwtService.java`; Test `src/test/java/org/ecocean/api/auth/JwtServiceTest.java`
+
+The JwtService is the security-critical, fully unit-testable core. Keys are RSA. Private key signs (Wildbook = issuer); public key verifies (the external kernel holds the public key; JwtService.verify exists for round-trip testing and any future Wildbook-side verification).
+
+- [ ] **Step 1: Write failing tests (round-trip, expiry, tamper, wrong aud/iss, disabled)**
+
+Create `JwtServiceTest.java`:
+```java
+package org.ecocean.api.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.Test;
+
+class JwtServiceTest {
+
+    private JwtService serviceWithFreshKeys() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()); // PKCS8
+        String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());   // X.509
+        return JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+    }
+
+    @Test void signThenVerify_roundTrip() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("user-uuid-123", "context0", 60_000L); // 60s TTL
+        Jws<Claims> jws = svc.verify(token);
+        Claims c = jws.getPayload();
+        assertEquals("user-uuid-123", c.getSubject(), "subject = user uuid");
+        assertEquals("context0", c.get("context", String.class), "context claim");
+        assertEquals("wildbook", c.getIssuer(), "issuer");
+        assertNotNull(c.getId(), "jti present");
+        assertTrue(c.getExpiration().getTime() > System.currentTimeMillis(), "exp in future");
+        assertNull(c.get("admin"), "no admin claim");
+        assertNull(c.get("roles"), "no roles claim");
+    }
+
+    @Test void expiredToken_rejected() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("u", "context0", -1000L); // already expired
+        assertThrows(JwtException.class, () -> svc.verify(token), "expired token must be rejected");
+    }
+
+    @Test void tamperedToken_rejected() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("u", "context0", 60_000L);
+        String tampered = token.substring(0, token.length() - 2) + (token.endsWith("a") ? "bb" : "aa");
+        assertThrows(JwtException.class, () -> svc.verify(tampered), "bad signature must be rejected");
+    }
+
+    @Test void wrongAudienceOrIssuer_rejected() throws Exception {
+        JwtService a = serviceWithFreshKeys();
+        String token = a.sign("u", "context0", 60_000L);
+        // a different service (different keys) cannot verify a's token
+        JwtService b = serviceWithFreshKeys();
+        assertThrows(JwtException.class, () -> b.verify(token), "token signed by other key must fail");
+    }
+
+    @Test void disabledWhenKeysMissing() {
+        JwtService svc = JwtService.fromBase64Keys(null, null, "wildbook", "wildbook-scoped-api");
+        assertFalse(svc.isEnabled(), "service disabled without keys");
+        assertThrows(IllegalStateException.class, () -> svc.sign("u", "context0", 1000L),
+            "signing while disabled must throw");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=JwtServiceTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: FAIL — `JwtService` does not exist.
+
+- [ ] **Step 3: Implement JwtService**
+
+Create `src/main/java/org/ecocean/api/auth/JwtService.java`:
+```java
+package org.ecocean.api.auth;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+
+import org.ecocean.CommonConfiguration;
+import org.ecocean.Util;
+
+/**
+ * Issues and verifies short-lived RS256 JWTs that carry ONLY identity
+ * (subject = user UUID, context). No admin/role claims — the consumer
+ * resolves privileges fresh. Wildbook holds the private (signing) key;
+ * the external scoped-access kernel holds the public key.
+ *
+ * Keys are RSA, supplied as Base64 of the encoded key bytes (private = PKCS8,
+ * public = X.509), via commonConfiguration.properties:
+ *   jwtPrivateKeyBase64=...   (signing; required to mint tokens)
+ *   jwtPublicKeyBase64=...    (verify; optional Wildbook-side)
+ *   jwtIssuer=wildbook
+ *   jwtAudience=wildbook-scoped-api
+ * If the private key is absent, the service is "disabled" and the token
+ * endpoint returns 503.
+ */
+public class JwtService {
+    private final PrivateKey privateKey;
+    private final PublicKey publicKey;
+    private final String issuer;
+    private final String audience;
+
+    private JwtService(PrivateKey priv, PublicKey pub, String issuer, String audience) {
+        this.privateKey = priv;
+        this.publicKey = pub;
+        this.issuer = issuer;
+        this.audience = audience;
+    }
+
+    public static JwtService fromBase64Keys(String privB64, String pubB64, String issuer,
+        String audience) {
+        PrivateKey priv = null;
+        PublicKey pub = null;
+        try {
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            if (Util.stringExists(privB64)) {
+                priv = kf.generatePrivate(
+                    new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privB64.trim())));
+            }
+            if (Util.stringExists(pubB64)) {
+                pub = kf.generatePublic(
+                    new X509EncodedKeySpec(Base64.getDecoder().decode(pubB64.trim())));
+            }
+        } catch (Exception ex) {
+            System.out.println("JwtService: failed to load keys: " + ex);
+        }
+        return new JwtService(priv, pub, issuer, audience);
+    }
+
+    public static JwtService fromConfig(String context) {
+        return fromBase64Keys(
+            CommonConfiguration.getProperty("jwtPrivateKeyBase64", context),
+            CommonConfiguration.getProperty("jwtPublicKeyBase64", context),
+            orDefault(CommonConfiguration.getProperty("jwtIssuer", context), "wildbook"),
+            orDefault(CommonConfiguration.getProperty("jwtAudience", context),
+                "wildbook-scoped-api"));
+    }
+
+    private static String orDefault(String v, String d) {
+        return Util.stringExists(v) ? v : d;
+    }
+
+    public boolean isEnabled() {
+        return privateKey != null;
+    }
+
+    public String sign(String userUuid, String context, long ttlMillis) {
+        if (!isEnabled()) throw new IllegalStateException("JwtService not enabled (no private key)");
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
+            .issuer(issuer)
+            .audience().add(audience).and()
+            .subject(userUuid)
+            .claim("context", context)
+            .id(Util.generateUUID())
+            .issuedAt(new Date(now))
+            .expiration(new Date(now + ttlMillis))
+            .signWith(privateKey, Jwts.SIG.RS256)
+            .compact();
+    }
+
+    public Jws<Claims> verify(String token) {
+        if (publicKey == null) throw new IllegalStateException("JwtService cannot verify (no public key)");
+        return Jwts.parser()
+            .requireIssuer(issuer)
+            .requireAudience(audience)
+            .verifyWith(publicKey)
+            .build()
+            .parseSignedClaims(token);
+    }
+}
+```
+(Note: this uses the jjwt 0.12.x builder API — `audience().add(...).and()`, `Jwts.SIG.RS256`, `parseSignedClaims`. If the resolved jjwt version's API differs, adapt to that version's signatures and report.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=JwtServiceTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' src/main/java/org/ecocean/api/auth/JwtService.java src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+git -C /mnt/c/Wildbook-integration-b add src/main/java/org/ecocean/api/auth/JwtService.java src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+git -C /mnt/c/Wildbook-integration-b commit -m "feat(api): JwtService — RS256 sign/verify for scoped-access tokens"
+```
+
+---
+
+## Task 3: AuthToken endpoint (B1)
+
+**Files:** Create `src/main/java/org/ecocean/api/AuthToken.java`; Modify `web.xml`; Test `src/test/java/org/ecocean/api/AuthTokenTest.java`
+
+- [ ] **Step 1: Implement the servlet**
+
+Create `src/main/java/org/ecocean/api/AuthToken.java`:
+```java
+package org.ecocean.api;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.User;
+import org.ecocean.Util;
+import org.ecocean.api.auth.JwtService;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+
+/**
+ * POST /api/v3/auth/token
+ * Gated by existing Shiro auth (authcBasicWildbook). Mints a short-lived
+ * RS256 token carrying only the caller's identity (uuid + context). The
+ * external scoped-access kernel validates it with the public key.
+ */
+public class AuthToken extends ApiBase {
+    private static final long DEFAULT_TTL_MILLIS = 30L * 60L * 1000L; // 30 min
+
+    @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+        String context = ServletUtilities.getContext(request);
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("api.AuthToken.doPost");
+        myShepherd.beginDBTransaction();
+        try {
+            User user = myShepherd.getUser(request);
+            if (user == null) {
+                writeError(response, 401, "unauthenticated");
+                return;
+            }
+            JwtService jwt = JwtService.fromConfig(context);
+            if (!jwt.isEnabled()) {
+                writeError(response, 503, "token issuance not configured");
+                return;
+            }
+            long ttl = ttlFromConfig(context);
+            String token = jwt.sign(user.getId(), context, ttl);
+            JSONObject out = new JSONObject();
+            out.put("token", token);
+            out.put("tokenType", "Bearer");
+            out.put("expiresInSeconds", ttl / 1000L);
+            response.setStatus(200);
+            response.setContentType("application/json");
+            response.getWriter().write(out.toString());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            writeError(response, 500, "token issuance failed");
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private long ttlFromConfig(String context) {
+        String v = org.ecocean.CommonConfiguration.getProperty("jwtTtlSeconds", context);
+        if (Util.stringExists(v)) {
+            try { return Long.parseLong(v.trim()) * 1000L; } catch (NumberFormatException ignore) {}
+        }
+        return DEFAULT_TTL_MILLIS;
+    }
+
+    private void writeError(HttpServletResponse response, int code, String message)
+        throws IOException {
+        response.setStatus(code);
+        response.setContentType("application/json");
+        response.getWriter().write(new JSONObject().put("success", false)
+            .put("error", message).toString());
+    }
+}
+```
+(Confirm `ServletUtilities.getContext(request)` exists — used by MatchInspection; if the helper signature differs, match the real one. Confirm `User.getId()` returns the UUID.)
+
+- [ ] **Step 2: Register + protect in web.xml**
+
+In `web.xml`, add a `<servlet>` + `<servlet-mapping>` (next to the other `/api/v3` servlets):
+```xml
+  <servlet>
+    <servlet-name>AuthToken</servlet-name>
+    <servlet-class>org.ecocean.api.AuthToken</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>AuthToken</servlet-name>
+    <url-pattern>/api/v3/auth/token</url-pattern>
+  </servlet-mapping>
+```
+And in the Shiro `[urls]` section (near line 101-106), add (so it is NOT open):
+```
+/api/v3/auth/token = authcBasicWildbook
+```
+(Basic auth so non-browser clients can bootstrap username/password → token. Read the existing `[urls]` entries to match exact filter names available in this web.xml.)
+
+- [ ] **Step 3: Write a Mockito unit test**
+
+Create `src/test/java/org/ecocean/api/AuthTokenTest.java` following the `EncounterApiTest` MockedConstruction idiom: mock `Shepherd` so `getUser(request)` returns null → assert 401 (capture response via a mocked `HttpServletResponse` + `StringWriter`). (Full token-mint path needs keys/config; cover the 401 unauthenticated path and the 503 disabled path here — the happy path is covered by JwtServiceTest + the integration smoke in Task 5. Read EncounterApiTest for the exact mocking setup.)
+
+- [ ] **Step 4: Run test + compile**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=AuthTokenTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** (normalize LF on all touched files first)
+
+```bash
+git -C /mnt/c/Wildbook-integration-b add src/main/java/org/ecocean/api/AuthToken.java src/main/webapp/WEB-INF/web.xml src/test/java/org/ecocean/api/AuthTokenTest.java
+git -C /mnt/c/Wildbook-integration-b commit -m "feat(api): POST /api/v3/auth/token — short-lived scoped-access token issuance"
+```
+
+---
+
+## Task 4: CanUserAccess endpoint (B2)
+
+**Files:** Create `src/main/java/org/ecocean/api/CanUserAccess.java`; Modify `web.xml`; Test `src/test/java/org/ecocean/api/CanUserAccessTest.java`
+
+- [ ] **Step 1: Implement the servlet**
+
+Create `src/main/java/org/ecocean/api/CanUserAccess.java`:
+```java
+package org.ecocean.api;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.Encounter;
+import org.ecocean.User;
+import org.ecocean.Util;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * POST /api/v3/can-user-access
+ * Admin/service-scoped. Body: {"userUuid": "...", "encounterIds": ["...", ...]}.
+ * Returns {"accessible": ["...", ...]} — the subset of encounterIds the target
+ * user may VIEW, computed from LIVE Collaboration/role objects (not the indexed
+ * viewUsers). Defense-in-depth backstop for the scoped-query kernel.
+ */
+public class CanUserAccess extends ApiBase {
+    private static final int MAX_IDS = 200;
+
+    @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+        String context = ServletUtilities.getContext(request);
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("api.CanUserAccess.doPost");
+        myShepherd.beginDBTransaction();
+        try {
+            User caller = myShepherd.getUser(request);
+            if (caller == null) {
+                writeError(response, 401, "unauthenticated");
+                return;
+            }
+            if (!caller.isAdmin(myShepherd)) {
+                writeError(response, 403, "admin required");
+                return;
+            }
+            JSONObject body = readBody(request);
+            if (body == null) { writeError(response, 400, "invalid JSON body"); return; }
+            String userUuid = body.optString("userUuid", null);
+            JSONArray idsArr = body.optJSONArray("encounterIds");
+            if (!Util.stringExists(userUuid) || idsArr == null) {
+                writeError(response, 400, "userUuid and encounterIds required");
+                return;
+            }
+            if (idsArr.length() > MAX_IDS) {
+                writeError(response, 400, "too many encounterIds (max " + MAX_IDS + ")");
+                return;
+            }
+            User target = myShepherd.getUserByUUID(userUuid);
+            JSONArray accessible = new JSONArray();
+            // target==null -> empty accessible set (unknown user sees nothing)
+            if (target != null) {
+                for (int i = 0; i < idsArr.length(); i++) {
+                    String encId = idsArr.optString(i, null);
+                    if (!Util.stringExists(encId)) continue;
+                    Encounter enc = myShepherd.getEncounter(encId);
+                    if (enc != null && enc.canUserView(target, myShepherd)) {
+                        accessible.put(encId);
+                    }
+                }
+            }
+            JSONObject out = new JSONObject();
+            out.put("accessible", accessible);
+            response.setStatus(200);
+            response.setContentType("application/json");
+            response.getWriter().write(out.toString());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            writeError(response, 500, "canUserAccess failed");
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private JSONObject readBody(HttpServletRequest request) {
+        try {
+            StringBuilder sb = new StringBuilder();
+            BufferedReader r = request.getReader();
+            String line;
+            while ((line = r.readLine()) != null) sb.append(line);
+            return new JSONObject(sb.toString());
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    private void writeError(HttpServletResponse response, int code, String message)
+        throws IOException {
+        response.setStatus(code);
+        response.setContentType("application/json");
+        response.getWriter().write(new JSONObject().put("success", false)
+            .put("error", message).toString());
+    }
+}
+```
+
+- [ ] **Step 2: Register + protect in web.xml**
+
+Add servlet + mapping:
+```xml
+  <servlet>
+    <servlet-name>CanUserAccess</servlet-name>
+    <servlet-class>org.ecocean.api.CanUserAccess</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>CanUserAccess</servlet-name>
+    <url-pattern>/api/v3/can-user-access</url-pattern>
+  </servlet-mapping>
+```
+Shiro `[urls]` (admin-gated — read the file to confirm the exact filter name for admin role; pattern is `authcBasicWildbook, roles[admin]`):
+```
+/api/v3/can-user-access = authcBasicWildbook, roles[admin]
+```
+(The in-code `caller.isAdmin` check is belt-and-suspenders alongside the role constraint.)
+
+- [ ] **Step 3: Mockito unit tests**
+
+Create `CanUserAccessTest.java`: (a) non-admin caller → 403; (b) admin caller + a target user where one encounter `canUserView`==true and another ==false → `accessible` contains only the true one; (c) unknown target uuid → empty accessible. Mock `Shepherd`, `User` (caller `isAdmin`→true/false; target), `Encounter` (`canUserView`→true/false). Follow EncounterApiTest mocking; capture the written JSON via a mocked response + StringWriter and parse it.
+
+- [ ] **Step 4: Run + compile**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=CanUserAccessTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** (LF-normalize first)
+
+```bash
+git -C /mnt/c/Wildbook-integration-b add src/main/java/org/ecocean/api/CanUserAccess.java src/main/webapp/WEB-INF/web.xml src/test/java/org/ecocean/api/CanUserAccessTest.java
+git -C /mnt/c/Wildbook-integration-b commit -m "feat(api): POST /api/v3/can-user-access — live per-user encounter access check"
+```
+
+---
+
+## Task 5: Keypair runbook + test shiro.ini + config docs
+
+**Files:** Create `docs/superpowers/runbooks/jwt-keypair-setup.md`; Modify `src/test/resources/shiro.ini`
+
+- [ ] **Step 1: Write the keypair/config runbook**
+
+Create `docs/superpowers/runbooks/jwt-keypair-setup.md` documenting:
+- Generate an RSA-2048 keypair and the Base64 (PKCS8 private / X.509 public) forms, e.g.:
+  ```
+  openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out jwt_private.pem
+  openssl pkcs8 -topk8 -nocrypt -in jwt_private.pem -outform DER | base64 -w0   # -> jwtPrivateKeyBase64
+  openssl rsa -in jwt_private.pem -pubout -outform DER | base64 -w0             # -> jwtPublicKeyBase64
+  ```
+- The `commonConfiguration.properties` keys: `jwtPrivateKeyBase64`, `jwtPublicKeyBase64`, `jwtIssuer` (default `wildbook`), `jwtAudience` (default `wildbook-scoped-api`), `jwtTtlSeconds` (default 1800).
+- Wildbook needs the PRIVATE key (to sign); the external kernel is given the PUBLIC key only. If `jwtPrivateKeyBase64` is unset, `/api/v3/auth/token` returns 503.
+- Key rotation note (swap keys; old tokens expire within TTL).
+
+- [ ] **Step 2: Add test auth rules**
+
+In `src/test/resources/shiro.ini` `[urls]`, add (matching the file's style) so tests exercise the auth gates:
+```
+/api/v3/auth/token = authcBasicWildbook
+/api/v3/can-user-access = authcBasicWildbook, roles[admin]
+```
+(Read the existing test shiro.ini to use the exact filter names defined there; if `authcBasicWildbook` isn't defined in the test ini, use the test ini's available auth filter equivalent.)
+
+- [ ] **Step 3: Normalize + commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' docs/superpowers/runbooks/jwt-keypair-setup.md src/test/resources/shiro.ini
+git -C /mnt/c/Wildbook-integration-b add docs/superpowers/runbooks/jwt-keypair-setup.md src/test/resources/shiro.ini
+git -C /mnt/c/Wildbook-integration-b commit -m "docs(api): JWT keypair setup runbook + test auth rules"
+```
+
+---
+
+## Task 6: Verification + final review
+
+- [ ] **Step 1: Unit tests**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=JwtServiceTest,AuthTokenTest,CanUserAccessTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: all pass.
+
+- [ ] **Step 2: Full compile**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn -q -DskipTests compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: CRLF check on branch files**
+
+Run: `cd /mnt/c/Wildbook-integration-b && for f in $(git diff --name-only main); do n=$(grep -cP '\r$' "$f" 2>/dev/null||echo 0); [ "$n" != "0" ] && echo "CRLF: $f"; done; echo done`
+Expected: only "done".
+
+- [ ] **Step 4: Confirm no stray files staged across commits**
+
+Run: `cd /mnt/c/Wildbook-integration-b && git diff --name-only main..HEAD`
+Expected: only the intended source/test/doc/pom/web.xml files; NO logs/ or runtime artifacts.
+
+---
+
+## Notes for the implementer
+- jjwt 0.12.x API specifics (builder `.audience().add().and()`, `Jwts.SIG.RS256`, `.parseSignedClaims`, `.verifyWith`) — if the resolved version's API differs, adapt and report which version/API you used.
+- `writeError` is defined per-endpoint (no ApiBase helper) — matches `MatchInspection`.
+- Always LF-normalize after each edit (`perl -i -pe 's/\r\n/\n/g'`); never stage `logs/application.json` — add only explicit paths.
+- Do NOT log token values or private keys anywhere.
+- Security stance: the token carries NO admin/role claims; the kernel resolves privileges fresh. B2 requires the CALLER to be admin and computes access for the TARGET user — never trust a caller-supplied "isAdmin".
+
+## Open questions for review
+1. jjwt 0.12.6 vs an alternative (nimbus-jose-jwt) — any packaging/transitive-dep concern in this WAR? (Dependabot/system-test per repo policy.)
+2. B2 caller gating: full `admin` role for v1 vs a dedicated narrow service role (`rest`?) — admin is simplest now; dedicated service role is a follow-up.
+3. Public-key distribution to the kernel: out-of-band config for v1 vs a `GET /api/v3/auth/jwks` endpoint (follow-up).
+4. Key storage: Base64-in-properties (this plan) vs file-path vs a secrets manager — properties is simplest for the Docker-mounted config; revisit for production secret hygiene.

--- a/docs/superpowers/runbooks/jwt-keypair-setup.md
+++ b/docs/superpowers/runbooks/jwt-keypair-setup.md
@@ -1,0 +1,98 @@
+# JWT Keypair Setup — Wildbook Scoped-Access Tokens
+
+This runbook covers generating the RSA-2048 keypair for `POST /api/v3/auth/token`,
+configuring Wildbook, and maintaining key hygiene + rotation.
+
+---
+
+## 1. Generate an RSA-2048 Keypair
+
+Run these commands on a secure workstation (not inside the container):
+
+```bash
+# 1. Generate the RSA-2048 private key in PEM form
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out jwt_private.pem
+
+# 2. Produce the Base64-encoded PKCS8 DER form → value for jwtPrivateKeyBase64
+openssl pkcs8 -topk8 -nocrypt -in jwt_private.pem -outform DER | base64 -w0
+
+# 3. Produce the Base64-encoded X.509 DER public key → value for jwtPublicKeyBase64
+openssl rsa -in jwt_private.pem -pubout -outform DER | base64 -w0
+```
+
+Copy the output of steps 2 and 3 into `commonConfiguration.properties` (see below).
+**Immediately restrict the PEM file permissions** (`chmod 600 jwt_private.pem`).
+
+---
+
+## 2. `commonConfiguration.properties` Keys
+
+Add these to the Docker-mounted `commonConfiguration.properties` (never to the git-tracked one):
+
+```properties
+# Required — Base64(PKCS8 DER) of the RSA-2048 private key (Wildbook signs tokens)
+jwtPrivateKeyBase64=<output of step 2 above>
+
+# Recommended — Base64(X.509 DER) of the RSA-2048 public key (optional Wildbook-side verify)
+jwtPublicKeyBase64=<output of step 3 above>
+
+# JWT issuer claim — default: wildbook
+jwtIssuer=wildbook
+
+# JWT audience claim — default: wildbook-scoped-api
+jwtAudience=wildbook-scoped-api
+
+# Token lifetime in seconds — default: 1800 (30 min), clamped to [60, 86400]
+jwtTtlSeconds=1800
+
+# Optional: sets the JWT 'kid' header for key rotation (see section 4)
+# jwtKeyId=v1
+
+# Optional: the context tokens are pinned to — default: context0
+# Do NOT derive this from the HTTP request; it is a server-side configuration value.
+# jwtContext=context0
+```
+
+All keys are read via `CommonConfiguration.getProperty(key, context)`.
+
+---
+
+## 3. Signing Split: Wildbook vs. Kernel
+
+| Component | Holds | Purpose |
+|---|---|---|
+| Wildbook | **Private key** (`jwtPrivateKeyBase64`) | Signs / mints tokens |
+| External scoped-query kernel | **Public key** (`jwtPublicKeyBase64` output) | Verifies token signature |
+
+- Wildbook signs (`RS256`); the kernel verifies. The public key is distributed to the kernel
+  **out of band** (config, not an endpoint — a JWKS endpoint is a planned follow-up).
+- If `jwtPrivateKeyBase64` is **unset**, `POST /api/v3/auth/token` returns **503
+  Service Unavailable** (`{"success":false,"error":"token issuance not configured"}`).
+- The public key (`jwtPublicKeyBase64`) is optional from Wildbook's perspective; its absence
+  only disables the Wildbook-side `JwtService.verify()` path (used in tests and future auditing).
+
+---
+
+## 4. Key Rotation
+
+1. **Generate a new keypair** (steps 1–3 above). Assign a distinct `jwtKeyId`, e.g. `v2`.
+2. **Distribute the new public key** to the kernel. Configure the kernel to accept BOTH
+   the old (`v1`) and new (`v2`) public keys, selected by the `kid` JWT header claim.
+   The kernel must keep the old public key for **at least one full TTL** after the new key
+   is deployed so that in-flight tokens minted with the old key continue to verify.
+3. **Update Wildbook** `commonConfiguration.properties`: set `jwtPrivateKeyBase64` to the
+   new private key and set `jwtKeyId=v2`. Reload/restart Wildbook.
+4. After the old TTL window has elapsed (all tokens signed with `v1` have expired), remove
+   the old public key from the kernel configuration.
+
+---
+
+## 5. Secret Hygiene
+
+- **NEVER commit** the private key (PEM or Base64) to git. It belongs only in the
+  Docker-mounted `commonConfiguration.properties`, which is excluded from version control.
+- **chmod 600** any `.pem` or key file on disk immediately after creation.
+- **Never log** the `jwtPrivateKeyBase64` value, the raw PEM, or any minted token string.
+  Wildbook's logging does not emit these, but verify any custom log lines before adding them.
+- Rotate immediately if there is any suspicion the private key was exposed.
+- The Base64 config value should be treated with the same care as a database password.

--- a/docs/superpowers/specs/2026-05-29-wildbook-acl-prereqs-design.md
+++ b/docs/superpowers/specs/2026-05-29-wildbook-acl-prereqs-design.md
@@ -104,7 +104,7 @@ Each must explicitly enqueue permissions-recompute for the affected encounters (
 
 Net-new, additive. No token/JWT/API-key infrastructure exists today (only Shiro HTTP Basic). Keep this off Artifact A's clean security diff.
 
-### B1 — `POST /api/auth/token` (short-lived token issuance)
+### B1 — `POST /api/v3/auth/token` (short-lived token issuance)
 - Gated by the **existing** Shiro authentication (an already-authenticated user calls it).
 - Mints a short-lived **signed** token. Claims: subject = user UUID, `context`, `iss`, `aud`, `jti`, `exp` (~30–60 min), `iat`. **No** admin/orgAdmin/role claims (privileges are resolved fresh by the kernel per request).
 - Signing: **asymmetric** (decided — the service runs remote). Wildbook holds the private signing key; the remote kernel validates with the public key only, so a kernel compromise cannot mint tokens. Key id in header + rotation support.

--- a/docs/superpowers/specs/2026-05-29-wildbook-acl-prereqs-design.md
+++ b/docs/superpowers/specs/2026-05-29-wildbook-acl-prereqs-design.md
@@ -1,0 +1,133 @@
+# Wildbook ACL Prerequisites — Design Spec
+
+**Date:** 2026-05-29
+**Status:** Draft — incorporated Codex design review (2026-05-29); pending user approval
+**Repo:** Wildbook (this repo)
+**Related specs:** [AI Co-Scientist + Scoped Query Kernel](2026-05-29-ai-coscientist-design.md)
+**Related memory:** `project_viewusers_acl_bug.md`, `project_ai_coscientist.md`
+
+## Purpose
+
+The AI Co-Scientist project (separate spec) needs a *sound* authorization boundary so an external read-only service can scope OpenSearch queries to exactly the data a given Wildbook user may see. A code review (Codex, 2026-05-29, verified in source) found that Wildbook's existing `viewUsers[]` OpenSearch ACL field — already relied on by Wildbook's *own* search via `Encounter.opensearchAccess` and `EncounterQueryProcessor` — is **not trustworthy as written**. This spec covers the Wildbook-side prerequisites:
+
+- **Artifact A — `viewUsers` ACL hardening.** A standalone security bugfix. Valuable independent of the co-scientist: it closes a live data-exposure path in Wildbook's existing search.
+- **Artifact B — Integration endpoints.** Net-new API the external kernel needs: short-lived token issuance and a live "can user access encounter" check used as a defense-in-depth backstop.
+
+These are **two separate branches/PRs** (A is a pure security bugfix; B is feature additions) so A's security diff stays clean and independently reviewable.
+
+## Background: the two confirmed defects
+
+Both verified in current source on 2026-05-29.
+
+### Defect 1 — revocation can leak indefinitely
+`Encounter.opensearchIndexPermissions()` (the correct background ACL writer) only pushes an update when the computed set is non-empty:
+
+```java
+// Encounter.java ~4224
+if (viewUsers.length() > 0) {
+    updateData.put("viewUsers", viewUsers);
+    os.indexUpdate("encounter", id, updateData);
+}
+```
+
+When the **last** collaborator/orgAdmin loses access, the computed set is empty, so **nothing is written** — the previously-indexed `viewUsers` array persists in OpenSearch until some unrelated full reindex happens to overwrite the document. A revoked user retains read access via the field for an unbounded period. This is not the ~10–45 min background-pass latency; it is potentially permanent.
+
+### Defect 2 — a second, contradictory `viewUsers` writer
+`Encounter.userIdsWithViewAccess()` is a *different* ACL computation used by the full-document serializer:
+
+```java
+// Encounter.java ~3351 — NO state filter, BACKWARDS direction
+List<Collaboration> collabs =
+    Collaboration.collaborationsForUser(myShepherd, this.getSubmitterID());
+for (Collaboration collab : collabs) {
+    User user = myShepherd.getUser(collab.getOtherUsername(this.getSubmitterID()));
+    if (user != null) ids.add(user.getId());
+}
+```
+
+It is invoked whenever `opensearchProcessPermissions == true` (`Encounter.java` ~4605–4615), which ordinary single-encounter edit servlets set (e.g. `EncounterSetLocationID`). Versus the correct background writer it:
+
+1. **Applies no state filter** — `collaborationsForUser(..., state=null)` returns `initialized`/`rejected`/`pending` collaborations, granting view access to users who never had it (or were rejected).
+2. **Uses the backwards direction** the background pass explicitly warns against (`Encounter.java` 4189–4193): it asks "who is the submitter collaborating with" rather than "who can see this submitter," which also **inverts orgAdmin one-way visibility** (org members would gain sight of the orgAdmin's own encounters).
+
+So in production `viewUsers` is a race between a correct writer (background pass) and a buggy writer (edit-triggered), and the buggy one runs on routine edits.
+
+### Impact beyond the co-scientist
+`EncounterQueryProcessor` post-filters search hits with `Encounter.opensearchAccess(doc, user, shepherd)`, which reads these exact fields. Both defects therefore affect **Wildbook's existing search authorization today**, independent of any new service.
+
+## Artifact A — `viewUsers` ACL hardening
+
+### Goals
+1. Exactly one ACL computation, used by every writer.
+2. `viewUsers` is always written for non-public encounters, including the empty set `[]` (revocation propagates).
+3. Revocation/rejection/removal of a collaboration or orgAdmin triggers reindex of affected encounters.
+4. Full-document reindex includes `viewUsers` (or never drops it).
+5. A one-time corrective full reindex repairs already-stale docs in existing installs.
+
+### Design
+
+**Single ACL writer.** Extract the correct logic (currently inline in `opensearchIndexPermissions()`, `Encounter.java` 4208–4222) into one method — e.g. `Encounter.computeViewUsers(Shepherd)` — that:
+- returns the set of user UUIDs who can see this encounter via **approved/edit** collaborations, in the correct "who can see the submitter" direction, including correctly-directed assumed orgAdmin collaborations;
+- returns `[]` for a non-public encounter with no viewers;
+- is the **only** producer of `viewUsers`.
+
+Replace `userIdsWithViewAccess()`'s body with a call to this method (or delete it and repoint callers). Delete the divergent state-less/backwards logic.
+
+**Always-write semantics.** Remove the `if (viewUsers.length() > 0)` guard at `Encounter.java` ~4224; always write the field (including `[]`) for non-public encounters. Public encounters set `publiclyReadable=true` and need no `viewUsers`.
+
+**Full-reindex includes the field — via two explicit code paths (resolves prior open Q1).** A full reindex must never emit a `viewUsers` it did not compute, and must never re-emit the stale indexed value (that would preserve exactly the bug A repairs, and cannot serve the corrective reindex). But naively computing the ACL on *every* full index is a real scale risk — generic per-doc `viewUsers` computation was previously removed from the base serializer as too expensive (`Base.java:214–216`); the background pass is only affordable because it builds the user/collab maps **once** and SQL-scans encounters (`Encounter.java:4143–4167`). Therefore define two paths, both sourced from the single `computeViewUsers` logic:
+- **Single-encounter recompute** — for edit servlets and lifecycle-triggered reindex of one encounter (live JDO collaboration scan; acceptable for one doc).
+- **Bulk ACL-computation service** — for full reindex and the background/corrective passes: build the maps once, pass a precomputed ACL snapshot into the reindex job. The full-document serializer takes `viewUsers` from this snapshot, never from the stale index and never dropping the field.
+
+Add timing metrics before adopting any always-compute path.
+
+**Revocation triggers reindex — enumerate every trigger; `IndexingManager` alone is insufficient.** The JDO lifecycle listener only special-cases `Base` and `Collaboration` objects (`WildbookLifecycleListener.java:53–68`), but several revocation paths mutate *other* objects and would silently fail to reindex:
+- Collaboration → `rejected`/deleted (already covered by the listener).
+- **orgAdmin role removal** — roles are plain `Role` objects (`UserCreate.java:194–200`), not `Base`/`Collaboration`.
+- **Org membership / hierarchy edits** — mutate `User`/`Organization` (`User.java:452–458`, `Organization.java:119–124`).
+- **User deletion / consolidation / rename** — affects both the old and new owner's encounters.
+
+Each must explicitly enqueue permissions-recompute for the affected encounters (submitter's encounters; for orgAdmin/org changes, the org members' encounters) via the bulk path.
+
+**Invalid/deleted/renamed submitters must fail closed.** Current permissions indexing *skips* an encounter when `submitterID` doesn't map to a user (`Encounter.java:4178–4184`), and full indexing omits `submitterUserId` when the user is missing (`Encounter.java:4344–4345`) — leaving any prior `viewUsers` orphaned. `computeViewUsers` must instead return and write `[]` for non-public encounters with invalid/missing owners (and log/audit them), so such encounters become admin-only, not stale-open. User rename/consolidation must enqueue both the old and new owner's encounters.
+
+**One-time corrective reindex.** Document an operator step (and/or a startup migration flag) to run a full permissions reindex once after deploy to repair already-stale `viewUsers` in existing installs.
+
+### Tests (required, security-sensitive)
+- Sole collaborator rejected → `viewUsers` becomes `[]`; previously-permitted user no longer matches.
+- orgAdmin role removed → org members' encounters drop that admin from `viewUsers`.
+- Edit servlet (e.g. set location) on an encounter does **not** introduce rejected/pending users and does **not** invert orgAdmin direction (regression test for Defect 2).
+- Full reindex of an encounter preserves correct `viewUsers`.
+- Cross-check: for a sample of encounters/users, the indexed `viewUsers`-based decision matches a live `Collaboration.canUserAccessEncounter` computation.
+
+## Artifact B — Integration endpoints
+
+Net-new, additive. No token/JWT/API-key infrastructure exists today (only Shiro HTTP Basic). Keep this off Artifact A's clean security diff.
+
+### B1 — `POST /api/auth/token` (short-lived token issuance)
+- Gated by the **existing** Shiro authentication (an already-authenticated user calls it).
+- Mints a short-lived **signed** token. Claims: subject = user UUID, `context`, `iss`, `aud`, `jti`, `exp` (~30–60 min), `iat`. **No** admin/orgAdmin/role claims (privileges are resolved fresh by the kernel per request).
+- Signing: **asymmetric** (decided — the service runs remote). Wildbook holds the private signing key; the remote kernel validates with the public key only, so a kernel compromise cannot mint tokens. Key id in header + rotation support.
+- Must have an **explicit** Shiro filter rule in `web.xml` (existing config covers only selected `/api/v3/...` paths; do not assume coverage). CSRF protection if the caller is cookie-authenticated.
+- No server-side session state required beyond signing keys; refresh = re-call with Basic auth.
+
+### B2 — Live `canUserAccess` check (defense-in-depth backstop)
+- An authenticated endpoint (admin/service-scoped) that, given a user UUID and a set of encounter IDs, returns the subset that user may access — computed from **live** `Collaboration`/role objects, **not** from the indexed `viewUsers`.
+- **Use the correct authorization entry point.** `Collaboration.canUserAccessEncounter(enc, context, username)` does **not** check admin and only does username-based collaboration (`Collaboration.java:465–470`); admin handling lives in `Encounter.canUserView` (`Encounter.java:3316–3318`). B2 must resolve the UUID to a `User` **in the requested context** and call `Encounter.canUserView(user, shepherd)` (or an audited equivalent), never the bare string overload — otherwise admins are wrongly denied and the result is unsound.
+- Batched (accept up to a page of IDs per call) so the kernel can re-validate a result page cheaply.
+- Purpose: closes the residual `viewUsers` staleness window for the user-facing API even after Artifact A; the kernel pre-filters on `viewUsers` for speed, then confirms the returned page against this live check.
+
+### Tests
+- Token: valid/expired/tampered signature; wrong `aud`/`iss`; context isolation (a token issued in `context0` cannot be used to read another context's data); admin claim in token is ignored (privileges resolved fresh).
+- canUserAccess: matches `Encounter.canUserView` for owner / approved-collab / orgAdmin / rejected-collab / public / admin cases; correctly excludes a just-rejected collaborator even when `viewUsers` is still stale.
+
+## Out of scope / follow-ups
+- Denormalizing ACL fields onto annotation/individual/occurrence indices (the external API is encounter-index-only for v1; see co-scientist spec).
+- Write/agentic endpoints (v1 is read-only).
+- Multi-context productionization beyond a mandatory indexed `context` field + per-request context scoping (see co-scientist spec § ACL boundary).
+
+## Open questions for review
+1. ~~Cost of computing the ACL on every full index~~ — **resolved** (Codex design review): two paths, single-encounter recompute + bulk ACL snapshot; never re-emit stale index value.
+2. ~~Symmetric vs. asymmetric token signing~~ — **resolved: asymmetric.** The service runs remote, so the signing (minting) key must never leave Wildbook; the remote kernel holds only the public verify key. Support key id + rotation.
+3. Should revocation-triggered reindex be synchronous-ish (security) or rely on the existing async queue (simplicity)? What revocation latency is acceptable given B2 backstops the user-facing path?
+4. Context handling (see co-scientist spec): v1 targets a single Wildbook context (typically `context0`); true multi-context scoping requires a mandatory indexed `context` field on **both** the encounter and annotation indices (none exists today) — confirm v1 may assume single-context.

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <testcontainers.version>2.0.3</testcontainers.version>
     <rest-assured.version>5.4.0</rest-assured.version>
     <wiremock.version>3.3.1</wiremock.version>
+    <jjwt.version>0.12.6</jjwt.version>
   </properties>
 
   <repositories>
@@ -616,6 +617,25 @@
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
       <version>2.3.0.1</version>
+    </dependency>
+
+    <!-- JWT signing / verification for scoped-access tokens -->
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>${jjwt.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>${jjwt.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>${jjwt.version}</version>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/ecocean/api/AuthToken.java
+++ b/src/main/java/org/ecocean/api/AuthToken.java
@@ -1,0 +1,84 @@
+package org.ecocean.api;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.User;
+import org.ecocean.Util;
+import org.ecocean.api.auth.JwtService;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+
+/**
+ * POST /api/v3/auth/token
+ * Gated by existing Shiro auth (authcBasicWildbook). Mints a short-lived
+ * RS256 token carrying only the caller's identity (uuid + context). The
+ * external scoped-access kernel validates it with the public key.
+ */
+public class AuthToken extends ApiBase {
+    private static final long DEFAULT_TTL_MILLIS = 30L * 60L * 1000L; // 30 min
+
+    @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+        String context = ServletUtilities.getContext(request);
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("api.AuthToken.doPost");
+        myShepherd.beginDBTransaction();
+        try {
+            User user = myShepherd.getUser(request);
+            if (user == null) {
+                writeError(response, 401, "unauthenticated");
+                return;
+            }
+            // SECURITY (Codex High #1): pin the token context SERVER-SIDE. Do NOT
+            // sign ServletUtilities.getContext(request) — it honors a caller's
+            // ?context=, while Basic auth authenticates only against context0, so a
+            // caller-influenced context claim would let a user mint a token for a
+            // context they didn't authenticate in. v1 is single-context.
+            String tokenContext = org.ecocean.CommonConfiguration.getProperty("jwtContext", context);
+            if (!Util.stringExists(tokenContext)) tokenContext = "context0";
+            JwtService jwt = JwtService.fromConfig(tokenContext);
+            if (!jwt.isEnabled()) {
+                writeError(response, 503, "token issuance not configured");
+                return;
+            }
+            long ttl = ttlFromConfig(tokenContext);
+            String token = jwt.sign(user.getId(), tokenContext, ttl);
+            JSONObject out = new JSONObject();
+            out.put("token", token);
+            out.put("tokenType", "Bearer");
+            out.put("expiresInSeconds", ttl / 1000L);
+            response.setStatus(200);
+            response.setContentType("application/json");
+            response.getWriter().write(out.toString());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            writeError(response, 500, "token issuance failed");
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private long ttlFromConfig(String context) {
+        String v = org.ecocean.CommonConfiguration.getProperty("jwtTtlSeconds", context);
+        if (Util.stringExists(v)) {
+            try {
+                long secs = Long.parseLong(v.trim());
+                // Codex Low: clamp to a sane range (1 min .. 24 h)
+                secs = Math.max(60L, Math.min(secs, 24L * 3600L));
+                return secs * 1000L;
+            } catch (NumberFormatException ignore) {}
+        }
+        return DEFAULT_TTL_MILLIS;
+    }
+
+    private void writeError(HttpServletResponse response, int code, String message)
+        throws IOException {
+        response.setStatus(code);
+        response.setContentType("application/json");
+        response.getWriter().write(new JSONObject().put("success", false)
+            .put("error", message).toString());
+    }
+}

--- a/src/main/java/org/ecocean/api/AuthToken.java
+++ b/src/main/java/org/ecocean/api/AuthToken.java
@@ -7,7 +7,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.ecocean.User;
 import org.ecocean.Util;
 import org.ecocean.api.auth.JwtService;
-import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
 import org.json.JSONObject;
 
@@ -22,7 +21,11 @@ public class AuthToken extends ApiBase {
 
     @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
-        String context = ServletUtilities.getContext(request);
+        // SECURITY (Codex High): pin to the fixed auth context. Basic auth authenticates
+        // against context0 (WildbookBasicHttpAuthenticationFilter), so the user lookup,
+        // signing key/config, and the token's context claim must ALL come from context0 —
+        // never from ServletUtilities.getContext(request), which honors ?context=.
+        final String context = "context0";
         Shepherd myShepherd = new Shepherd(context);
         myShepherd.setAction("api.AuthToken.doPost");
         myShepherd.beginDBTransaction();
@@ -32,11 +35,6 @@ public class AuthToken extends ApiBase {
                 writeError(response, 401, "unauthenticated");
                 return;
             }
-            // SECURITY (Codex High #1): pin the token context SERVER-SIDE. Do NOT
-            // sign ServletUtilities.getContext(request) — it honors a caller's
-            // ?context=, while Basic auth authenticates only against context0, so a
-            // caller-influenced context claim would let a user mint a token for a
-            // context they didn't authenticate in. v1 is single-context.
             String tokenContext = org.ecocean.CommonConfiguration.getProperty("jwtContext", context);
             if (!Util.stringExists(tokenContext)) tokenContext = "context0";
             JwtService jwt = JwtService.fromConfig(tokenContext);

--- a/src/main/java/org/ecocean/api/CanUserAccess.java
+++ b/src/main/java/org/ecocean/api/CanUserAccess.java
@@ -2,8 +2,6 @@ package org.ecocean.api;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -42,18 +40,33 @@ public class CanUserAccess extends ApiBase {
                 writeError(response, 403, "admin required");
                 return;
             }
-            // Codex Medium: validate content-type + cap body size BEFORE reading/parsing.
+            // Fix 3 (Low): parse media type before ';' for an exact match — reject
+            // types like "text/application/json" or "application/json-patch+json".
             String ctype = request.getContentType();
-            if (ctype == null || !ctype.toLowerCase().contains("application/json")) {
+            if (ctype == null) {
                 writeError(response, 415, "Content-Type must be application/json");
                 return;
             }
+            String mediaType = ctype.split(";")[0].trim().toLowerCase();
+            if (!mediaType.equals("application/json")) {
+                writeError(response, 415, "Content-Type must be application/json");
+                return;
+            }
+            // Fix 2 (Medium): pre-flight Content-Length guard.
             if (request.getContentLengthLong() > MAX_BODY_BYTES) {
                 writeError(response, 413, "request body too large");
                 return;
             }
-            JSONObject body = readBody(request);
-            if (body == null) { writeError(response, 400, "invalid JSON body"); return; }
+            JSONObject body;
+            try {
+                body = readBody(request);
+            } catch (BodyTooLargeException ex) {
+                writeError(response, 413, "request body too large");
+                return;
+            } catch (Exception ex) {
+                writeError(response, 400, "invalid JSON body");
+                return;
+            }
             String userUuid = body.optString("userUuid", null);
             JSONArray idsArr = body.optJSONArray("encounterIds");
             if (!Util.stringExists(userUuid) || idsArr == null) {
@@ -90,19 +103,28 @@ public class CanUserAccess extends ApiBase {
         }
     }
 
-    private JSONObject readBody(HttpServletRequest request) {
-        try {
-            StringBuilder sb = new StringBuilder();
-            BufferedReader r = request.getReader();
-            String line;
-            while ((line = r.readLine()) != null) {
-                sb.append(line);
-                if (sb.length() > MAX_BODY_BYTES) return null; // cap even if Content-Length lied
-            }
-            return new JSONObject(sb.toString());
-        } catch (Exception ex) {
-            return null;
+    /** Thrown by readBody when the request body exceeds MAX_BODY_BYTES. */
+    private static final class BodyTooLargeException extends Exception {
+        BodyTooLargeException() { super("request body too large"); }
+    }
+
+    /**
+     * Fix 2 (Medium): read body in chunks, counting ALL bytes read (not just
+     * newline-stripped line lengths). Throws BodyTooLargeException on overflow
+     * (maps to 413) and JSONException on bad JSON (maps to 400).
+     */
+    private JSONObject readBody(HttpServletRequest request) throws IOException, BodyTooLargeException {
+        StringBuilder sb = new StringBuilder();
+        BufferedReader r = request.getReader();
+        char[] buf = new char[8192];
+        long total = 0;
+        int n;
+        while ((n = r.read(buf)) != -1) {
+            total += n;
+            if (total > MAX_BODY_BYTES) throw new BodyTooLargeException();
+            sb.append(buf, 0, n);
         }
+        return new JSONObject(sb.toString()); // throws JSONException on invalid input
     }
 
     private void writeError(HttpServletResponse response, int code, String message)

--- a/src/main/java/org/ecocean/api/CanUserAccess.java
+++ b/src/main/java/org/ecocean/api/CanUserAccess.java
@@ -1,0 +1,115 @@
+package org.ecocean.api;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.Encounter;
+import org.ecocean.User;
+import org.ecocean.Util;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * POST /api/v3/can-user-access
+ * Admin/service-scoped. Body: {"userUuid": "...", "encounterIds": ["...", ...]}.
+ * Returns {"accessible": ["...", ...]} — the subset of encounterIds the target
+ * user may VIEW, computed from LIVE Collaboration/role objects (not the indexed
+ * viewUsers). Defense-in-depth backstop for the scoped-query kernel.
+ */
+public class CanUserAccess extends ApiBase {
+    private static final int MAX_IDS = 200;
+    private static final long MAX_BODY_BYTES = 64L * 1024L; // cap request body (Codex Medium)
+
+    @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+        String context = ServletUtilities.getContext(request);
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("api.CanUserAccess.doPost");
+        myShepherd.beginDBTransaction();
+        try {
+            User caller = myShepherd.getUser(request);
+            if (caller == null) {
+                writeError(response, 401, "unauthenticated");
+                return;
+            }
+            if (!caller.isAdmin(myShepherd)) {
+                writeError(response, 403, "admin required");
+                return;
+            }
+            // Codex Medium: validate content-type + cap body size BEFORE reading/parsing.
+            String ctype = request.getContentType();
+            if (ctype == null || !ctype.toLowerCase().contains("application/json")) {
+                writeError(response, 415, "Content-Type must be application/json");
+                return;
+            }
+            if (request.getContentLengthLong() > MAX_BODY_BYTES) {
+                writeError(response, 413, "request body too large");
+                return;
+            }
+            JSONObject body = readBody(request);
+            if (body == null) { writeError(response, 400, "invalid JSON body"); return; }
+            String userUuid = body.optString("userUuid", null);
+            JSONArray idsArr = body.optJSONArray("encounterIds");
+            if (!Util.stringExists(userUuid) || idsArr == null) {
+                writeError(response, 400, "userUuid and encounterIds required");
+                return;
+            }
+            if (idsArr.length() > MAX_IDS) {
+                writeError(response, 400, "too many encounterIds (max " + MAX_IDS + ")");
+                return;
+            }
+            User target = myShepherd.getUserByUUID(userUuid);
+            JSONArray accessible = new JSONArray();
+            // target==null -> empty accessible set (unknown user sees nothing)
+            if (target != null) {
+                for (int i = 0; i < idsArr.length(); i++) {
+                    String encId = idsArr.optString(i, null);
+                    if (!Util.stringExists(encId)) continue;
+                    Encounter enc = myShepherd.getEncounter(encId);
+                    if (enc != null && enc.canUserView(target, myShepherd)) {
+                        accessible.put(encId);
+                    }
+                }
+            }
+            JSONObject out = new JSONObject();
+            out.put("accessible", accessible);
+            response.setStatus(200);
+            response.setContentType("application/json");
+            response.getWriter().write(out.toString());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            writeError(response, 500, "canUserAccess failed");
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private JSONObject readBody(HttpServletRequest request) {
+        try {
+            StringBuilder sb = new StringBuilder();
+            BufferedReader r = request.getReader();
+            String line;
+            while ((line = r.readLine()) != null) {
+                sb.append(line);
+                if (sb.length() > MAX_BODY_BYTES) return null; // cap even if Content-Length lied
+            }
+            return new JSONObject(sb.toString());
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    private void writeError(HttpServletResponse response, int code, String message)
+        throws IOException {
+        response.setStatus(code);
+        response.setContentType("application/json");
+        response.getWriter().write(new JSONObject().put("success", false)
+            .put("error", message).toString());
+    }
+}

--- a/src/main/java/org/ecocean/api/CanUserAccess.java
+++ b/src/main/java/org/ecocean/api/CanUserAccess.java
@@ -1,7 +1,8 @@
 package org.ecocean.api;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -63,7 +64,8 @@ public class CanUserAccess extends ApiBase {
             } catch (BodyTooLargeException ex) {
                 writeError(response, 413, "request body too large");
                 return;
-            } catch (Exception ex) {
+            }
+            if (body == null) {
                 writeError(response, 400, "invalid JSON body");
                 return;
             }
@@ -109,22 +111,29 @@ public class CanUserAccess extends ApiBase {
     }
 
     /**
-     * Fix 2 (Medium): read body in chunks, counting ALL bytes read (not just
-     * newline-stripped line lengths). Throws BodyTooLargeException on overflow
-     * (maps to 413) and JSONException on bad JSON (maps to 400).
+     * Fix 2 (Medium): read raw bytes from the input stream, counting actual bytes
+     * against MAX_BODY_BYTES so multibyte UTF-8 sequences cannot evade the cap.
+     * Throws BodyTooLargeException on overflow (maps to 413); returns null on any
+     * other read/parse error (maps to 400 in doPost).
      */
-    private JSONObject readBody(HttpServletRequest request) throws IOException, BodyTooLargeException {
-        StringBuilder sb = new StringBuilder();
-        BufferedReader r = request.getReader();
-        char[] buf = new char[8192];
-        long total = 0;
-        int n;
-        while ((n = r.read(buf)) != -1) {
-            total += n;
-            if (total > MAX_BODY_BYTES) throw new BodyTooLargeException();
-            sb.append(buf, 0, n);
+    private JSONObject readBody(HttpServletRequest request) throws BodyTooLargeException {
+        try {
+            InputStream in = request.getInputStream();
+            java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+            byte[] buf = new byte[8192];
+            long total = 0;
+            int n;
+            while ((n = in.read(buf)) != -1) {
+                total += n;
+                if (total > MAX_BODY_BYTES) throw new BodyTooLargeException();
+                bos.write(buf, 0, n);
+            }
+            return new JSONObject(new String(bos.toByteArray(), StandardCharsets.UTF_8));
+        } catch (BodyTooLargeException e) {
+            throw e;                 // -> 413 in doPost
+        } catch (Exception ex) {
+            return null;             // -> 400 invalid JSON in doPost
         }
-        return new JSONObject(sb.toString()); // throws JSONException on invalid input
     }
 
     private void writeError(HttpServletResponse response, int code, String message)

--- a/src/main/java/org/ecocean/api/auth/JwtService.java
+++ b/src/main/java/org/ecocean/api/auth/JwtService.java
@@ -10,6 +10,7 @@ import java.util.Date;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 
 import org.ecocean.CommonConfiguration;
@@ -107,11 +108,19 @@ public class JwtService {
 
     public Jws<Claims> verify(String token) {
         if (publicKey == null) throw new IllegalStateException("JwtService cannot verify (no public key)");
-        return Jwts.parser()
+        Jws<Claims> jws = Jwts.parser()
             .requireIssuer(issuer)
             .requireAudience(audience)
             .verifyWith(publicKey)
             .build()
             .parseSignedClaims(token);
+        // Pin to RS256: reject same-key tokens signed with a different RSA/PSS variant.
+        // jjwt 0.12.6's sig().clear().add() API throws IAE before build(), so we check
+        // the algorithm header explicitly after a successful signature verification.
+        String alg = jws.getHeader().getAlgorithm();
+        if (!Jwts.SIG.RS256.getId().equals(alg)) {
+            throw new JwtException("JWT algorithm '" + alg + "' is not accepted; only RS256 is allowed");
+        }
+        return jws;
     }
 }

--- a/src/main/java/org/ecocean/api/auth/JwtService.java
+++ b/src/main/java/org/ecocean/api/auth/JwtService.java
@@ -1,0 +1,117 @@
+package org.ecocean.api.auth;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+
+import org.ecocean.CommonConfiguration;
+import org.ecocean.Util;
+
+/**
+ * Issues and verifies short-lived RS256 JWTs that carry ONLY identity
+ * (subject = user UUID, context). No admin/role claims — the consumer
+ * resolves privileges fresh. Wildbook holds the private (signing) key;
+ * the external scoped-access kernel holds the public key.
+ *
+ * Keys are RSA, supplied as Base64 of the encoded key bytes (private = PKCS8,
+ * public = X.509), via commonConfiguration.properties:
+ *   jwtPrivateKeyBase64=...   (signing; required to mint tokens)
+ *   jwtPublicKeyBase64=...    (verify; optional Wildbook-side)
+ *   jwtIssuer=wildbook
+ *   jwtAudience=wildbook-scoped-api
+ * If the private key is absent, the service is "disabled" and the token
+ * endpoint returns 503.
+ */
+public class JwtService {
+    private final PrivateKey privateKey;
+    private final PublicKey publicKey;
+    private final String issuer;
+    private final String audience;
+    private final String keyId; // JWT header 'kid' for key rotation (Codex Medium); may be null
+
+    private JwtService(PrivateKey priv, PublicKey pub, String issuer, String audience,
+        String keyId) {
+        this.privateKey = priv;
+        this.publicKey = pub;
+        this.issuer = issuer;
+        this.audience = audience;
+        this.keyId = keyId;
+    }
+
+    // test/explicit overload without a keyId
+    public static JwtService fromBase64Keys(String privB64, String pubB64, String issuer,
+        String audience) {
+        return fromBase64Keys(privB64, pubB64, issuer, audience, null);
+    }
+
+    public static JwtService fromBase64Keys(String privB64, String pubB64, String issuer,
+        String audience, String keyId) {
+        PrivateKey priv = null;
+        PublicKey pub = null;
+        try {
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            if (Util.stringExists(privB64)) {
+                priv = kf.generatePrivate(
+                    new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privB64.trim())));
+            }
+            if (Util.stringExists(pubB64)) {
+                pub = kf.generatePublic(
+                    new X509EncodedKeySpec(Base64.getDecoder().decode(pubB64.trim())));
+            }
+        } catch (Exception ex) {
+            System.out.println("JwtService: failed to load keys: " + ex);
+        }
+        return new JwtService(priv, pub, issuer, audience, keyId);
+    }
+
+    public static JwtService fromConfig(String context) {
+        return fromBase64Keys(
+            CommonConfiguration.getProperty("jwtPrivateKeyBase64", context),
+            CommonConfiguration.getProperty("jwtPublicKeyBase64", context),
+            orDefault(CommonConfiguration.getProperty("jwtIssuer", context), "wildbook"),
+            orDefault(CommonConfiguration.getProperty("jwtAudience", context),
+                "wildbook-scoped-api"),
+            CommonConfiguration.getProperty("jwtKeyId", context)); // may be null
+    }
+
+    private static String orDefault(String v, String d) {
+        return Util.stringExists(v) ? v : d;
+    }
+
+    public boolean isEnabled() {
+        return privateKey != null;
+    }
+
+    public String sign(String userUuid, String context, long ttlMillis) {
+        if (!isEnabled()) throw new IllegalStateException("JwtService not enabled (no private key)");
+        long now = System.currentTimeMillis();
+        io.jsonwebtoken.JwtBuilder b = Jwts.builder()
+            .issuer(issuer)
+            .audience().add(audience).and()
+            .subject(userUuid)
+            .claim("context", context)
+            .id(Util.generateUUID())
+            .issuedAt(new Date(now))
+            .expiration(new Date(now + ttlMillis));
+        if (Util.stringExists(keyId)) b.header().keyId(keyId).and(); // 'kid' for rotation
+        return b.signWith(privateKey, Jwts.SIG.RS256).compact();
+    }
+
+    public Jws<Claims> verify(String token) {
+        if (publicKey == null) throw new IllegalStateException("JwtService cannot verify (no public key)");
+        return Jwts.parser()
+            .requireIssuer(issuer)
+            .requireAudience(audience)
+            .verifyWith(publicKey)
+            .build()
+            .parseSignedClaims(token);
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -100,6 +100,7 @@
 
 				# ===== v3 API Security =====
 				/api/v3/auth/token = authcBasicWildbook
+				/api/v3/can-user-access = authcBasicWildbook, roles[admin]
 				/api/v3/bulk-import = authc
 				/api/v3/bulk-import/** = authc
 				/api/v3/bulk-export = authc
@@ -543,6 +544,16 @@
 	<servlet-mapping>
 		<servlet-name>AuthToken</servlet-name>
 		<url-pattern>/api/v3/auth/token</url-pattern>
+	</servlet-mapping>
+
+	<servlet>
+		<servlet-name>CanUserAccess</servlet-name>
+		<servlet-class>org.ecocean.api.CanUserAccess</servlet-class>
+	</servlet>
+
+	<servlet-mapping>
+		<servlet-name>CanUserAccess</servlet-name>
+		<url-pattern>/api/v3/can-user-access</url-pattern>
 	</servlet-mapping>
 
 	<servlet>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -99,6 +99,7 @@
 				/LightRest/** = authcBasicWildbook,roles[researcher]
 
 				# ===== v3 API Security =====
+				/api/v3/auth/token = authcBasicWildbook
 				/api/v3/bulk-import = authc
 				/api/v3/bulk-import/** = authc
 				/api/v3/bulk-export = authc
@@ -532,6 +533,16 @@
 	<servlet-mapping>
 		<servlet-name>MatchInspection</servlet-name>
 		<url-pattern>/api/v3/match-inspection/*</url-pattern>
+	</servlet-mapping>
+
+	<servlet>
+		<servlet-name>AuthToken</servlet-name>
+		<servlet-class>org.ecocean.api.AuthToken</servlet-class>
+	</servlet>
+
+	<servlet-mapping>
+		<servlet-name>AuthToken</servlet-name>
+		<url-pattern>/api/v3/auth/token</url-pattern>
 	</servlet-mapping>
 
 	<servlet>

--- a/src/test/java/org/ecocean/api/AuthTokenTest.java
+++ b/src/test/java/org/ecocean/api/AuthTokenTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -63,6 +64,46 @@ class AuthTokenTest {
             JSONObject json = new JSONObject(body);
             assertFalse(json.optBoolean("success", true), "success must be false");
             assertEquals("unauthenticated", json.optString("error"), "error message");
+        }
+    }
+
+    /**
+     * SECURITY regression: the Shepherd must always be constructed with "context0",
+     * regardless of ?context= or any other request parameter.
+     * A caller supplying context=evilcontext must not shift user lookup or key config
+     * to another context. We capture the first constructor arg via MockedConstruction
+     * and assert it equals "context0".
+     * The request is also unauthenticated (getUser→null) so we get a 401, confirming
+     * the servlet completed the pinned construction path before returning.
+     */
+    @Test
+    void requestContextParamIgnored() throws Exception {
+        // Make the request look like it carries a context override
+        when(mockRequest.getParameter("context")).thenReturn("evilcontext");
+
+        AtomicReference<String> capturedCtorArg = new AtomicReference<>();
+
+        try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    // ctx.arguments() holds the constructor args; first arg is the context String
+                    if (!ctx.arguments().isEmpty()) {
+                        capturedCtorArg.set(String.valueOf(ctx.arguments().get(0)));
+                    }
+                    doNothing().when(mock).beginDBTransaction();
+                    doNothing().when(mock).setAction(anyString());
+                    doNothing().when(mock).rollbackAndClose();
+                    // unauthenticated → servlet returns 401 without attempting to sign
+                    when(mock.getUser(any(HttpServletRequest.class))).thenReturn(null);
+                })) {
+            AuthToken servlet = new AuthToken();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            // Shepherd must have been constructed with the pinned context, not "evilcontext"
+            assertEquals("context0", capturedCtorArg.get(),
+                "Shepherd must be constructed with pinned context0, not a request-derived value");
+            // Unauthenticated → 401 (confirms the code path ran fully through construction)
+            verify(mockResponse).setStatus(401);
         }
     }
 

--- a/src/test/java/org/ecocean/api/AuthTokenTest.java
+++ b/src/test/java/org/ecocean/api/AuthTokenTest.java
@@ -1,0 +1,102 @@
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.User;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+class AuthTokenTest {
+
+    HttpServletRequest mockRequest;
+    HttpServletResponse mockResponse;
+    StringWriter responseOut;
+    PrintWriter writer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockRequest = mock(HttpServletRequest.class);
+        mockResponse = mock(HttpServletResponse.class);
+        responseOut = new StringWriter();
+        writer = new PrintWriter(responseOut);
+        when(mockResponse.getWriter()).thenReturn(writer);
+        // getContext(request) reads servletContext; return "context0" for tests
+        when(mockRequest.getServletContext()).thenReturn(null);
+        when(mockRequest.getContextPath()).thenReturn("");
+    }
+
+    /**
+     * Primary protection gate: unauthenticated caller (getUser returns null) → 401.
+     * This is the most important unit-testable gate: the endpoint must reject requests
+     * where Shiro passed but no User principal was resolved.
+     */
+    @Test
+    void unauthenticated_returns401() throws Exception {
+        try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    doNothing().when(mock).beginDBTransaction();
+                    doNothing().when(mock).setAction(anyString());
+                    doNothing().when(mock).rollbackAndClose();
+                    when(mock.getUser(any(HttpServletRequest.class))).thenReturn(null);
+                })) {
+            AuthToken servlet = new AuthToken();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            verify(mockResponse).setStatus(401);
+            String body = responseOut.toString();
+            assertFalse(body.isEmpty(), "response body must not be empty");
+            JSONObject json = new JSONObject(body);
+            assertFalse(json.optBoolean("success", true), "success must be false");
+            assertEquals("unauthenticated", json.optString("error"), "error message");
+        }
+    }
+
+    /**
+     * JwtService disabled (no private key configured) → 503.
+     * Exercises the second gate after successful auth.
+     */
+    @Test
+    void jwtDisabled_returns503() throws Exception {
+        User fakeUser = new User();
+        fakeUser.setUsername("test-user");
+
+        try (MockedStatic<org.ecocean.CommonConfiguration> mockConfig =
+                mockStatic(org.ecocean.CommonConfiguration.class);
+             MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                 (mock, ctx) -> {
+                     doNothing().when(mock).beginDBTransaction();
+                     doNothing().when(mock).setAction(anyString());
+                     doNothing().when(mock).rollbackAndClose();
+                     when(mock.getUser(any(HttpServletRequest.class))).thenReturn(fakeUser);
+                 })) {
+            // All CommonConfiguration.getProperty calls return null → JwtService disabled
+            mockConfig.when(() -> org.ecocean.CommonConfiguration.getProperty(
+                anyString(), anyString())).thenReturn(null);
+
+            AuthToken servlet = new AuthToken();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            verify(mockResponse).setStatus(503);
+            String body = responseOut.toString();
+            JSONObject json = new JSONObject(body);
+            assertFalse(json.optBoolean("success", true), "success must be false");
+            assertEquals("token issuance not configured", json.optString("error"));
+        }
+    }
+}

--- a/src/test/java/org/ecocean/api/CanUserAccessTest.java
+++ b/src/test/java/org/ecocean/api/CanUserAccessTest.java
@@ -5,12 +5,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -30,6 +32,17 @@ class CanUserAccessTest {
     HttpServletResponse mockResponse;
     StringWriter responseOut;
     PrintWriter writer;
+
+    /** Wraps a byte array as a ServletInputStream for mocking getInputStream(). */
+    private static ServletInputStream servletInputStreamOf(byte[] bytes) {
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        return new ServletInputStream() {
+            @Override public int read() throws IOException { return bais.read(); }
+            @Override public boolean isFinished() { return bais.available() == 0; }
+            @Override public boolean isReady() { return true; }
+            @Override public void setReadListener(ReadListener rl) {}
+        };
+    }
 
     @BeforeEach
     void setUp() throws IOException {
@@ -96,8 +109,8 @@ class CanUserAccessTest {
         reqBody.put("userUuid", targetUuid);
         reqBody.put("encounterIds", new JSONArray().put(enc1Id).put(enc2Id));
 
-        when(mockRequest.getReader()).thenReturn(
-            new BufferedReader(new StringReader(reqBody.toString())));
+        when(mockRequest.getInputStream()).thenReturn(
+            servletInputStreamOf(reqBody.toString().getBytes(StandardCharsets.UTF_8)));
 
         try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
                 (mock, ctx) -> {
@@ -138,8 +151,8 @@ class CanUserAccessTest {
         reqBody.put("userUuid", unknownUuid);
         reqBody.put("encounterIds", new JSONArray().put("enc-aaa").put("enc-bbb"));
 
-        when(mockRequest.getReader()).thenReturn(
-            new BufferedReader(new StringReader(reqBody.toString())));
+        when(mockRequest.getInputStream()).thenReturn(
+            servletInputStreamOf(reqBody.toString().getBytes(StandardCharsets.UTF_8)));
 
         try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
                 (mock, ctx) -> {

--- a/src/test/java/org/ecocean/api/CanUserAccessTest.java
+++ b/src/test/java/org/ecocean/api/CanUserAccessTest.java
@@ -1,0 +1,164 @@
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.Encounter;
+import org.ecocean.User;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+class CanUserAccessTest {
+
+    HttpServletRequest mockRequest;
+    HttpServletResponse mockResponse;
+    StringWriter responseOut;
+    PrintWriter writer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockRequest = mock(HttpServletRequest.class);
+        mockResponse = mock(HttpServletResponse.class);
+        responseOut = new StringWriter();
+        writer = new PrintWriter(responseOut);
+        when(mockResponse.getWriter()).thenReturn(writer);
+        // getContext(request) reads servletContext + contextPath
+        when(mockRequest.getServletContext()).thenReturn(null);
+        when(mockRequest.getContextPath()).thenReturn("");
+        // default: reasonable content-type and size for tests that reach parsing
+        when(mockRequest.getContentType()).thenReturn("application/json");
+        when(mockRequest.getContentLengthLong()).thenReturn(100L);
+    }
+
+    /**
+     * (a) Non-admin caller → 403.
+     * The PRIMARY admin gate must reject any authenticated user who is not admin.
+     */
+    @Test
+    void nonAdminCaller_returns403() throws Exception {
+        User callerUser = mock(User.class);
+
+        try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    doNothing().when(mock).beginDBTransaction();
+                    doNothing().when(mock).setAction(anyString());
+                    doNothing().when(mock).rollbackAndClose();
+                    when(mock.getUser(any(HttpServletRequest.class))).thenReturn(callerUser);
+                    when(callerUser.isAdmin(mock)).thenReturn(false);
+                })) {
+            CanUserAccess servlet = new CanUserAccess();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            verify(mockResponse).setStatus(403);
+            String body = responseOut.toString();
+            assertFalse(body.isEmpty(), "response body must not be empty");
+            JSONObject json = new JSONObject(body);
+            assertFalse(json.optBoolean("success", true), "success must be false");
+            assertEquals("admin required", json.optString("error"), "error message");
+        }
+    }
+
+    /**
+     * (b) Admin caller, target user, two encounters:
+     *   - enc1: canUserView → true  → must appear in accessible
+     *   - enc2: canUserView → false → must NOT appear
+     */
+    @Test
+    void adminCaller_filtersEncountersByCanUserView() throws Exception {
+        User callerUser = mock(User.class);
+        User targetUser = mock(User.class);
+
+        Encounter enc1 = mock(Encounter.class);
+        Encounter enc2 = mock(Encounter.class);
+
+        String enc1Id = "enc-visible-001";
+        String enc2Id = "enc-hidden-002";
+        String targetUuid = "target-uuid-abc";
+
+        JSONObject reqBody = new JSONObject();
+        reqBody.put("userUuid", targetUuid);
+        reqBody.put("encounterIds", new JSONArray().put(enc1Id).put(enc2Id));
+
+        when(mockRequest.getReader()).thenReturn(
+            new BufferedReader(new StringReader(reqBody.toString())));
+
+        try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    doNothing().when(mock).beginDBTransaction();
+                    doNothing().when(mock).setAction(anyString());
+                    doNothing().when(mock).rollbackAndClose();
+                    when(mock.getUser(any(HttpServletRequest.class))).thenReturn(callerUser);
+                    when(callerUser.isAdmin(mock)).thenReturn(true);
+                    when(mock.getUserByUUID(targetUuid)).thenReturn(targetUser);
+                    when(mock.getEncounter(enc1Id)).thenReturn(enc1);
+                    when(mock.getEncounter(enc2Id)).thenReturn(enc2);
+                    when(enc1.canUserView(targetUser, mock)).thenReturn(true);
+                    when(enc2.canUserView(targetUser, mock)).thenReturn(false);
+                })) {
+            CanUserAccess servlet = new CanUserAccess();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            verify(mockResponse).setStatus(200);
+            String body = responseOut.toString();
+            JSONObject json = new JSONObject(body);
+            JSONArray accessible = json.getJSONArray("accessible");
+            assertEquals(1, accessible.length(), "only one encounter should be accessible");
+            assertEquals(enc1Id, accessible.getString(0), "the visible encounter id");
+        }
+    }
+
+    /**
+     * (c) Admin caller, unknown target uuid (getUserByUUID → null) → empty accessible.
+     * Fail-closed: unknown users see nothing.
+     */
+    @Test
+    void unknownTargetUuid_returnsEmptyAccessible() throws Exception {
+        User callerUser = mock(User.class);
+
+        String unknownUuid = "no-such-user-uuid";
+        JSONObject reqBody = new JSONObject();
+        reqBody.put("userUuid", unknownUuid);
+        reqBody.put("encounterIds", new JSONArray().put("enc-aaa").put("enc-bbb"));
+
+        when(mockRequest.getReader()).thenReturn(
+            new BufferedReader(new StringReader(reqBody.toString())));
+
+        try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    doNothing().when(mock).beginDBTransaction();
+                    doNothing().when(mock).setAction(anyString());
+                    doNothing().when(mock).rollbackAndClose();
+                    when(mock.getUser(any(HttpServletRequest.class))).thenReturn(callerUser);
+                    when(callerUser.isAdmin(mock)).thenReturn(true);
+                    when(mock.getUserByUUID(unknownUuid)).thenReturn(null);
+                })) {
+            CanUserAccess servlet = new CanUserAccess();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            verify(mockResponse).setStatus(200);
+            String body = responseOut.toString();
+            JSONObject json = new JSONObject(body);
+            JSONArray accessible = json.getJSONArray("accessible");
+            assertEquals(0, accessible.length(), "unknown user sees no encounters");
+        }
+    }
+}

--- a/src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
+++ b/src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
@@ -1,0 +1,176 @@
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Asserts that the AuthToken and CanUserAccess endpoints are both registered in
+ * web.xml AND gated by the appropriate Shiro rules.  No DB, no containers.
+ *
+ * <p>Maven runs tests with CWD = module root, so relative File paths resolve
+ * against the project root.
+ */
+class EndpointAuthWiringTest {
+
+    private static List<String> lines;
+
+    @BeforeAll
+    static void loadWebXml() throws Exception {
+        File webXml = new File("src/main/webapp/WEB-INF/web.xml");
+        assertTrue(webXml.exists(),
+                "web.xml not found at expected path: " + webXml.getAbsolutePath());
+        lines = Files.readAllLines(webXml.toPath());
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static String fullText() {
+        return String.join("\n", lines);
+    }
+
+    /** Returns the 0-based index of the first line that contains {@code needle}, or -1. */
+    private static int lineIndexOf(String needle) {
+        for (int i = 0; i < lines.size(); i++) {
+            if (lines.get(i).contains(needle)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    // -----------------------------------------------------------------------
+    // Assertion 1 & 2 — servlet registrations present
+    // -----------------------------------------------------------------------
+
+    @Test
+    void authToken_servletClassIsRegistered() {
+        assertTrue(fullText().contains("<servlet-class>org.ecocean.api.AuthToken</servlet-class>"),
+                "web.xml must contain a <servlet-class> declaration for org.ecocean.api.AuthToken");
+    }
+
+    @Test
+    void authToken_urlPatternIsRegistered() {
+        assertTrue(fullText().contains("<url-pattern>/api/v3/auth/token</url-pattern>"),
+                "web.xml must contain a <url-pattern> mapping for /api/v3/auth/token");
+    }
+
+    @Test
+    void canUserAccess_servletClassIsRegistered() {
+        assertTrue(fullText().contains("<servlet-class>org.ecocean.api.CanUserAccess</servlet-class>"),
+                "web.xml must contain a <servlet-class> declaration for org.ecocean.api.CanUserAccess");
+    }
+
+    @Test
+    void canUserAccess_urlPatternIsRegistered() {
+        assertTrue(fullText().contains("<url-pattern>/api/v3/can-user-access</url-pattern>"),
+                "web.xml must contain a <url-pattern> mapping for /api/v3/can-user-access");
+    }
+
+    // -----------------------------------------------------------------------
+    // Assertion 3 — /api/v3/auth/token is auth-gated (not anon)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void authToken_shiroRuleIsAuthGated() {
+        // Find the Shiro [urls] rule line for the token endpoint (non-comment)
+        String ruleLine = lines.stream()
+                .filter(l -> {
+                    String t = l.stripLeading();
+                    return !t.startsWith("#") && t.contains("/api/v3/auth/token");
+                })
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(ruleLine,
+                "Shiro [urls] must contain a rule line for /api/v3/auth/token");
+
+        // The rule value must not be just "anon"
+        String value = ruleLine.substring(ruleLine.indexOf("/api/v3/auth/token")
+                + "/api/v3/auth/token".length()).trim();
+        if (value.startsWith("=")) {
+            value = value.substring(1).trim();
+        }
+        assertFalse("anon".equalsIgnoreCase(value.trim()),
+                "Shiro rule for /api/v3/auth/token must not be 'anon' (was: '" + value + "')");
+
+        assertTrue(ruleLine.contains("authc"),
+                "Shiro rule for /api/v3/auth/token must contain 'authc' (was: '" + ruleLine.strip() + "')");
+    }
+
+    // -----------------------------------------------------------------------
+    // Assertion 4 — /api/v3/can-user-access requires roles[admin]
+    // -----------------------------------------------------------------------
+
+    @Test
+    void canUserAccess_shiroRuleRequiresAdminRole() {
+        String ruleLine = lines.stream()
+                .filter(l -> {
+                    String t = l.stripLeading();
+                    return !t.startsWith("#") && t.contains("/api/v3/can-user-access");
+                })
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(ruleLine,
+                "Shiro [urls] must contain a rule line for /api/v3/can-user-access");
+
+        assertTrue(ruleLine.contains("roles[admin]"),
+                "Shiro rule for /api/v3/can-user-access must contain 'roles[admin]' (was: '"
+                        + ruleLine.strip() + "')");
+    }
+
+    // -----------------------------------------------------------------------
+    // Assertion 5 — ordering guard: both new rules appear before /** catch-all
+    // -----------------------------------------------------------------------
+
+    @Test
+    void shiroRules_newEndpointsBeforeCatchAll() {
+        // Find the catch-all line, if any (/** = ..., not commented out)
+        int catchAllIdx = -1;
+        for (int i = 0; i < lines.size(); i++) {
+            String t = lines.get(i).stripLeading();
+            if (!t.startsWith("#") && t.startsWith("/**")) {
+                catchAllIdx = i;
+                break;
+            }
+        }
+
+        if (catchAllIdx == -1) {
+            // No catch-all — nothing to check
+            return;
+        }
+
+        int tokenRuleIdx = -1;
+        int canAccessRuleIdx = -1;
+        for (int i = 0; i < lines.size(); i++) {
+            String t = lines.get(i).stripLeading();
+            if (t.startsWith("#")) continue;
+            if (t.contains("/api/v3/auth/token") && tokenRuleIdx == -1) {
+                tokenRuleIdx = i;
+            }
+            if (t.contains("/api/v3/can-user-access") && canAccessRuleIdx == -1) {
+                canAccessRuleIdx = i;
+            }
+        }
+
+        assertNotEquals(-1, tokenRuleIdx,
+                "Shiro [urls] must have a rule for /api/v3/auth/token before the /** catch-all");
+        assertTrue(tokenRuleIdx < catchAllIdx,
+                "Shiro rule for /api/v3/auth/token (line " + (tokenRuleIdx + 1)
+                        + ") must appear before the /** catch-all (line " + (catchAllIdx + 1) + ")");
+
+        assertNotEquals(-1, canAccessRuleIdx,
+                "Shiro [urls] must have a rule for /api/v3/can-user-access before the /** catch-all");
+        assertTrue(canAccessRuleIdx < catchAllIdx,
+                "Shiro rule for /api/v3/can-user-access (line " + (canAccessRuleIdx + 1)
+                        + ") must appear before the /** catch-all (line " + (catchAllIdx + 1) + ")");
+    }
+}

--- a/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+++ b/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
@@ -1,0 +1,78 @@
+package org.ecocean.api.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.Test;
+
+class JwtServiceTest {
+
+    private JwtService serviceWithFreshKeys() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()); // PKCS8
+        String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());   // X.509
+        return JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+    }
+
+    @Test void signThenVerify_roundTrip() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("user-uuid-123", "context0", 60_000L); // 60s TTL
+        Jws<Claims> jws = svc.verify(token);
+        Claims c = jws.getPayload();
+        assertEquals("user-uuid-123", c.getSubject(), "subject = user uuid");
+        assertEquals("context0", c.get("context", String.class), "context claim");
+        assertEquals("wildbook", c.getIssuer(), "issuer");
+        assertNotNull(c.getId(), "jti present");
+        assertTrue(c.getExpiration().getTime() > System.currentTimeMillis(), "exp in future");
+        assertNull(c.get("admin"), "no admin claim");
+        assertNull(c.get("roles"), "no roles claim");
+    }
+
+    @Test void expiredToken_rejected() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("u", "context0", -1000L); // already expired
+        assertThrows(JwtException.class, () -> svc.verify(token), "expired token must be rejected");
+    }
+
+    @Test void tamperedToken_rejected() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("u", "context0", 60_000L);
+        String tampered = token.substring(0, token.length() - 2) + (token.endsWith("a") ? "bb" : "aa");
+        assertThrows(JwtException.class, () -> svc.verify(tampered), "bad signature must be rejected");
+    }
+
+    @Test void wrongAudienceOrIssuer_rejected() throws Exception {
+        // SAME keypair (valid signature), but the verifier requires a different
+        // issuer/audience — this genuinely exercises requireIssuer/requireAudience
+        // (a different-key test would pass even if those checks were removed).
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+
+        JwtService signer = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+        String token = signer.sign("u", "context0", 60_000L);
+
+        JwtService wrongIssuer = JwtService.fromBase64Keys(privB64, pubB64, "evil-issuer", "wildbook-scoped-api");
+        assertThrows(JwtException.class, () -> wrongIssuer.verify(token), "mismatched issuer must be rejected");
+
+        JwtService wrongAudience = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "some-other-aud");
+        assertThrows(JwtException.class, () -> wrongAudience.verify(token), "mismatched audience must be rejected");
+    }
+
+    @Test void disabledWhenKeysMissing() {
+        JwtService svc = JwtService.fromBase64Keys(null, null, "wildbook", "wildbook-scoped-api");
+        assertFalse(svc.isEnabled(), "service disabled without keys");
+        assertThrows(IllegalStateException.class, () -> svc.sign("u", "context0", 1000L),
+            "signing while disabled must throw");
+    }
+}

--- a/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+++ b/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
@@ -147,6 +147,45 @@ class JwtServiceTest {
             "HS256-with-RSA-public-key forged token must be rejected");
     }
 
+    // ------------------------------------------------------------------ //
+    // Key-ID (kid) header tests (key-rotation support, Fix 2)            //
+    // ------------------------------------------------------------------ //
+
+    /**
+     * When a keyId is supplied via the 5-arg overload, the signed token must
+     * carry a `kid` header that survives round-trip verification.
+     */
+    @Test void keyIdHeader_setWhenProvided() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pubB64  = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+
+        JwtService svc = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api", "key-1");
+        String token = svc.sign("kid-user", "context0", 60_000L);
+        Jws<Claims> jws = svc.verify(token);
+
+        // kid header must be propagated
+        assertEquals("key-1", jws.getHeader().getKeyId(), "kid header must equal supplied keyId");
+
+        // round-trip claims must still be correct
+        Claims c = jws.getPayload();
+        assertEquals("kid-user", c.getSubject(), "subject preserved with kid header");
+        assertEquals("wildbook", c.getIssuer(), "issuer preserved with kid header");
+    }
+
+    /**
+     * When no keyId is provided (4-arg overload), the `kid` header must be
+     * absent (null) — confirming the header is not injected spuriously.
+     */
+    @Test void keyIdHeader_absentWhenNotProvided() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("no-kid-user", "context0", 60_000L);
+        Jws<Claims> jws = svc.verify(token);
+        assertNull(jws.getHeader().getKeyId(), "kid header must be absent when no keyId supplied");
+    }
+
     /**
      * A token signed with RS384 using the SAME RSA private key must be rejected
      * once the verifier is pinned to RS256.  (This is the test that should FAIL

--- a/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+++ b/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
@@ -2,24 +2,41 @@ package org.ecocean.api.auth;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.util.Base64;
+import java.util.Date;
+
+import javax.crypto.spec.SecretKeySpec;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.Test;
 
 class JwtServiceTest {
 
+    /** Generates a fresh RSA-2048 keypair and returns a JwtService wired to it. */
     private JwtService serviceWithFreshKeys() throws Exception {
+        return serviceWithFreshKeys("wildbook", "wildbook-scoped-api");
+    }
+
+    private JwtService serviceWithFreshKeys(String issuer, String audience) throws Exception {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
         kpg.initialize(2048);
         KeyPair kp = kpg.generateKeyPair();
         String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()); // PKCS8
         String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());   // X.509
-        return JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+        return JwtService.fromBase64Keys(privB64, pubB64, issuer, audience);
+    }
+
+    /** Returns a fresh RSA-2048 KeyPair (used by algorithm-confusion tests). */
+    private KeyPair freshKeyPair() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
     }
 
     @Test void signThenVerify_roundTrip() throws Exception {
@@ -74,5 +91,85 @@ class JwtServiceTest {
         assertFalse(svc.isEnabled(), "service disabled without keys");
         assertThrows(IllegalStateException.class, () -> svc.sign("u", "context0", 1000L),
             "signing while disabled must throw");
+    }
+
+    // ------------------------------------------------------------------ //
+    // Algorithm-confusion regression tests (defence-in-depth, Fix 1)      //
+    // ------------------------------------------------------------------ //
+
+    /**
+     * alg=none UNSECURED JWT must be rejected.
+     * jjwt 0.12.x will not emit alg=none via its builder, so we craft the
+     * token string manually: base64url(header) + "." + base64url(payload) + "."
+     * (empty signature part) — which is the canonical unsecured-JWT form.
+     */
+    @Test void algNone_rejected() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+
+        Base64.Encoder b64url = Base64.getUrlEncoder().withoutPadding();
+        String header  = b64url.encodeToString(
+            "{\"alg\":\"none\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8));
+        long now = System.currentTimeMillis() / 1000;
+        String payload = b64url.encodeToString(
+            ("{\"iss\":\"wildbook\",\"aud\":\"wildbook-scoped-api\","
+                + "\"sub\":\"u\",\"iat\":" + now + ",\"exp\":" + (now + 3600) + "}")
+            .getBytes(StandardCharsets.UTF_8));
+        // canonical unsecured JWT: header.payload. (empty signature)
+        String unsecuredToken = header + "." + payload + ".";
+
+        assertThrows(JwtException.class, () -> svc.verify(unsecuredToken),
+            "alg=none token must be rejected");
+    }
+
+    /**
+     * HS256 token signed with the RSA public key's raw bytes as the HMAC secret
+     * must be rejected (algorithm-confusion / symmetric-with-asymmetric attack).
+     */
+    @Test void hs256ForgedWithPublicKey_rejected() throws Exception {
+        KeyPair kp = freshKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pubB64  = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+        JwtService svc = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+
+        // forge: sign with HS256 using the RSA public key bytes as HMAC secret
+        SecretKeySpec hmacKey = new SecretKeySpec(kp.getPublic().getEncoded(), "HmacSHA256");
+        long now = System.currentTimeMillis();
+        String forged = Jwts.builder()
+            .issuer("wildbook")
+            .audience().add("wildbook-scoped-api").and()
+            .subject("u")
+            .issuedAt(new Date(now))
+            .expiration(new Date(now + 3_600_000L))
+            .signWith(hmacKey, Jwts.SIG.HS256)
+            .compact();
+
+        assertThrows(JwtException.class, () -> svc.verify(forged),
+            "HS256-with-RSA-public-key forged token must be rejected");
+    }
+
+    /**
+     * A token signed with RS384 using the SAME RSA private key must be rejected
+     * once the verifier is pinned to RS256.  (This is the test that should FAIL
+     * before Fix 1 is applied and PASS after.)
+     */
+    @Test void rs384SameKey_rejected() throws Exception {
+        KeyPair kp = freshKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pubB64  = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+        JwtService svc = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+
+        // forge: sign with RS384 (stronger but wrong algorithm)
+        long now = System.currentTimeMillis();
+        String rs384Token = Jwts.builder()
+            .issuer("wildbook")
+            .audience().add("wildbook-scoped-api").and()
+            .subject("u")
+            .issuedAt(new Date(now))
+            .expiration(new Date(now + 3_600_000L))
+            .signWith(kp.getPrivate(), Jwts.SIG.RS384)
+            .compact();
+
+        assertThrows(JwtException.class, () -> svc.verify(rs384Token),
+            "RS384-signed token must be rejected when verifier is pinned to RS256");
     }
 }

--- a/src/test/resources/shiro.ini
+++ b/src/test/resources/shiro.ini
@@ -20,5 +20,9 @@ roles.unauthorizedUrl = /accessDenied.jsp
 /api/v3/home = authc
 /api/v3/encounters/export-images = authc, roles[researcher]
 
+# API token issuance and admin access-check endpoints
+/api/v3/auth/token = authcBasicWildbook
+/api/v3/can-user-access = authcBasicWildbook, roles[admin]
+
 # Allow everything else for testing purposes
 /** = anon


### PR DESCRIPTION
## Summary

Adds the two Wildbook-side endpoints the external scoped-query kernel / co-scientist depends on (**Artifact B** of the AI co-scientist prerequisites; design spec under `docs/superpowers/specs/`). Independent of Artifact A (PR #1592) — this branch is off `main` and uses the pre-existing `Encounter.canUserView`.

- **`POST /api/v3/auth/token`** — gated by existing Shiro Basic auth; mints a short-lived **RS256** JWT carrying **only identity** (`sub`=user UUID, `context`, `iss`/`aud`/`jti`/`iat`/`exp`, optional `kid`) — **no admin/role claims** (the consumer resolves privileges fresh). Context is **pinned server-side** (never from `?context=`). TTL default 30 min, clamped [60 s, 24 h]. Returns 503 if no signing key configured.
- **`POST /api/v3/can-user-access`** — admin-gated; given a target user UUID + encounterIds, returns the subset that user may **view**, computed from **live** `Collaboration`/role objects via `Encounter.canUserView` (the defense-in-depth backstop for the kernel, independent of the indexed `viewUsers`). Caller-vs-target separated (no escalation); content-type/size/`MAX_IDS` guards; fail-closed on unknown target.
- **`JwtService`** (jjwt 0.12.6, new locked dep) — RS256 sign/verify; verification requires issuer+audience and is **pinned to RS256** (rejects `alg=none`, HS256-with-public-key, and same-key RS384/512/PS256). Keys are Base64 in `commonConfiguration.properties` (Wildbook holds the private key; the kernel gets the public key only).
- web.xml servlet mappings + Shiro `[urls]` constraints, plus an `EndpointAuthWiringTest` guard so the auth gates can't silently regress.

## Test plan

- [x] `JwtServiceTest` (10), `AuthTokenTest` (3), `CanUserAccessTest` (3), `EndpointAuthWiringTest` (7) — **23/23 pass**, BUILD SUCCESS.
- [ ] **Post-deploy:** generate an RSA keypair and set the `jwt*` properties per `docs/superpowers/runbooks/jwt-keypair-setup.md`.

## Reviews

Independent Codex reviews at every stage: the implementation plan, the `JwtService` crypto core (RS256 pinning + alg-confusion regression tests added), and the full implemented diff — which caught a context-pinning High (issuance context could be shifted via `?context=`) and a byte-vs-char body-cap Medium, both **fixed and re-confirmed**. Final Codex verdict: **safe to merge**.

## Known follow-ups (deferred, not silently broken)

- **No user-facing token-retrieval UX yet** — issuance is programmatic (Basic-auth → JWT) for an automated client (MCP) that holds credentials and refreshes. A human "paste into Claude" flow (profile-page PAT or session-auth UI) is a Consumer-C decision.
- The kernel must enforce the token's `context` claim against its own configured context (`JwtService.verify` authenticates but doesn't make that policy call).
- JWKS / public-key distribution endpoint; a dedicated narrow service role instead of `admin` for `can-user-access`; a `jti` replay store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)