### PR TITLE
Fix bulk-import task page polling stall across Import→Detection handoff

### DIFF
--- a/docs/plans/2026-06-04-bulk-import-poll-handoff-stall.md
+++ b/docs/plans/2026-06-04-bulk-import-poll-handoff-stall.md
@@ -1,0 +1,192 @@
+# Bulk Import Task page: polling stalls across the Import→Detection handoff
+
+**Date:** 2026-06-04
+**Branch:** `fix/bulk-import-poll-handoff-stall`
+**Files:** `frontend/src/models/bulkImport/useGetBulkImportTask.js` (+ new unit test)
+
+## Problem
+
+On `/react/bulk-import-task`, if the user switches browser tabs while the import
+is finishing and returns during the Import→Detection handoff, the page looks
+stalled at Import even though the backend has moved on to Detection. A manual
+refresh fixes it.
+
+## Root cause (confirmed by code tracing)
+
+Polling is driven by the `refetchInterval` callback in `useGetBulkImportTask.js`
+returning `5000` (keep polling) vs `false` (stop). In react-query **v3.39.3**:
+
+- `refetchInterval: false` → `clearRefetchInterval()` destroys the timer
+  (`queryObserver.js:259,283`). There is no timer afterward.
+- `refetchOnWindowFocus: false` (line 63) → `query.onFocus()` does **not**
+  re-arm or re-evaluate the interval (`query.js:156`). Returning to the tab
+  triggers no fetch.
+- `refetchIntervalInBackground: false` (line 148) → while hidden the interval
+  fires but skips the fetch, freezing the last data + last interval value. On
+  return you get effectively **one** catch-up fetch; whatever state it lands in
+  decides everything.
+
+So if `refetchInterval` ever returns `false` during a legitimate in-progress
+state, polling dies permanently with no focus-based recovery.
+
+It returns `false` during real handoff states because the in-flight whitelist
+(`IN_FLIGHT_STATUSES = {"processing-pipeline","sent"}`, lines 14-21) and the
+`!hasEncounters`-gated early-phase branch (line 101) don't cover the actual
+`task.status` strings the backend emits:
+
+1. **The `"imported"` window** — `BulkImport.java:498` commits
+   `status="imported"`, `importPercent=1.0`, encounters attached (commit at
+   `:516`), *then* calls `initiateIA()` (`:521-523`). `initiateIA` doesn't commit
+   `status="processing-detection"` + start the IA task until after the
+   `handleBulkImport()` round-trip to the ML service (`:808 → :824`). During that
+   window the task JSON is `status="imported"`, `detectionStatus` **absent**,
+   `pipelineStarted=false`. `"imported"` ∉ whitelist; `detectionStatus` undefined;
+   `hasEncounters===true` disables the early-phase branch → **`false`**.
+2. **`"processing-detection"` is not in the whitelist** (`BulkImport.java:808`).
+   Detection only stays "alive" because `iaSummaryJson` emits
+   `detectionStatus="sent"` (`ImportTask.java:712`). The detection→identification
+   handoff (detection complete, identification not yet requested,
+   `ImportTask.java:714`) leaves both statuses non-in-flight → **`false`**.
+
+Foreground polls every 5s and mostly samples `"sent"` states, riding over the
+brief gaps. The single catch-up fetch after a tab-return is far more likely to
+land in a gap, and when it does, polling dies with no recovery.
+
+## Fix design (revised after Codex round-1 review)
+
+Codex flagged that a broad `pipelineStarted && !pipelineComplete` unbounded poll
+would **poll forever** on settled-but-incomplete states — the legacy path emits
+`detectionStatus="complete"` + `identificationStatus="unknown"` with
+`pipelineComplete=false` (`ImportTask.java:759`), and `"identification not
+started"` with zero match tasks (`:736`) persists indefinitely. It also flagged
+the missing global terminal-error stop and that a `task.dateCreated`-based budget
+is blown for long imports. The revised design keeps **unbounded** polling only
+for *explicit* in-flight signals and routes every un-statused gap through a
+single **first-observed-bounded** branch.
+
+### Change 1 — extract `refetchInterval` as a pure, testable function
+
+The decision logic is an inline closure (not exportable, not unit-testable, reads
+`Date.now()` + a `useRef`). Extract:
+
+```js
+export function computeBulkImportPollInterval(response, clocks, now = Date.now())
+// clocks = { handoffFirstSeen, taskInfoLagFirstSeen }; mutated in place.
+// returns 5000 | false. `now` injectable for deterministic tests.
+```
+
+### Change 2 — single decision flow (replaces whitelist + early-phase + ad-hoc branches)
+
+```
+if response === undefined            -> 5000        (initial load)
+if !task                             -> false       (deleted/malformed)
+if TERMINAL_ERROR_STATUSES(status)   -> false        (Codex Major 2: global stop, FIRST)
+if isInFlight(status|detection|ident)-> 5000, reset handoff clock   (active work, unbounded)
+if pipelineComplete                  -> taskInfo-lag poll (bounded) else false
+else (handoff/pre-pipeline gap)      -> poll bounded by first-observed handoff budget
+```
+
+- **Explicit in-flight = unbounded** keeps the long-standing `"sent"` /
+  `"processing-pipeline"` semantics. Each in-flight observation **resets** the
+  handoff clock so a later gap (e.g. detection→identification) gets a fresh
+  budget instead of inheriting elapsed time from an earlier phase.
+- **`pipelineComplete`** routes to the existing taskInfo-aggregation-lag poll
+  (kept, bounded by its own first-seen clock); otherwise stop.
+- **Handoff/pre-pipeline gap** (not in-flight, not complete, not terminal-error)
+  covers every un-statused window: `"processing-background"` (early CSV import,
+  no encounters), `"imported"` (import committed, IA not yet started),
+  `"processing-detection"` before `detectionStatus="sent"`, and detection-complete
+  before `identificationStatus="sent"`. It also catches **settled** non-complete
+  states (legacy `"unknown"`, `"identification not started"`). Because a single
+  snapshot can't tell transient from settled, the poll is **bounded by
+  elapsed-since-first-observed** (NOT `task.dateCreated`): worst case a settled
+  state over-polls one budget window then stops — **never infinite** (Codex
+  Major 1). First-observed (not task age) keeps long imports covered (Codex
+  Major 3).
+
+This removes the old `IN_FLIGHT`-whitelist gap, the `!hasEncounters`-gated
+early-phase branch, and the now-unused `taskAgeMillis` helper.
+
+### Change 3 — focus backstop
+
+Set `refetchOnWindowFocus: true` (was `false`) and rewrite the stale comment.
+Returning to the tab re-samples immediately and re-arms the interval if work is
+still in flight — turning any residual stall (e.g. a handoff budget that expired
+while the tab was hidden) into a self-healing one. Cost: one extra GET on focus,
+which is the desired "refresh on return". Codex confirmed this is acceptable and
+not relied on as the primary fix (Change 2 is).
+
+## Why this combination
+
+- Change 2's in-flight branch handles **active** detection/identification for any
+  import length, unbounded, deterministically.
+- Change 2's handoff branch closes the **`"imported"` / pre-`sent` / handoff**
+  gaps — bounded so settled states can't poll forever.
+- Change 3 is the **tab-return safety net**, directly targeting the report.
+
+## Testing
+
+New `frontend/src/__tests__/models/bulkImport/useGetBulkImportTask.test.js`
+unit-testing `computeBulkImportPollInterval` across:
+
+- `undefined` response → 5000 (initial load)
+- no `task` → false
+- `status="processing-background"`, no encounters → 5000 (early phase)
+- **`status="imported"`, encounters present, no `iaSummary` detection** → 5000 (regression test for the bug)
+- `pipelineStarted && !pipelineComplete` (detection "sent") → 5000
+- detection→ident handoff (detection "complete", identification absent, pipelineStarted true) → 5000 (regression)
+- `pipelineComplete` and all encounters have taskInfo → false
+- `pipelineComplete` but taskInfo lagging, within budget → 5000; past budget → false
+- `status="failed"` pre-pipeline → false
+- fully-skipped (`pipelineComplete` true, pipelineStarted false) → false (no 5-min over-poll)
+- `"imported"` past the 5-min age budget → false (focus backstop covers it)
+
+Run: `cd frontend && npx jest useGetBulkImportTask`
+
+## Risk / out of scope
+
+- Pure frontend change; no backend or DB changes.
+- Does not change the 5-min budgets or the post-ident taskInfo-lag logic
+  (untouched except for being moved into the extracted function).
+- LF normalization required after edit (CRLF working tree under `/mnt/c/`).
+- Commit only `useGetBulkImportTask.js` + the new test (working tree has ~646
+  unrelated CRLF-noise files).
+
+## Review resolutions (Codex round 1)
+
+- **Major 1** (unbounded `pipelineStarted&&!pipelineComplete` polls forever on
+  legacy `"unknown"` / `"identification not started"`): resolved — only explicit
+  in-flight statuses poll unbounded; all gaps are first-observed-bounded.
+- **Major 2** (no global terminal stop): resolved — terminal-error check runs
+  immediately after `!task`, before any in-flight/structural check.
+- **Major 3** (long-import budget keyed off `dateCreated`): resolved — handoff
+  budget is elapsed-since-first-observed.
+- **Major 4** (detection→ident gap imprecise): test both
+  detection-complete+annotations-pending and detection-complete+zero-annotations.
+- **Minor 5** (relaxed branch over-polls terminal/no-IA): bounded to one budget
+  window; malformed/missing `iaSummary` covered by tests.
+- **Minor 6/7**: `refetchOnWindowFocus:true` kept as backstop; explicit
+  `isInFlight` checks kept, with bounded gap logic kept separate.
+- **Minor 8** (unrelated `BulkImportTask.jsx` import-progress ternary always
+  renders truthy `importPercent` as 100%): **out of scope** for this branch —
+  flagged separately to the user; it is a display bug, not the polling stall.
+
+## Review resolutions (Codex round 2 — on the implementation)
+
+- **Major 1** (`"processing-pipeline"` whitelisted unbounded → polls forever when
+  a re-ID's identification settles incomplete, e.g. `"unknown"`/zero-annotation,
+  per BulkImport.java:887 overlay): resolved — `IN_FLIGHT_STATUSES` is now only
+  `{"sent"}`; `"processing-pipeline"` falls to the bounded handoff branch and
+  only polls unbounded while detection/ident is actually `"sent"`.
+- **Major 2** (long `"processing-background"`/`"processing-foreground"` imports
+  stop at the 5-min budget): resolved — advancing `importPercent` is treated as
+  liveness and resets the handoff budget; a wedged import (no progress for a
+  full window) still stops. `importPercent` is bounded [0,1] so it cannot reset
+  forever.
+- **Major 3** (incomplete clock reset): resolved — `taskInfoLagFirstSeen` is now
+  cleared on in-flight and on every non-complete branch (so a timed-out lag
+  can't carry into a re-run); both clocks reset via a `useEffect` keyed on
+  `taskId`.
+- Added tests: `"processing-pipeline"`+settled-incomplete (bounded) and +`"sent"`
+  (unbounded), long-import-with-advancing-percent (polls past budget),
+  wedged-import (stops), taskInfo-lag-clears-on-rerun, exact budget boundary.

--- a/frontend/src/__tests__/models/bulkImport/useGetBulkImportTask.test.js
+++ b/frontend/src/__tests__/models/bulkImport/useGetBulkImportTask.test.js
@@ -1,0 +1,394 @@
+import {
+  computeBulkImportPollInterval,
+  initialPollClocks,
+} from "../../../models/bulkImport/useGetBulkImportTask";
+
+const POLL = 5000;
+const BUDGET_MS = 5 * 60 * 1000;
+
+// Fresh clocks object per call so tests don't leak state into one another.
+const clocks = () => initialPollClocks();
+
+describe("computeBulkImportPollInterval", () => {
+  test("polls on initial load (undefined response from react-query)", () => {
+    expect(computeBulkImportPollInterval(undefined, clocks(), 0)).toBe(POLL);
+  });
+
+  test("stops when response has no task (deleted/invalid id)", () => {
+    expect(computeBulkImportPollInterval({ task: null }, clocks(), 0)).toBe(
+      false,
+    );
+    expect(computeBulkImportPollInterval({}, clocks(), 0)).toBe(false);
+  });
+
+  test("stops immediately on terminal-error status, even if iaSummary looks in-flight", () => {
+    const response = {
+      task: {
+        status: "failed",
+        iaSummary: { detectionStatus: "sent", pipelineStarted: true },
+      },
+    };
+    expect(computeBulkImportPollInterval(response, clocks(), 0)).toBe(false);
+    expect(
+      computeBulkImportPollInterval(
+        { task: { status: "error", iaSummary: { identificationStatus: "sent" } } },
+        clocks(),
+        0,
+      ),
+    ).toBe(false);
+  });
+
+  test("polls during early CSV import (processing-background, no encounters)", () => {
+    const response = { task: { status: "processing-background", encounters: [] } };
+    expect(computeBulkImportPollInterval(response, clocks(), 0)).toBe(POLL);
+  });
+
+  // Regression: the reported bug. Import committed ("imported"), encounters
+  // persisted, but the IA task hasn't registered a detectionStatus yet. The old
+  // !hasEncounters-gated branch dropped polling the instant encounters
+  // persisted, stranding the page across the Import->Detection handoff.
+  test("polls during the 'imported' pre-IA handoff window (encounters present, no iaSummary)", () => {
+    const response = {
+      task: {
+        status: "imported",
+        encounters: [{ id: "e1" }, { id: "e2" }],
+        iaSummary: {},
+      },
+    };
+    expect(computeBulkImportPollInterval(response, clocks(), 0)).toBe(POLL);
+  });
+
+  test("polls during the 'imported' window even with a missing iaSummary object", () => {
+    const response = { task: { status: "imported", encounters: [{ id: "e1" }] } };
+    expect(computeBulkImportPollInterval(response, clocks(), 0)).toBe(POLL);
+  });
+
+  test("polls while detection is running (detectionStatus=sent)", () => {
+    const response = {
+      task: {
+        status: "processing-detection",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineStarted: true,
+          pipelineComplete: false,
+          detectionStatus: "sent",
+        },
+      },
+    };
+    expect(computeBulkImportPollInterval(response, clocks(), 0)).toBe(POLL);
+  });
+
+  // Regression: detection->identification handoff. Detection complete,
+  // identification not yet "sent" (status absent / "identification not
+  // started"); neither is in the in-flight whitelist, pipeline not complete.
+  test("polls across the detection->identification handoff (detection complete, ident not yet started)", () => {
+    const detectionDoneNoIdent = {
+      task: {
+        status: "processing-detection",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineStarted: true,
+          pipelineComplete: false,
+          detectionStatus: "complete",
+          identificationStatus: "identification not started",
+        },
+      },
+    };
+    expect(computeBulkImportPollInterval(detectionDoneNoIdent, clocks(), 0)).toBe(
+      POLL,
+    );
+
+    const detectionDoneAbsentIdent = {
+      task: {
+        status: "processing-detection",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineStarted: true,
+          pipelineComplete: false,
+          detectionStatus: "complete",
+        },
+      },
+    };
+    expect(
+      computeBulkImportPollInterval(detectionDoneAbsentIdent, clocks(), 0),
+    ).toBe(POLL);
+  });
+
+  test("polls while identification is running (identificationStatus=sent)", () => {
+    const response = {
+      task: {
+        status: "processing-detection",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineStarted: true,
+          pipelineComplete: false,
+          detectionStatus: "complete",
+          identificationStatus: "sent",
+        },
+      },
+    };
+    expect(computeBulkImportPollInterval(response, clocks(), 0)).toBe(POLL);
+  });
+
+  test("stops when pipeline complete and all encounters have taskInfo", () => {
+    const response = {
+      task: {
+        status: "complete",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineStarted: true,
+          pipelineComplete: true,
+          identificationStatus: "complete",
+          statsAnnotations: { encounterTaskInfo: { e1: [["t1", "x", "y"]] } },
+        },
+      },
+    };
+    expect(computeBulkImportPollInterval(response, clocks(), 0)).toBe(false);
+  });
+
+  test("polls while pipeline complete but taskInfo lags, within budget; stops past budget", () => {
+    const response = {
+      task: {
+        status: "complete",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineStarted: true,
+          pipelineComplete: true,
+          identificationStatus: "complete",
+          statsAnnotations: { encounterTaskInfo: {} },
+        },
+      },
+    };
+    const c = clocks();
+    // first observation at t=0 starts the lag clock
+    expect(computeBulkImportPollInterval(response, c, 0)).toBe(POLL);
+    expect(c.taskInfoLagFirstSeen).toBe(0);
+    // still within budget
+    expect(computeBulkImportPollInterval(response, c, BUDGET_MS - 1)).toBe(POLL);
+    // past budget -> stop
+    expect(computeBulkImportPollInterval(response, c, BUDGET_MS + 1)).toBe(false);
+  });
+
+  // Codex Major 1: legacy completed task (detection complete, identification
+  // "unknown", pipelineComplete false) must NOT poll forever. It is treated as
+  // a settled gap state, bounded by the handoff budget.
+  test("bounds legacy 'unknown' identification (does not poll forever)", () => {
+    const response = {
+      task: {
+        status: "complete",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineStarted: true,
+          pipelineComplete: false,
+          detectionStatus: "complete",
+          identificationStatus: "unknown",
+        },
+      },
+    };
+    const c = clocks();
+    expect(computeBulkImportPollInterval(response, c, 0)).toBe(POLL);
+    expect(computeBulkImportPollInterval(response, c, BUDGET_MS + 1)).toBe(false);
+  });
+
+  // Codex Major 4: detection complete + zero/trivial annotations -> zero match
+  // tasks -> "identification not started" is a settled gap, also bounded.
+  test("bounds detection-complete + zero annotations (identification not started)", () => {
+    const response = {
+      task: {
+        status: "processing-detection",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineStarted: true,
+          pipelineComplete: false,
+          detectionStatus: "complete",
+          identificationStatus: "identification not started",
+        },
+      },
+    };
+    const c = clocks();
+    expect(computeBulkImportPollInterval(response, c, 0)).toBe(POLL);
+    expect(computeBulkImportPollInterval(response, c, BUDGET_MS + 1)).toBe(false);
+  });
+
+  test("fully-skipped import (pipelineComplete via skipped) stops without over-polling", () => {
+    const response = {
+      task: {
+        status: "complete",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineStarted: false,
+          pipelineComplete: true,
+          detectionStatus: "skipped",
+          identificationStatus: "skipped",
+        },
+      },
+    };
+    expect(computeBulkImportPollInterval(response, clocks(), 0)).toBe(false);
+  });
+
+  // Round-2 Major 1: "processing-pipeline" overlay (re-ID on an already-
+  // "complete" task) must NOT poll forever when identification settles
+  // incomplete. It is treated as a bounded gap, not unbounded in-flight.
+  test("bounds 'processing-pipeline' overlay with settled-incomplete identification", () => {
+    const response = {
+      task: {
+        status: "processing-pipeline",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineStarted: true,
+          pipelineComplete: false,
+          detectionStatus: "complete",
+          identificationStatus: "unknown",
+        },
+      },
+    };
+    const c = clocks();
+    expect(computeBulkImportPollInterval(response, c, 0)).toBe(POLL);
+    expect(computeBulkImportPollInterval(response, c, BUDGET_MS + 1)).toBe(false);
+  });
+
+  test("polls unbounded while 'processing-pipeline' re-ID is actively running (ident=sent)", () => {
+    const response = {
+      task: {
+        status: "processing-pipeline",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineStarted: true,
+          pipelineComplete: false,
+          detectionStatus: "complete",
+          identificationStatus: "sent",
+        },
+      },
+    };
+    const c = clocks();
+    // far past a budget window — still polls because it's genuinely active
+    expect(computeBulkImportPollInterval(response, c, 10 * BUDGET_MS)).toBe(POLL);
+  });
+
+  // Round-2 Major 2: a legitimately long CSV import keeps polling past the
+  // budget as long as importPercent advances (liveness); a wedged one stops.
+  test("keeps polling a long CSV import while importPercent advances", () => {
+    const c = clocks();
+    const at = (pct, t) =>
+      computeBulkImportPollInterval(
+        { task: { status: "processing-background", encounters: [], importPercent: pct } },
+        c,
+        t,
+      );
+    expect(at(0.1, 0)).toBe(POLL);
+    // progress at t just under a budget window resets the clock...
+    expect(at(0.4, BUDGET_MS - 1)).toBe(POLL);
+    // ...so well past the original budget we still poll because pct advanced
+    expect(at(0.7, 2 * BUDGET_MS - 2)).toBe(POLL);
+  });
+
+  test("stops a wedged CSV import after the budget when importPercent does not advance", () => {
+    const c = clocks();
+    const stuck = {
+      task: { status: "processing-background", encounters: [], importPercent: 0.3 },
+    };
+    expect(computeBulkImportPollInterval(stuck, c, 0)).toBe(POLL);
+    // same pct, past budget -> stop
+    expect(computeBulkImportPollInterval(stuck, c, BUDGET_MS + 1)).toBe(false);
+  });
+
+  // Round-2 Major 3: a timed-out taskInfo lag must not carry into a later
+  // re-run and immediately stop the next aggregation poll. An in-flight
+  // observation clears the lag clock.
+  test("in-flight observation clears a timed-out taskInfo-lag clock for the next run", () => {
+    const c = clocks();
+    const lagging = {
+      task: {
+        status: "complete",
+        encounters: [{ id: "e1" }],
+        iaSummary: {
+          pipelineComplete: true,
+          identificationStatus: "complete",
+          statsAnnotations: { encounterTaskInfo: {} },
+        },
+      },
+    };
+    // lag observed at t=0, then times out past budget -> stop
+    expect(computeBulkImportPollInterval(lagging, c, 0)).toBe(POLL);
+    expect(computeBulkImportPollInterval(lagging, c, BUDGET_MS + 1)).toBe(false);
+
+    // operator re-runs identification -> ident goes "sent" (in-flight)
+    const rerun = {
+      task: {
+        status: "processing-pipeline",
+        encounters: [{ id: "e1" }],
+        iaSummary: { identificationStatus: "sent" },
+      },
+    };
+    expect(computeBulkImportPollInterval(rerun, c, BUDGET_MS + 2)).toBe(POLL);
+    expect(c.taskInfoLagFirstSeen).toBe(null);
+
+    // ident completes again with taskInfo still lagging -> fresh budget, polls
+    expect(computeBulkImportPollInterval(lagging, c, BUDGET_MS + 3)).toBe(POLL);
+    expect(c.taskInfoLagFirstSeen).toBe(BUDGET_MS + 3);
+  });
+
+  test("importPercent that does not strictly advance (equal/undefined) does not reset budget", () => {
+    // equal percent across polls -> no reset -> stops after budget
+    const cEq = clocks();
+    const eq = { task: { status: "processing-background", encounters: [], importPercent: 0.5 } };
+    expect(computeBulkImportPollInterval(eq, cEq, 0)).toBe(POLL);
+    expect(computeBulkImportPollInterval(eq, cEq, BUDGET_MS + 1)).toBe(false);
+
+    // undefined percent -> no liveness signal -> bounded by first-observed
+    const cU = clocks();
+    const noPct = { task: { status: "processing-background", encounters: [] } };
+    expect(computeBulkImportPollInterval(noPct, cU, 0)).toBe(POLL);
+    expect(computeBulkImportPollInterval(noPct, cU, BUDGET_MS + 1)).toBe(false);
+  });
+
+  test("'imported' with constant importPercent=1.0 resets once then stops after budget", () => {
+    const c = clocks();
+    const imported = {
+      task: { status: "imported", encounters: [{ id: "e1" }], importPercent: 1.0 },
+    };
+    expect(computeBulkImportPollInterval(imported, c, 0)).toBe(POLL);
+    expect(c.lastImportPercent).toBe(1.0);
+    // constant 1.0 is not a strict advance -> no further reset -> stops
+    expect(computeBulkImportPollInterval(imported, c, BUDGET_MS + 1)).toBe(false);
+  });
+
+  test("handoff poll stops exactly at the budget boundary (strict <)", () => {
+    const c = clocks();
+    const response = { task: { status: "imported", encounters: [{ id: "e1" }] } };
+    expect(computeBulkImportPollInterval(response, c, 0)).toBe(POLL);
+    expect(computeBulkImportPollInterval(response, c, BUDGET_MS)).toBe(false);
+  });
+
+  // An active phase must reset the handoff clock so a LATER gap gets a fresh
+  // budget rather than inheriting elapsed time from an earlier phase.
+  test("in-flight observation resets the handoff clock for a later gap", () => {
+    const c = clocks();
+    // long CSV import: handoff clock starts at t=0
+    const importing = { task: { status: "processing-background", encounters: [] } };
+    expect(computeBulkImportPollInterval(importing, c, 0)).toBe(POLL);
+    expect(c.handoffFirstSeen).toBe(0);
+
+    // detection goes in-flight near the budget edge -> resets clock
+    const detecting = {
+      task: {
+        status: "processing-detection",
+        encounters: [{ id: "e1" }],
+        iaSummary: { detectionStatus: "sent" },
+      },
+    };
+    expect(computeBulkImportPollInterval(detecting, c, BUDGET_MS - 1)).toBe(POLL);
+    expect(c.handoffFirstSeen).toBe(null);
+
+    // a later handoff gap re-arms the clock fresh and keeps polling
+    const handoff = {
+      task: {
+        status: "processing-detection",
+        encounters: [{ id: "e1" }],
+        iaSummary: { detectionStatus: "complete" },
+      },
+    };
+    expect(computeBulkImportPollInterval(handoff, c, BUDGET_MS)).toBe(POLL);
+    expect(c.handoffFirstSeen).toBe(BUDGET_MS);
+  });
+});

--- a/frontend/src/components/ProgressCard.jsx
+++ b/frontend/src/components/ProgressCard.jsx
@@ -49,7 +49,7 @@ export const ProgressCard = ({
               })}
             >
               <span style={{ fontSize: 11 }}>
-                {`${(progress * 100).toFixed(0)}%`}
+                {`${progress === 1 ? 100 : Math.min(99, Math.floor(progress * 100))}%`}
               </span>
             </CircularProgressbarWithChildren>
           )}

--- a/frontend/src/models/bulkImport/useGetBulkImportTask.js
+++ b/frontend/src/models/bulkImport/useGetBulkImportTask.js
@@ -1,45 +1,166 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { client } from "../../api/client";
 import { useQuery } from "react-query";
 
-// Whitelist of statuses that mean "work is in flight — keep polling."
-// Anything else (terminal, unknown, missing) stops polling. Chose a
-// whitelist over a terminal-blacklist because the backend emits a
-// somewhat open-ended set of statuses (e.g. ImportTask.java emits
-// "complete", "sent", "skipped", "identification not started",
-// "unknown"; BulkImport.java overlays "processing-pipeline" at the
-// task level) and the safe failure mode is "stop polling on an
-// unrecognized status" rather than "poll forever waiting for a
-// status string we'll never recognize."
-const IN_FLIGHT_STATUSES = new Set([
-  // Task-level transient states (see BulkImport.java:892,
-  // ImportTask.java)
-  "processing-pipeline",
-  // IA phase transient state — queued/running, not yet terminal
-  // (ImportTask.java:689, :711, :726)
-  "sent",
-]);
+// Statuses that mean "work is actively in flight" — poll UNBOUNDED while any of
+// these is present. Only the IA-phase "sent" signal qualifies: a running
+// detection/identification task already polled forever under the old "sent"
+// path, so this is not a new infinite-poll risk. Task-level overlay statuses
+// (e.g. "processing-pipeline") are deliberately NOT here — that overlay
+// persists whenever the IA phase settles incomplete (e.g. re-ID on an
+// already-"complete" task whose identification ends "unknown"/zero-annotation),
+// and treating it as unbounded-active would poll forever. Everything not in
+// this set is routed through the bounded handoff branch below, so an
+// unrecognized or settled-but-incomplete status can never poll forever.
+const IN_FLIGHT_STATUSES = new Set(["sent"]);
 
 const isInFlight = (status) => IN_FLIGHT_STATUSES.has(status);
 
-// Polling time budget from task creation. Used to bound the
-// early-phase poll (encounters not yet persisted) and the
-// post-ident-complete poll (encounterTaskInfo aggregation lagging
-// the identificationStatus flip). A degenerate import that never
-// progresses past creation, or an import whose taskInfo never
-// finishes aggregating, would otherwise poll forever.
-const PHASE_POLL_BUDGET_MS = 5 * 60 * 1000;
+// Terminal failure statuses — stop polling immediately and unconditionally,
+// even if a stale iaSummary field still looks in-flight. Must run before any
+// structural/in-flight check.
 const TERMINAL_ERROR_STATUSES = new Set(["error", "failed"]);
 
-// Fail-closed: if task.dateCreated is missing or unparseable, return
-// Infinity so any "is this within budget" check evaluates false and
-// polling stops. The alternative — returning 0 — would poll forever
-// on a degenerate response shape (Codex C8 round-1 Minor).
-const taskAgeMillis = (task) => {
-  if (!task?.dateCreated) return Infinity;
-  const created = new Date(task.dateCreated).getTime();
-  return Number.isFinite(created) ? Date.now() - created : Infinity;
-};
+// Poll cadence while work is in flight.
+const POLL_INTERVAL_MS = 5000;
+
+// Bound for both bounded polls: (a) the handoff / pre-pipeline gap and (b) the
+// post-ident encounterTaskInfo-aggregation lag. Measured from the first poll on
+// which we OBSERVED the gap — never from task.dateCreated. A long import can be
+// older than this budget by the time it reaches a handoff window, which is
+// exactly when the gap is most user-visible.
+const PHASE_POLL_BUDGET_MS = 5 * 60 * 1000;
+
+// Initial state for the per-gap "first observed" clocks the bounded polls use.
+export const initialPollClocks = () => ({
+  handoffFirstSeen: null,
+  taskInfoLagFirstSeen: null,
+  lastImportPercent: null,
+});
+
+// Pure polling-cadence decision, extracted from the hook so every branch is
+// unit-testable without driving react-query timers. Reads and updates the
+// `clocks` object in place; `now` is injectable for deterministic tests.
+// Returns POLL_INTERVAL_MS to keep polling or false to stop.
+export function computeBulkImportPollInterval(
+  response,
+  clocks,
+  now = Date.now(),
+) {
+  // react-query passes `undefined` before the first successful response. Poll
+  // so we pick up the initial state.
+  if (response === undefined) return POLL_INTERVAL_MS;
+
+  // Response came back but no task — backend returned an empty or malformed
+  // body (invalid/deleted task id). Re-polling cannot make it re-materialize.
+  const task = response?.task;
+  if (!task) {
+    clocks.handoffFirstSeen = null;
+    clocks.taskInfoLagFirstSeen = null;
+    return false;
+  }
+
+  // Global terminal-error stop: a failed/errored task never makes further
+  // progress; ignore any lingering in-flight-looking iaSummary fields.
+  if (task.status && TERMINAL_ERROR_STATUSES.has(task.status)) {
+    clocks.handoffFirstSeen = null;
+    clocks.taskInfoLagFirstSeen = null;
+    return false;
+  }
+
+  const ia = task.iaSummary || {};
+
+  // Explicit in-flight signal → unbounded poll (detection/identification
+  // running). Reset BOTH clocks: a fresh active phase invalidates any earlier
+  // handoff gap AND any earlier taskInfo-lag timeout (so a re-run's later
+  // aggregation lag gets a fresh budget rather than an already-expired one).
+  if (
+    isInFlight(task.status) ||
+    isInFlight(ia.detectionStatus) ||
+    isInFlight(ia.identificationStatus)
+  ) {
+    clocks.handoffFirstSeen = null;
+    clocks.taskInfoLagFirstSeen = null;
+    return POLL_INTERVAL_MS;
+  }
+
+  // Pipeline finished. The only reason to keep polling now is the
+  // encounterTaskInfo aggregation lagging the identificationStatus flip (it
+  // drives the per-encounter "Class" match-result links and can trail by one
+  // or more polls). Bounded by elapsed-since-first-observed-lag.
+  if (ia.pipelineComplete === true) {
+    clocks.handoffFirstSeen = null;
+    if (ia.identificationStatus === "complete") {
+      const encs = Array.isArray(task.encounters) ? task.encounters : [];
+      const taskInfo = ia.statsAnnotations?.encounterTaskInfo || {};
+      const anyMissing =
+        encs.length > 0 &&
+        encs.some(
+          (e) => !Array.isArray(taskInfo[e.id]) || taskInfo[e.id].length === 0,
+        );
+      if (anyMissing) {
+        if (clocks.taskInfoLagFirstSeen === null) {
+          clocks.taskInfoLagFirstSeen = now;
+        }
+        if (now - clocks.taskInfoLagFirstSeen < PHASE_POLL_BUDGET_MS) {
+          return POLL_INTERVAL_MS;
+        }
+      } else {
+        // taskInfo populated — clear so a future lag gets a fresh budget.
+        clocks.taskInfoLagFirstSeen = null;
+      }
+    } else {
+      // identification "skipped" (or otherwise non-"complete") has no match
+      // results to wait on — clear the lag clock and stop.
+      clocks.taskInfoLagFirstSeen = null;
+    }
+    return false;
+  }
+
+  // Handoff / pre-pipeline gap: not explicitly in-flight, not terminal-error,
+  // pipeline not yet complete. Covers every un-statused transition window the
+  // backend leaves between phases:
+  //   - "processing-background" / "processing-foreground" (active CSV import,
+  //     encounters not yet persisted)
+  //   - "imported": import committed but initiateIA() hasn't started the IA
+  //     task yet (BulkImport.java commits "imported" at :516, then initiateIA()
+  //     flips it to "processing-detection" + registers the IA task only after
+  //     the handleBulkImport round-trip at :824)
+  //   - "processing-detection" before detectionStatus="sent" appears
+  //   - detection complete before identificationStatus="sent" appears
+  //   - "processing-pipeline" overlay (re-ID) when identification is not "sent"
+  // It also catches SETTLED non-complete states (legacy
+  // identificationStatus="unknown" at ImportTask.java:759; "identification not
+  // started" with zero match tasks at :736). A single snapshot can't tell
+  // transient from settled, so bound this poll by elapsed-since-first-observed:
+  // worst case a settled state over-polls one budget window, then stops —
+  // never infinite.
+  //
+  // We're pre-completion, so any earlier taskInfo-lag timeout is stale; clear
+  // it so a later completion gets a fresh lag budget.
+  clocks.taskInfoLagFirstSeen = null;
+
+  // Active CSV import reports a monotonically-increasing importPercent. Treat
+  // forward progress as liveness: reset the handoff budget whenever
+  // importPercent advances, so a legitimately long import is never cut off,
+  // while a genuinely wedged one (no progress for a full budget window) still
+  // stops. importPercent is bounded [0,1], so this cannot reset forever.
+  const pct =
+    typeof task.importPercent === "number" ? task.importPercent : null;
+  if (
+    pct !== null &&
+    (clocks.lastImportPercent === null || pct > clocks.lastImportPercent)
+  ) {
+    clocks.lastImportPercent = pct;
+    clocks.handoffFirstSeen = now;
+  }
+
+  if (clocks.handoffFirstSeen === null) clocks.handoffFirstSeen = now;
+  if (now - clocks.handoffFirstSeen < PHASE_POLL_BUDGET_MS) {
+    return POLL_INTERVAL_MS;
+  }
+  return false;
+}
 
 export default function useGetBulkImportTask(taskId) {
   const fetchTask = async () => {
@@ -47,105 +168,38 @@ export default function useGetBulkImportTask(taskId) {
     return data;
   };
 
-  // Client-side timestamp of the first response where
-  // identificationStatus first became "complete" with any encounter
-  // still missing its taskInfo entry. Drives the post-ident tail
-  // bound separately from task.dateCreated, which can be older than
-  // the 5-min budget on long imports (Codex C8 round-1 Major).
-  const taskInfoLagFirstSeenRef = useRef(null);
+  // Per-gap "first observed" timestamps backing the two bounded polls, held in
+  // a ref so they persist across re-renders without re-triggering the query.
+  const clocksRef = useRef(initialPollClocks());
+
+  // Reset the clocks when the observed task changes (the hook is reused for
+  // different task ids, e.g. the unfinished-task probe on the import landing
+  // page); otherwise a prior task's expired budget would carry over and stop
+  // the new task's polling immediately.
+  useEffect(() => {
+    clocksRef.current = initialPollClocks();
+  }, [taskId]);
 
   const { data, isLoading, error, refetch } = useQuery(
     ["bulkImportTask", taskId],
     fetchTask,
     {
       enabled: Boolean(taskId),
-      refetchOnWindowFocus: false,
       retry: false,
       select: (d) => d ?? [],
-      // Poll every 5s while ANY of the three observable phase
-      // statuses (task.status, iaSummary.detectionStatus,
-      // iaSummary.identificationStatus) is in flight. Stop polling
-      // once none of them is in flight. The IA phases run after task
-      // upload completes (BulkImportTask.jsx:498 gates the re-ID
-      // button on both task.status and iaSummary.detectionStatus
-      // being complete), so we cannot stop on task.status alone.
-      refetchInterval: (response) => {
-        // First load not complete yet — react-query passes `undefined`
-        // before the first successful response. Poll so we pick up
-        // the initial state.
-        if (response === undefined) return 5000;
-        // Response came back but no task — backend returned an empty
-        // or malformed body (e.g. the task id is invalid or was
-        // deleted). Stop polling; re-polling cannot make the task
-        // re-materialize, and infinite polling on a 200-with-no-task
-        // would hammer the API.
-        const task = response?.task;
-        if (!task) return false;
-        if (isInFlight(task.status)) return 5000;
-        if (isInFlight(task.iaSummary?.detectionStatus)) return 5000;
-        if (isInFlight(task.iaSummary?.identificationStatus)) return 5000;
-        // Early-phase polling: bulk-import row persistence runs in the
-        // background (BulkImport.java#createImport [background]) before
-        // IA queueing. If we hit the page in that window task exists
-        // but task.encounters is empty AND no IA phase has fired yet,
-        // and task.status is one of the early CSV-import strings
-        // ("started", "Importing N", "imported", "complete") none of
-        // which match the in-flight whitelist. Without this branch the
-        // page strands on "There are no records to display" and never
-        // refreshes. Bound: stop if the task is older than 5 min
-        // (degenerate import, 0 MAs, IA never fires) or if task.status
-        // is already terminal-error.
-        const hasEncounters = Array.isArray(task.encounters) &&
-          task.encounters.length > 0;
-        const pipelineStarted = task.iaSummary?.pipelineStarted === true;
-        if (!hasEncounters && !pipelineStarted) {
-          if (task.status && TERMINAL_ERROR_STATUSES.has(task.status)) {
-            return false;
-          }
-          if (taskAgeMillis(task) < PHASE_POLL_BUDGET_MS) return 5000;
-        }
-        // Post-ident-complete polling: encounterTaskInfo (which drives
-        // the per-encounter "Class" column match-result links) is
-        // aggregated lazily and can lag the identificationStatus flip
-        // by one or more polls. Keep polling while ident is complete
-        // but any encounter still lacks its taskInfo entry — the
-        // alternative is the page goes static and the user has to
-        // manually refresh to see the links.
-        //
-        // Bound by elapsed-since-we-first-observed-the-lag, NOT task
-        // age. A long bulk import that takes >5 min to complete IA
-        // would otherwise skip this branch entirely, which is the
-        // exact case where the lag is most user-visible.
-        if (task.iaSummary?.identificationStatus === "complete") {
-          const encs = hasEncounters ? task.encounters : [];
-          const taskInfo =
-            task.iaSummary?.statsAnnotations?.encounterTaskInfo || {};
-          const anyMissing =
-            encs.length > 0 &&
-            encs.some(
-              (e) =>
-                !Array.isArray(taskInfo[e.id]) || taskInfo[e.id].length === 0,
-            );
-          if (anyMissing) {
-            if (taskInfoLagFirstSeenRef.current === null) {
-              taskInfoLagFirstSeenRef.current = Date.now();
-            }
-            const elapsed = Date.now() - taskInfoLagFirstSeenRef.current;
-            if (elapsed < PHASE_POLL_BUDGET_MS) return 5000;
-          } else {
-            // taskInfo populated — clear the ref so a future lag
-            // (e.g. operator re-runs identification on this task)
-            // gets a fresh 5-min budget.
-            taskInfoLagFirstSeenRef.current = null;
-          }
-        }
-        return false;
-      },
-      // Pause polling when the browser tab is hidden. Polling resumes
-      // on the next scheduled interval after the tab regains focus
-      // (refetchOnWindowFocus stays false so we do not double-fetch
-      // the instant the tab is restored).
+      refetchInterval: (response) =>
+        computeBulkImportPollInterval(response, clocksRef.current),
+      // Do not fetch on a hidden tab: the interval keeps firing but skips the
+      // fetch, so the last data + last interval value freeze.
       refetchIntervalInBackground: false,
+      // Refetch when the tab regains focus. With refetchIntervalInBackground
+      // false a backgrounded tab's polling is suspended; in react-query v3 a
+      // refetchInterval that returned `false` clears the timer and nothing
+      // re-arms it on its own. A focus refetch re-samples the backend the
+      // instant the user returns and re-arms polling if work is still in
+      // flight — turning a terminal stall into a self-healing one. Cost is one
+      // extra GET on focus, which is the desired "refresh on return" behavior.
+      refetchOnWindowFocus: true,
     },
   );
 

--- a/frontend/src/pages/BulkImport/BulkImportTask.jsx
+++ b/frontend/src/pages/BulkImport/BulkImportTask.jsx
@@ -283,32 +283,31 @@ const BulkImportTask = observer(() => {
       <Row className="g-2">
         <div className="d-flex flex-row gap-3">
           {[
-            {
-              title: intl.formatMessage({
-                id: "IMPORT",
-              }),
-              progress:
-                task?.importPercent ||
+            (() => {
+              // Import is "done" once it hits 100%, or once a later phase
+              // proves it finished (task complete, detection complete, or the
+              // pipeline overlay is running). Compute once so progress and
+              // status stay consistent. NOTE: the bar must show the *actual*
+              // fractional importPercent while in progress — guarding only
+              // against `=== 1` here, not any truthy value, otherwise a 30%
+              // import renders as a full bar.
+              const importComplete =
+                task?.importPercent === 1 ||
                 task?.status === "complete" ||
                 task?.iaSummary?.detectionStatus === "complete" ||
-                task?.status === "processing-pipeline"
-                  ? 1
-                  : 0,
-              status: (() => {
-                if (
-                  task?.importPercent === 1 ||
-                  task?.status === "complete" ||
-                  task?.iaSummary?.detectionStatus === "complete" ||
-                  task?.status === "processing-pipeline"
-                ) {
-                  return "complete";
-                } else if (task?.importPercent) {
-                  return "in_progress";
-                } else {
-                  return "not_started";
-                }
-              })(),
-            },
+                task?.status === "processing-pipeline";
+              return {
+                title: intl.formatMessage({
+                  id: "IMPORT",
+                }),
+                progress: importComplete ? 1 : task?.importPercent || 0,
+                status: importComplete
+                  ? "complete"
+                  : task?.importPercent
+                    ? "in_progress"
+                    : "not_started",
+              };
+            })(),
             {
               title: intl.formatMessage({
                 id: "DETECTION",


### PR DESCRIPTION
## Problem

On `/react/bulk-import-task`, switching browser tabs while an import was finishing and returning during the Import→Detection transition left the page **stalled at Import**, even though the backend had moved on to Detection. A manual refresh fixed it.

## Root cause (react-query v3.39.3)

Polling is driven by `useGetBulkImportTask`'s `refetchInterval` returning `5000` (keep polling) vs `false` (stop). In react-query v3:

- `refetchInterval: false` clears the interval timer (`queryObserver.js`), and with `refetchOnWindowFocus: false` nothing re-arms it.
- `refetchIntervalInBackground: false` suspends fetches on a hidden tab, so returning to the tab produces a single catch-up fetch — whatever state it lands in decides everything.

`refetchInterval` returned `false` during legitimate in-progress states the backend emits between phases that the in-flight whitelist and the `!hasEncounters`-gated early-phase branch didn't cover:

- **`"imported"`** — committed (`BulkImport.java:498`) before `initiateIA()` starts the IA task (`:824`); `detectionStatus` is absent in this window.
- **`"processing-detection"`** (`:808`) and the **detection→identification handoff** where `detectionStatus`/`identificationStatus` are momentarily absent.

Foreground dense polling rode over the brief gaps; a backgrounded tab's single catch-up fetch on return often landed in a gap and killed polling permanently.

## Fix (frontend only)

- Extract the cadence decision into a pure, unit-testable `computeBulkImportPollInterval(response, clocks, now)`.
- Poll **unbounded only** on the explicit `"sent"` IA signal; route every un-statused gap (`"imported"`, pre-`"sent"` detection, detection→ident handoff, `"processing-pipeline"` re-ID while ident isn't `"sent"`) and settled-incomplete states (legacy `"unknown"`, `"identification not started"`) through a single branch **bounded by elapsed-since-first-observed** — so nothing polls forever.
- Treat advancing `importPercent` as liveness so long CSV imports aren't cut off at the budget, while a wedged one still stops.
- Global terminal-error stop runs first; each in-flight observation resets the handoff clock and clears the taskInfo-lag clock; budget keyed off first-observed (not `task.dateCreated`); both clocks reset on `taskId` change.
- `refetchOnWindowFocus: true` as a self-healing backstop on tab return.

Also fixes an unrelated display bug surfaced during review: the IMPORT progress card rendered **100% for any partial import** (`||`/`?:` precedence in the `progress` expression); now computes a single `importComplete` boolean, and `ProgressCard` floors+caps the label at 99 until truly complete.

## Testing

- 23 unit tests for `computeBulkImportPollInterval` covering every branch incl. the handoff and re-run regressions (`frontend/src/__tests__/models/bulkImport/useGetBulkImportTask.test.js`).
- Both touched JSX files parse clean.
- Reviewed with Codex across two rounds on the polling change (7 findings, all incorporated) and once on the display fix (no Critical/Major).

> Note: `frontend/src/__tests__/pages/BulkImport/BulkImportTask.test.js` has a **pre-existing** babel parse failure on `main` (confirmed present with this branch's changes reverted) — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
