### PR TITLE
Add wildbook_tasks_vectorMatch gauge + fix MiewID gauge metric-name collision

### DIFF
--- a/src/main/java/org/ecocean/MetricsBot.java
+++ b/src/main/java/org/ecocean/MetricsBot.java
@@ -536,7 +536,23 @@ public class MetricsBot {
             "wildbook_tasks_pieTwo", "Number of tasks using PieTwo algorithm", context));
 		addLineIfNotNull(csvLines, buildGauge(
             "SELECT count(this) FROM org.ecocean.ia.Task where  children == null && parameters.indexOf('MiewId')>-1",
-            "wildbook_tasks_pieTwo", "Number of tasks using MiewId algorithm", context));
+            "wildbook_tasks_miewId", "Number of tasks using MiewId algorithm", context));
+
+        // ml-service v2 vector (MiewID) re-ID matches carry mlServiceV2Match=true
+        // (MlServiceProcessor.runMatchProspects); the per-annotation leaf subtasks
+        // inherit it (Embedding.findMatchProspects -> new Task(matchTask)).
+        // children==null counts those leaves (one per annotation), parallel to the
+        // hotspotter/pieTwo gauges above; the parent match task has children and is
+        // excluded, so no double counting. Edge case: an invalid/rejected match
+        // config aborts before any subtask is created, leaving the parent match
+        // task childless — that rare failure counts as one terminal leaf here.
+        // Match the quoted JSON key (like the hotspotter '"sv_on"' gauge) so we
+        // hit the key, not an incidental substring elsewhere in the params.
+        addLineIfNotNull(csvLines, buildGauge(
+            "SELECT count(this) FROM org.ecocean.ia.Task where children == null && parameters.indexOf('\"mlServiceV2Match\"')>-1",
+            "wildbook_tasks_vectorMatch",
+            "Number of ml-service v2 vector (MiewID) re-ID leaf tasks (one per matched annotation; a rare invalid-config match failure counts as one)",
+            context));
 
 
 


### PR DESCRIPTION
## Background

The `/metrics` algorithm-breakdown gauges (`MetricsBot.addTasksToCsv`) classify `org.ecocean.ia.Task` by substring-matching `Task.parameters`. ml-service v2 **vector (MiewID) re-ID** matches were not represented in any per-algorithm gauge.

Note: vector re-ID is **already** counted by the *general* identification gauges (`wildbook_identification_tasks_added/completed_last24`, `wildbook_tasks_idSpecies_*`), because the match task stamps an `ibeis.identification` block and its per-annotation leaf subtasks inherit it. **This PR only adds the missing per-algorithm breakdown** — it is not fixing a total-invisibility bug.

## Changes (MetricsBot-only, no core class changes)

1. **New gauge `wildbook_tasks_vectorMatch`.** Vector match tasks carry `mlServiceV2Match=true` (`MlServiceProcessor.runMatchProspects`), and the per-annotation leaf subtasks created by `Embedding.findMatchProspects` (`new Task(matchTask)`) inherit it. The gauge counts `children == null && parameters.indexOf('"mlServiceV2Match"') > -1` — leaf tasks, one per matched annotation, parallel to the existing hotspotter/PieTwo gauges. The parent match task has children and is excluded, so there's no double count. Quoted-key form mirrors the hotspotter `'"sv_on"'` gauge.

2. **Fix a pre-existing metric-name collision.** The MiewID gauge published under the metric name `wildbook_tasks_pieTwo` — *identical* to the PieTwo gauge two lines above it — so the two values clobbered each other in the exported CSV. Renamed to `wildbook_tasks_miewId`. Its filter is left unchanged (kept distinct from vector counting, per the chosen design).

## Why query-only here (vs. the detection change in #1601)

Unlike the detection task — which carried no type flag in its parameters — vector match tasks **already** carry a precise, self-describing flag (`mlServiceV2Match`). So this is cleanly a metrics-layer change keyed on an existing signal: no edits to `IA.java` / `MlServiceProcessor.java`, worst-case blast radius is "a gauge is wrong," never broken matching.

## Scope / edge case

- Counts **leaf subtasks** (per annotation), matching the existing algorithm gauges' `children == null` style.
- Documented in code: an invalid/rejected match config aborts before any subtask is created, leaving the parent match task childless — that **rare failure counts as one** terminal leaf. Acceptable for an algorithm-volume gauge; tightening it would add JDOQL complexity for no real benefit.
- The renamed `wildbook_tasks_miewId` still greps the literal `'MiewId'` (legacy behavior, possibly vestigial); not expanded here. External dashboards reading the old colliding `wildbook_tasks_pieTwo` for MiewID data should switch to `wildbook_tasks_miewId`.

## Verification

- `mvn -DskipTests compile` passes.
- LF line endings confirmed.
- Codex-reviewed (verdict GO-WITH-CHANGES; both low/nit findings — quoted-key form and the edge-case note — are applied in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)