### PR TITLE
fix(ia): apply IA.json _save_as iaClass remap in ml-service detection

### DIFF
--- a/src/main/java/org/ecocean/ia/MlServiceProcessor.java
+++ b/src/main/java/org/ecocean/ia/MlServiceProcessor.java
@@ -221,7 +221,7 @@ public class MlServiceProcessor {
             shep.commitDBTransaction();
             return new DetectionContext(webUrl.toString(),
                 configs.mlConfig.optString("api_endpoint", null), configs.mlConfig,
-                configs.matchConfig);
+                configs.matchConfig, effectiveTaxonomy);
         } finally {
             shep.rollbackAndClose();
         }
@@ -353,11 +353,28 @@ public class MlServiceProcessor {
                 return PersistResult.done(MlServiceJobOutcome.stale(staleReason));
             }
 
+            // Resolve the _save_as remap inputs ONCE (not per-detection): the
+            // IA.json config and the effective Taxonomy that selected the
+            // detection configs. taxy stays null if no taxonomy is known, in
+            // which case applySaveAs is a no-op. getOrCreateTaxonomy(..., false)
+            // does not persist a new row.
+            IAJsonProperties iaConf = IAJsonProperties.iaConfig();
+            Taxonomy taxy = Util.stringExists(det.effectiveTaxonomyString)
+                ? shep.getOrCreateTaxonomy(det.effectiveTaxonomyString, false) : null;
+
             for (int i = 0; i < results.length(); i++) {
                 JSONObject result = results.getJSONObject(i);
                 double[] bbox = parseBbox(result.getJSONArray("bbox"));
                 double theta = result.getDouble("theta");
                 String[] mv = parseEmbeddingMethodVersion(result);
+                // Resolve the iaClass once, up front: the model-native class
+                // from the response, then the IA.json _save_as remap (parity
+                // with legacy IBEISIA detection, IBEISIA.java:1234,2150) so the
+                // annotation carries the catalog-stored class that
+                // Annotation.getMatchingSetQuery filters match candidates on.
+                String rawIaClass = result.optString("iaClass",
+                    result.optString("class_name", result.optString("class", null)));
+                String iaClass = applySaveAs(iaConf, taxy, rawIaClass);
                 Annotation existing = findExistingAnnotation(ma, bbox, theta);
                 if (existing != null) {
                     // Dedup hit: an annotation with this bbox+theta already
@@ -374,6 +391,16 @@ public class MlServiceProcessor {
                         shep.getPM().makePersistent(emb);
                         existing.setVersion();
                     }
+                    // Self-heal an annotation persisted by the pre-_save_as
+                    // build: if its stored class is exactly the raw model class
+                    // that we now remap to something else, restamp it so it
+                    // matches the catalog. Guarded to the raw==stored case so a
+                    // legitimately different class is never clobbered.
+                    // setIAClass() bumps VERSION (OpenSearch reindex).
+                    if (Util.stringExists(rawIaClass) && rawIaClass.equals(existing.getIAClass())
+                        && !rawIaClass.equals(iaClass)) {
+                        existing.setIAClass(iaClass);
+                    }
                     annotationIds.add(existing.getId());
                     continue;
                 }
@@ -381,8 +408,6 @@ public class MlServiceProcessor {
                 JSONObject featureParams = featureParams(bbox, theta,
                     result.optString("viewpoint", null));
                 Feature feature = new Feature(BOUNDING_BOX_FEATURE, featureParams);
-                String iaClass = result.optString("iaClass",
-                    result.optString("class_name", result.optString("class", null)));
                 Annotation ann = new Annotation(null, feature, iaClass);
                 ann.setAcmId(ann.getId());
                 ann.setMatchAgainst(true);
@@ -901,6 +926,27 @@ public class MlServiceProcessor {
         return null;
     }
 
+    /**
+     * Apply the IA.json {@code _save_as} iaClass remap, restoring parity with
+     * the legacy IBEISIA detection path ({@code IBEISIA.java:1234,2150}). The
+     * ml-service returns a model-native class (e.g. {@code "zebra_grevys"});
+     * {@code _save_as} maps it to the catalog-stored class (e.g. {@code
+     * "zebra"}) so the new annotation shares the iaClass that {@link
+     * org.ecocean.Annotation#getMatchingSetQuery} filters match candidates on.
+     *
+     * <p>Null-safe by design: if the config, taxonomy, or raw class is
+     * missing, the raw class is returned unchanged. In particular a class-less
+     * detection must NOT fall through to a {@code _default._save_as} default,
+     * which would stamp a real catalog class onto an unclassified box.</p>
+     *
+     * <p>Package-visible + pure (config and taxonomy injected) so it unit-tests
+     * without a deployment IA.json or a database.</p>
+     */
+    static String applySaveAs(IAJsonProperties iac, Taxonomy taxy, String rawIaClass) {
+        if (iac == null || taxy == null || !Util.stringExists(rawIaClass)) return rawIaClass;
+        return iac.convertIAClassForTaxonomy(rawIaClass, taxy);
+    }
+
     private void markTaskError(String taskId, String code, String message) {
         Shepherd shep = new Shepherd(context);
         shep.setAction(ACTION_PREFIX + "markTaskError");
@@ -1152,14 +1198,20 @@ public class MlServiceProcessor {
         final String apiEndpoint;
         final JSONObject mlConfig;
         final JSONObject matchConfig;
+        // Effective taxonomy (request override or encounter fallback) used to
+        // select the configs above; carried so persistDetections applies the
+        // _save_as iaClass remap against the SAME taxonomy. String (not a JDO
+        // Taxonomy) to avoid carrying a PM-bound object across transactions.
+        final String effectiveTaxonomyString;
         final MlServiceJobOutcome outcome;
 
         DetectionContext(String imageUri, String apiEndpoint, JSONObject mlConfig,
-            JSONObject matchConfig) {
+            JSONObject matchConfig, String effectiveTaxonomyString) {
             this.imageUri = imageUri;
             this.apiEndpoint = apiEndpoint;
             this.mlConfig = mlConfig;
             this.matchConfig = matchConfig;
+            this.effectiveTaxonomyString = effectiveTaxonomyString;
             this.outcome = null;
         }
 
@@ -1168,6 +1220,7 @@ public class MlServiceProcessor {
             this.apiEndpoint = null;
             this.mlConfig = null;
             this.matchConfig = null;
+            this.effectiveTaxonomyString = null;
             this.outcome = outcome;
         }
 

--- a/src/test/java/org/ecocean/ia/MlServiceProcessorTest.java
+++ b/src/test/java/org/ecocean/ia/MlServiceProcessorTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.ecocean.Annotation;
+import org.ecocean.IAJsonProperties;
+import org.ecocean.Taxonomy;
 import org.ecocean.media.Feature;
 import org.ecocean.media.FeatureType;
 import org.ecocean.media.MediaAsset;
@@ -272,5 +274,60 @@ class MlServiceProcessorTest {
         mv = MlServiceProcessor.parseEmbeddingMethodVersion(trailing);
         assertEquals("miewid-", mv[0]);
         assertEquals("msv4.1", mv[1]);
+    }
+
+    // --- applySaveAs (_save_as iaClass remap; parity with IBEISIA) ------
+
+    // In-memory IA.json with an Equus.quagga._save_as mapping for the
+    // model-native zebra classes the ml-service returns. Mirrors
+    // IAJsonPropertiesTest's setJson() injection so no deployment IA.json
+    // or database is needed.
+    private IAJsonProperties iaConfigWithZebraSaveAs() {
+        JSONObject json = new JSONObject()
+            .put("Equus", new JSONObject()
+                .put("quagga", new JSONObject()
+                    .put("zebra_grevys", new JSONObject().put("_save_as", "zebra"))
+                    .put("zebra_plains", new JSONObject().put("_save_as", "zebra"))));
+        IAJsonProperties iac = IAJsonProperties.iaConfig();
+        iac.setJson(json);
+        return iac;
+    }
+
+    @Test void applySaveAsRemapsModelClassToCatalogClass() {
+        // The live-confirmed bug: ml-service returns "zebra_grevys" but the
+        // catalog is stored as "zebra"; _save_as must remap so matching
+        // candidates line up.
+        IAJsonProperties iac = iaConfigWithZebraSaveAs();
+        Taxonomy taxy = new Taxonomy("Equus quagga");
+        assertEquals("zebra", MlServiceProcessor.applySaveAs(iac, taxy, "zebra_grevys"));
+        assertEquals("zebra", MlServiceProcessor.applySaveAs(iac, taxy, "zebra_plains"));
+    }
+
+    @Test void applySaveAsPassesThroughUnmappedClass() {
+        // A class with no _save_as entry is returned unchanged.
+        IAJsonProperties iac = iaConfigWithZebraSaveAs();
+        Taxonomy taxy = new Taxonomy("Equus quagga");
+        assertEquals("giraffe", MlServiceProcessor.applySaveAs(iac, taxy, "giraffe"));
+    }
+
+    @Test void applySaveAsNullConfigReturnsRawClass() {
+        Taxonomy taxy = new Taxonomy("Equus quagga");
+        assertEquals("zebra_grevys",
+            MlServiceProcessor.applySaveAs(null, taxy, "zebra_grevys"));
+    }
+
+    @Test void applySaveAsNullTaxonomyReturnsRawClass() {
+        // No taxonomy known => cannot build the lookup key => no remap.
+        IAJsonProperties iac = iaConfigWithZebraSaveAs();
+        assertEquals("zebra_grevys",
+            MlServiceProcessor.applySaveAs(iac, null, "zebra_grevys"));
+    }
+
+    @Test void applySaveAsNullOrEmptyRawClassReturnedUnchanged() {
+        // A class-less detection must NOT fall through to _default._save_as.
+        IAJsonProperties iac = iaConfigWithZebraSaveAs();
+        Taxonomy taxy = new Taxonomy("Equus quagga");
+        assertNull(MlServiceProcessor.applySaveAs(iac, taxy, null));
+        assertEquals("", MlServiceProcessor.applySaveAs(iac, taxy, ""));
     }
 }


### PR DESCRIPTION
## Root cause

The new ml-service detection path (`MlServiceProcessor.persistDetections`) stored annotations with the **raw** model-native `iaClass` the classifier returns (e.g. `zebra_grevys` / `zebra_plains` from the `zebra_v1` labeler), skipping the IA.json `_save_as` remap that the legacy IBEISIA path applies (`IBEISIA.java:1234,2150`, via `IAJsonProperties.convertIAClassForTaxonomy`).

`Annotation.getMatchingSetQuery` (Annotation.java:965-972) filters match candidates by the query annotation's `iaClass`. The legacy catalog was stored as `zebra` (129,383 annotations), but new detections came in as `zebra_grevys`, so the candidate set was empty no matter the location.

Confirmed on prod (`SELECT "IACLASS", COUNT(*) ...`):

| IACLASS | count |
|---|---|
| zebra | 129,383 |
| (null) | 27,961 |
| giraffe | 39 |
| quagga | 24 |
| **zebra_grevys** | **1** (the new detection) |

A 1-row re-stamp (`zebra_grevys`→`zebra`, with a `VERSION` bump) restored matching live, proving the mechanism.

## Fix

Restore `_save_as` parity in the ml-service detection path:

- **`DetectionContext` carries the effective taxonomy as a `String`** (request override or encounter fallback) — not a PM-bound JDO `Taxonomy` — so `persistDetections` remaps against the *same* taxonomy that selected `_mlservice_conf`, and no detached object crosses transactions.
- **New pure, package-visible `applySaveAs(IAJsonProperties, Taxonomy, String)`**, null-safe on all three inputs. A class-less detection is intentionally **not** defaulted via `_default._save_as` (which would stamp a real catalog class onto an unclassified box).
- `IAJsonProperties` + `Taxonomy` resolved **once** before the result loop (not per-detection).
- **Dedup-reuse branch self-heals** an annotation persisted by the pre-fix build: if its stored class is exactly the raw model class we now remap, it restamps `iaClass` (`setIAClass` bumps `VERSION` for OpenSearch reindex). Guarded to the `raw == stored` case so a legitimately different class is never clobbered.

## Operator action — IA.json `_save_as` pattern

`_save_as` is honored from each deployment's **private-repo IA.json** (not this repo). Under each taxonomy node, add an object keyed by the **raw class the ml-service returns**, holding `_save_as`:

```json
"Equus": {
  "quagga": { "zebra_grevys": {"_save_as": "zebra"}, "zebra_plains": {"_save_as": "zebra"} },
  "grevyi": { "zebra_grevys": {"_save_as": "zebra"}, "zebra_plains": {"_save_as": "zebra"} }
}
```

Lookup key is `<scientificName with spaces→dots>.<rawClass>._save_as` (falls back to `<taxonomy>._default._save_as`). **Note:** a redirect *string* at a class key (e.g. `"zebra_grevys": "@Equus.grevyi.zebra"`) blocks the lookup — the value must be the `_save_as` object.

## Optional immediate data cleanup

The dedup branch self-heals lazily on re-detection. To fix all already-saved raw-class rows at once (bumping `VERSION` so OpenSearch reindexes):

```sql
BEGIN;
UPDATE "ANNOTATION"
SET "IACLASS" = 'zebra',
    "VERSION" = (EXTRACT(EPOCH FROM now()) * 1000)::bigint
WHERE "IACLASS" IN ('zebra_grevys','zebra_plains');
COMMIT;
```

(Per-deployment; class list depends on species.)

## Tests

5 new `MlServiceProcessorTest` cases (remap to catalog class, unmapped pass-through, null-config / null-taxonomy / null-or-empty-class guards). **29/29 pass.**

## Review

Codex design review and code review, both green — taxonomy source, JDO detachment safety, null-handling, and the dedup self-heal all confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
