### PR TITLE
Harden IndexingManager against postStore-before-commit indexing race

### DIFF
--- a/src/main/java/org/ecocean/IndexingManager.java
+++ b/src/main/java/org/ecocean/IndexingManager.java
@@ -5,99 +5,169 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.ecocean.shepherd.core.Shepherd;
 import org.ecocean.shepherd.core.ShepherdProperties;
 
 
 
 public class IndexingManager {
-	
-	//The ExecutorService executes indexing jobs
-	private final ExecutorService executor;
-		
-	//The indexingQueue is a List of Strings that represent the UUIDs of Base class-implementing objects 
-	//(Encounter, MarkedIndividual, Annotation, etc.) that need to be indexed or unindexed.
-	//The queue ensures that overzealous calls from the WildbookLifecycleListener do not cause
-	//unnecessary, duplicate indexing jobs. The UUIDs of the objects being ndexed are removed 
-	//from the queue once completed.
+
+    // The ScheduledExecutorService executes indexing jobs (and re-schedules retries).
+    private final ScheduledExecutorService executor;
+
+    // The indexingQueue is a List of Strings that represent the UUIDs of Base class-implementing
+    // objects (Encounter, MarkedIndividual, Annotation, etc.) that need to be indexed or unindexed.
+    // The queue ensures that overzealous calls from the WildbookLifecycleListener do not cause
+    // unnecessary, duplicate indexing jobs. The UUIDs of the objects being indexed are removed
+    // from the queue once the job reaches a terminal outcome (success, give-up, or could-not-schedule).
+    // An id intentionally stays in the queue across retries so concurrent postStore events for the
+    // same object are deduped while a job is pending.
     private List<String> indexingQueue = Collections.synchronizedList(new ArrayList<String>());
-  
+
+    // Stable lock for all compound (check-then-act) mutations of indexingQueue. We cannot synchronize
+    // on indexingQueue itself because resetIndexingQueuehWithInitialCapacity() reassigns the field.
+    private final Object queueLock = new Object();
+
+    // Total number of attempts (the initial attempt plus retries) before giving up on an object that
+    // cannot be found in the datastore. The common cause is the postStore-before-commit race: the
+    // indexing job is enqueued on JDO flush, but the creating transaction has not committed yet, so the
+    // row is not visible to this background thread's separate connection (JDOObjectNotFoundException).
+    private static final int MAX_INDEXING_ATTEMPTS = 6;
+
+    // Delay (seconds) BEFORE the next attempt, indexed by the just-failed attempt number (1-based).
+    // Length is MAX_INDEXING_ATTEMPTS - 1. Cumulative budget ~62s, comfortably longer than a typical
+    // detection-callback transaction. Retries are scheduled (not slept), so no worker thread is held.
+    private static final long[] RETRY_DELAY_SECONDS = { 2L, 4L, 8L, 16L, 32L };
+
     public IndexingManager() {
-    	
-    	int numAllowedThreads = 4;
-    	Properties props = ShepherdProperties.getProperties("OpenSearch.properties", "", "context0");
-    	if(props!=null) {
-	    	String indexingNumAllowedThreads = props.getProperty("indexingNumAllowedThreads");
-	    	if(indexingNumAllowedThreads!=null) {
-	    		Integer allowThreads = Integer.getInteger(indexingNumAllowedThreads);
-	    		if(allowThreads!=null)numAllowedThreads = allowThreads.intValue();
-	    	}
-    	}
-    	executor = Executors.newFixedThreadPool(numAllowedThreads);
-    	
+        int numAllowedThreads = 4;
+        Properties props = ShepherdProperties.getProperties("OpenSearch.properties", "", "context0");
+        if (props != null) {
+            String indexingNumAllowedThreads = props.getProperty("indexingNumAllowedThreads");
+            if (indexingNumAllowedThreads != null) {
+                Integer allowThreads = Integer.getInteger(indexingNumAllowedThreads);
+                if (allowThreads != null) numAllowedThreads = allowThreads.intValue();
+            }
+        }
+        executor = Executors.newScheduledThreadPool(numAllowedThreads);
     }
-    
-    //Returns the indexing queue List of Strings
+
+    // Returns the indexing queue List of Strings
     public List<String> getIndexingQueue() { return indexingQueue; }
-    
+
     /*
      * Adds a Base object to the queue for indexing or unindexing
      * @Base base The Base-class implementing object to be indexed or unindexed
      * @boolean unindex Whether the object is to be indexed or unindexed.
      */
     public void addIndexingQueueEntry(Base base, boolean unindex) {
-    	String objectID = base.getId();
-    	Class myClass = base.getClass();
-    	if(!indexingQueue.contains(objectID)) {
-    		indexingQueue.add(objectID);
-    		
-    		//IMPORTANT - no persistent objects, such as the passed in Base can be referenced inside this method
-            Runnable rn = new Runnable() {
-                public void run() {
-                    Shepherd bgShepherd = new Shepherd("context0");
-                    bgShepherd.setAction("IndexingManager_" + objectID);
-                    bgShepherd.beginDBTransaction();
-                    try {
-                    	Base base = (Base)bgShepherd.getPM().getObjectById(myClass, objectID);
-                    	if(unindex) {base.opensearchUnindexDeep();}
-                    	else{base.opensearchIndexDeep();}
-                    	
-                    } 
-                    catch (Exception e) {
-                        e.printStackTrace();
-                    } 
-                    finally {
-                        bgShepherd.rollbackAndClose();
-                    }
-                    
-                    //remove from indexing queue
-                    if(indexingQueue.contains(objectID))indexingQueue.remove(objectID);
-                }
-            };
-
-            executor.execute(rn);
-    		
-    	}
-
+        String objectID = base.getId();
+        Class myClass = base.getClass();
+        // Atomic check-then-add so two concurrent postStore events for the same object schedule
+        // only one job.
+        synchronized (queueLock) {
+            if (indexingQueue.contains(objectID)) return;
+            indexingQueue.add(objectID);
+        }
+        // IMPORTANT - no persistent objects, such as the passed in Base, can be referenced inside the
+        // job; we carry only the (id, class) and re-fetch by id on each attempt.
+        scheduleIndexingJob(objectID, myClass, unindex, 1, 0L);
     }
 
-    //Removes an oject's UUID from the queue
-    public void removeIndexingQueueEntry(String objectID) {
-        if (indexingQueue.contains(objectID)) {
-        	indexingQueue.remove(objectID);
+    // Schedules (or immediately submits, when delaySeconds==0) one indexing attempt. Guarantees that the
+    // queue entry is either handed to a running/scheduled job or removed if scheduling is rejected
+    // (e.g. executor shutdown), so an id can never be orphaned in the queue.
+    private void scheduleIndexingJob(final String objectID, final Class myClass, final boolean unindex,
+        final int attempt, long delaySeconds) {
+        final Runnable rn = new Runnable() {
+            public void run() {
+                Shepherd bgShepherd = null;
+                try {
+                    bgShepherd = new Shepherd("context0");
+                    bgShepherd.setAction("IndexingManager_" + objectID);
+                    bgShepherd.beginDBTransaction();
+                    Base base = null;
+                    try {
+                        base = (Base)bgShepherd.getPM().getObjectById(myClass, objectID);
+                    } catch (javax.jdo.JDOObjectNotFoundException nf) {
+                        // Object not visible to this connection. Almost always the postStore-before-commit
+                        // race; handle (retry the index path) and stop here for this attempt.
+                        handleObjectNotFound(objectID, myClass, unindex, attempt);
+                        return;
+                    }
+                    if (unindex) {
+                        base.opensearchUnindexDeep();
+                    } else {
+                        base.opensearchIndexDeep();
+                    }
+                    // success - terminal
+                    removeIndexingQueueEntry(objectID);
+                } catch (Exception e) {
+                    // A genuine indexing failure (not the commit race), or a failure setting up the
+                    // Shepherd. Make it visible rather than silently swallowing it, then drop it; the
+                    // background reconciler (OpenSearch.opensearchSyncIndex) will recover it on its next
+                    // pass if the row exists.
+                    System.out.println("IndexingManager: WARNING - indexing failed for " + objectID +
+                        " (attempt " + attempt + "/" + MAX_INDEXING_ATTEMPTS + "); dropping. " +
+                        "Background reconciler will recover it if it exists. " + e);
+                    e.printStackTrace();
+                    removeIndexingQueueEntry(objectID);
+                } finally {
+                    if (bgShepherd != null) bgShepherd.rollbackAndClose();
+                }
+            }
+        };
+
+        try {
+            executor.schedule(rn, delaySeconds, TimeUnit.SECONDS);
+        } catch (RejectedExecutionException rex) {
+            // Executor is shutting down; do not leak the queue entry.
+            System.out.println("IndexingManager: could not schedule indexing job for " + objectID +
+                " (executor shutdown?); removing from queue. " + rex);
+            removeIndexingQueueEntry(objectID);
         }
     }
 
-    //Resets the indexing queue
-    public void resetIndexingQueuehWithInitialCapacity(int initialCapacity) {
-    	indexingQueue = null;
-    	indexingQueue = Collections.synchronizedList(new ArrayList<String>());
+    // Handles the "row not visible" case. For the index path this is the commit-visibility race, so we
+    // retry with backoff (leaving the id in the queue to dedup concurrent events). For the unindex path a
+    // missing row means the object is already gone and there is nothing to deep-unindex, so we give up.
+    private void handleObjectNotFound(final String objectID, final Class myClass, final boolean unindex,
+        final int attempt) {
+        if (!unindex && attempt < MAX_INDEXING_ATTEMPTS) {
+            long delay = RETRY_DELAY_SECONDS[attempt - 1];
+            System.out.println("IndexingManager: object " + objectID + " not yet visible (attempt " +
+                attempt + "/" + MAX_INDEXING_ATTEMPTS + "); likely an uncommitted transaction, retrying in " +
+                delay + "s");
+            scheduleIndexingJob(objectID, myClass, unindex, attempt + 1, delay);
+            // NOTE: id intentionally stays in indexingQueue across retries.
+        } else {
+            System.out.println("IndexingManager: object " + objectID + " still not found after " + attempt +
+                " attempt(s); giving up (object may have been rolled back / never committed, or is an " +
+                "unindex of an already-deleted row). Background reconciler will index it if it exists.");
+            removeIndexingQueueEntry(objectID);
+        }
     }
-    
+
+    // Removes an object's UUID from the queue
+    public void removeIndexingQueueEntry(String objectID) {
+        synchronized (queueLock) {
+            indexingQueue.remove(objectID);
+        }
+    }
+
+    // Resets the indexing queue
+    public void resetIndexingQueuehWithInitialCapacity(int initialCapacity) {
+        synchronized (queueLock) {
+            indexingQueue = Collections.synchronizedList(new ArrayList<String>());
+        }
+    }
+
     public void shutdown() {
-    	if(executor!=null)executor.shutdown();
+        if (executor != null) executor.shutdown();
     }
 
 }


### PR DESCRIPTION
## Problem

`JDOObjectNotFoundException: No such database row` is logged from `IndexingManager$1.run`:

```
javax.jdo.JDOObjectNotFoundException: No such database row
FailedObject:ec1cefb1-c490-4ba1-8ed4-8a6bbdbf96ae
    at ...JDOPersistenceManager.getObjectById(JDOPersistenceManager.java:1747)
    at org.ecocean.IndexingManager$1.run(IndexingManager.java:63)
```

OpenSearch auto-indexing is triggered from `WildbookLifecycleListener.postStore()`, which fires on a JDO **flush/store** event — **not** commit. It enqueues an async job on `IndexingManager`'s thread pool; that job opens its **own** `Shepherd` (separate PM + JDBC connection) and calls `getObjectById(class, id)` with validation. When the creating transaction hasn't committed yet (e.g. the IBEISIA detection callback only commits at the end via `updateDBTransaction()`), the new row is invisible to the background connection under `READ COMMITTED` → the exception.

The previous job only `printStackTrace()`'d and then **unconditionally removed** the id from the queue, so:
- the object was **never indexed in real time**, and
- there was **no retry** — the failure was silently dropped.

The ~20-minute background reconciler (`OpenSearch.opensearchSyncIndex`, which re-indexes any row present in the DB but absent from the index) eventually recovers it, but until then the object is missing from OpenSearch. That isn't only a stale-search-UI issue: the matching candidate set is built from the OpenSearch annotation index (`Annotation.getMatchingSet()` → `os.queryPit("annotation", ...)`), so **freshly created annotations can be missed as match candidates** (e.g. intra-bulk-import matches) until the sweep catches up.

## Fix (this PR)

Make the async indexer **race-tolerant** and **non-silent**, **without** moving the enqueue point (planned as a separate follow-up that moves enqueueing to after commit):

- **Scheduled retries, not sleeps.** Switch the pool to a `ScheduledExecutorService` so a failed attempt reschedules itself after a delay instead of blocking a worker thread (sleeping would starve the pool when a whole transaction enqueues many objects at once).
- **Bounded retry on the race only.** Retry on `JDOObjectNotFoundException` from the `getObjectById` call (wrapped in its own `try`, so a not-found thrown deep inside `opensearchIndexDeep()` is **not** treated as the race). 6 total attempts, backoff `2/4/8/16/32`s (~62s budget). Retry only the index path; deep-indexing failures and the (currently unused) unindex path are not retried.
- **No silent drops.** Genuine indexing failures are logged at WARNING with the exception before the id is dropped (the reconciler remains the backstop).
- **No orphaned queue entries.** If scheduling is rejected (executor shutdown) the id is removed; `Shepherd` setup is inside the `try`, so a setup failure still hits the `finally` (close) and the drop path.
- **Queue integrity.** Atomic check-then-add, and a stable `queueLock` for all queue mutations (the `indexingQueue` field is reassigned by `resetIndexingQueuehWithInitialCapacity()`, so we can't lock on the field itself).

Public method signatures are unchanged.

## Scope / follow-ups

- **PR2 (planned):** move the enqueue from `postStore` (flush) to after `Shepherd.commitDBTransaction()` so the row is guaranteed visible — the real semantic fix. This PR hardens the worker so that fix composes cleanly.
- **Matching freshness (planned):** the deeper coupling — matching depends on an eventually-consistent async index with no read-your-writes guarantee — warrants its own design (e.g. ensure a batch's annotations are indexed before building its candidate set).

## Testing

- `javac` clean against the project classpath; `git diff --check` clean (LF, no whitespace errors).
- No unit harness exists for `IndexingManager` (it news-up `Shepherd` internally); behavior verified by code review (two independent passes). Manual verification: re-run a detection callback and confirm `No such database row` no longer ends in a terminal drop — it retries and succeeds post-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)