### PR TITLE
Fix #1608: rebuild match graph from DB at startup, stop resurrecting deleted spot maps

### DIFF
--- a/src/main/java/org/ecocean/StartupWildbook.java
+++ b/src/main/java/org/ecocean/StartupWildbook.java
@@ -886,9 +886,6 @@ public class StartupWildbook implements ServletContextListener {
         System.out.println("* StartupWildbook destroyed called for: " +
             servletContextInfo(sContext));
 
-        if (CommonConfiguration.useSpotPatternRecognition(context)) {
-            saveMatchGraph(sContext, context);
-        }
         // Stop the WBIA poller first so it does not race teardown of
         // Shepherd / IndexingManager / QueueUtil while a poll cycle is in
         // flight. shutdownWbiaRegisterExecutor signals shutdown by
@@ -938,28 +935,16 @@ public class StartupWildbook implements ServletContextListener {
      * via MatchGraphCreationThread.
      */
     public static void loadMatchGraphOrRebuild(ServletContext sContext, String context) {
-        try {
-            String dataDir = CommonConfiguration.getDataDirectory(sContext, context).getAbsolutePath();
-            String cacheFile = GridManager.getCacheFilePath(dataDir);
-            if (new File(cacheFile).exists() && GridManager.cacheRead(cacheFile)) {
-                System.out.println("INFO: matchGraph loaded from cache.");
-                return;
-            }
-        } catch (Exception e) {
-            System.out.println("WARNING: Could not load matchGraph cache, rebuilding from DB: " +
-                e.getMessage());
-        }
+        // Always rebuild the match graph from the database at startup. The match
+        // graph is the candidate set for Modified-Groth scans; rebuilding from the
+        // DB on every startup guarantees deleted spot maps / encounters cannot
+        // reappear as match candidates (issue #1608). The former
+        // WEB-INF/MatchGraphCache.json startup cache was only refreshed on a
+        // graceful shutdown, so a crash/kill left it stale and the next startup
+        // resurrected deleted spots. setMatchGraphReady(false) up front keeps
+        // scans gated until the rebuild completes.
+        GridManager.setMatchGraphReady(false);
         createMatchGraph();
-    }
-
-    public static void saveMatchGraph(ServletContext sContext, String context) {
-        try {
-            String dataDir = CommonConfiguration.getDataDirectory(sContext, context).getAbsolutePath();
-            String cacheFile = GridManager.getCacheFilePath(dataDir);
-            GridManager.cacheWrite(cacheFile);
-        } catch (Exception e) {
-            System.out.println("WARNING: Could not save matchGraph cache: " + e.getMessage());
-        }
     }
 
     public static boolean skipInit(ServletContextEvent sce, String extra) {

--- a/src/main/java/org/ecocean/grid/GridManager.java
+++ b/src/main/java/org/ecocean/grid/GridManager.java
@@ -2,13 +2,10 @@ package org.ecocean.grid;
 
 // import org.apache.commons.math.stat.descriptive.SummaryStatistics;
 // import org.ecocean.CommonConfiguration;
-import org.ecocean.Util;
 import org.ecocean.shepherd.core.Shepherd;
 
 // import org.ecocean.servlet.ServletUtilities;
 
-import java.io.IOException;
-import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.http.HttpServletRequest;
@@ -16,7 +13,6 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Enumeration;
 
-import org.json.JSONObject;
 
 // import org.apache.commons.math.stat.descriptive.SummaryStatistics;
 
@@ -666,77 +662,9 @@ public class GridManager {
     }
 
     public void resetMatchGraphWithInitialCapacity(int initialCapacity) {
-        matchGraph = null;
+        // Single assignment: never expose a null matchGraph to concurrent mutators
+        // (servlet add/remove) during a rebuild -- the old null-then-new sequence
+        // had an NPE window. (#1608)
         matchGraph = new ConcurrentHashMap<String, EncounterLite>(initialCapacity);
-    }
-
-    private static final String CACHE_FILEPATH = "WEB-INF/MatchGraphCache.json";
-
-    public static String getCacheFilePath(String dataDir) {
-        return dataDir + "/" + CACHE_FILEPATH;
-    }
-
-    /**
-     * Serialize the matchGraph to a JSONObject for disk caching.
-     */
-    public static JSONObject cacheToJSONObject() {
-        JSONObject root = new JSONObject();
-        root.put("timestamp", System.currentTimeMillis());
-        JSONObject entries = new JSONObject();
-        for (ConcurrentHashMap.Entry<String, EncounterLite> entry : matchGraph.entrySet()) {
-            entries.put(entry.getKey(), entry.getValue().toJSONObject());
-        }
-        root.put("matchGraph", entries);
-        root.put("count", matchGraph.size());
-        return root;
-    }
-
-    /**
-     * Write the matchGraph cache to disk as JSON.
-     */
-    public static void cacheWrite(String filepath) throws IOException {
-        long t = System.currentTimeMillis();
-        System.out.println("INFO: GridManager.cacheWrite() writing to " + filepath);
-        Util.writeToFile(cacheToJSONObject().toString(), filepath);
-        System.out.println("INFO: GridManager.cacheWrite() complete with " + matchGraph.size() +
-            " entries in " + (System.currentTimeMillis() - t) + "ms");
-    }
-
-    /**
-     * Read the matchGraph cache from disk JSON.
-     * Returns true if the cache was loaded successfully, false otherwise.
-     */
-    public static boolean cacheRead(String filepath) throws IOException {
-        long t = System.currentTimeMillis();
-        matchGraphReady = false;
-        String content = Util.readFromFile(filepath);
-        JSONObject root = Util.stringToJSONObject(content);
-        if (root == null) {
-            System.out.println("ERROR: GridManager.cacheRead() could not parse " + filepath);
-            return false;
-        }
-        System.out.println("INFO: GridManager.cacheRead() from " + filepath +
-            " timestamp=" + root.optLong("timestamp"));
-
-        JSONObject entries = root.optJSONObject("matchGraph");
-        if (entries == null || entries.length() < 1) {
-            System.out.println("ERROR: GridManager.cacheRead() empty matchGraph in " + filepath);
-            return false;
-        }
-
-        matchGraph = new ConcurrentHashMap<String, EncounterLite>(entries.length());
-        Iterator<String> keys = entries.keys();
-        while (keys.hasNext()) {
-            String key = keys.next();
-            JSONObject elJson = entries.optJSONObject(key);
-            if (elJson == null) continue;
-            EncounterLite el = EncounterLite.fromJSONObject(elJson);
-            matchGraph.put(key, el);
-        }
-        resetPatternCounts();
-        matchGraphReady = true;
-        System.out.println("INFO: GridManager.cacheRead() complete with " + matchGraph.size() +
-            " entries in " + (System.currentTimeMillis() - t) + "ms");
-        return true;
     }
 }

--- a/src/main/java/org/ecocean/grid/MatchGraphCreationThread.java
+++ b/src/main/java/org/ecocean/grid/MatchGraphCreationThread.java
@@ -74,6 +74,14 @@ public class MatchGraphCreationThread implements Runnable, ISharkGridThread {
 
             for (int i = 0; i < numEncs; i++) {
                 Encounter enc = myShepherd.getEncounter(encNumbers.get(i));
+                // getEncounter() returns null if the encounter was deleted after the
+                // id snapshot above (a concurrent EncounterDelete during the rebuild)
+                // or otherwise could not be fetched. Skip it rather than NPE-aborting
+                // the whole rebuild. A genuine exception while building the
+                // EncounterLite below is NOT swallowed: it propagates to the outer
+                // catch, which aborts the rebuild WITHOUT flipping matchGraphReady to
+                // true, so we never publish a silently-incomplete graph. (#1608)
+                if (enc == null) continue;
                 if (((enc.getRightSpots() != null) && (enc.getRightSpots().size() > 0)) ||
                     ((enc.getSpots() != null) && (enc.getSpots().size() > 0))) {
                     EncounterLite el = new EncounterLite(enc);

--- a/src/main/java/org/ecocean/servlet/EncounterDelete.java
+++ b/src/main/java/org/ecocean/servlet/EncounterDelete.java
@@ -56,6 +56,22 @@ public class EncounterDelete extends HttpServlet {
         PrintWriter out = response.getWriter();
         boolean locked = false;
 
+        // Refuse deletion while the match graph is rebuilding from the DB (only
+        // for ~15 min after a restart on spot-matching installs). A concurrent
+        // deletion during the rebuild could be undone by the rebuild's stale read
+        // and resurrect the encounter as a match candidate. (#1608)
+        if (CommonConfiguration.useSpotPatternRecognition(context) &&
+            !GridManager.isMatchGraphReady()) {
+            myShepherd.closeDBTransaction(); // PM opened in ctor; no tx begun yet
+            out.println(ServletUtilities.getHeader(request));
+            out.println(
+                "<strong>Please wait:</strong> the match graph is rebuilding. Please try deleting this encounter again in a few minutes.");
+            out.println(ServletUtilities.getFooter(context));
+            response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            out.close();
+            return;
+        }
+
         // setup data dir
         String rootWebappPath = getServletContext().getRealPath("/");
         File webappsDir = new File(rootWebappPath).getParentFile();
@@ -171,11 +187,13 @@ public class EncounterDelete extends HttpServlet {
                     enc2trash.setSkipAutoIndexing(false);
                     myShepherd.throwAwayEncounter(enc2trash);
 
-                    // remove from grid too
-                    GridManager gm = GridManagerFactory.getGridManager();
-                    gm.removeMatchGraphEntry(request.getParameter("number"));
-
-                    myShepherd.commitDBTransaction();
+                    // Only drop the match-graph entry once the deletion is confirmed
+                    // committed, so a swallowed commit failure can't remove a
+                    // still-present encounter from the candidate set. (#1608)
+                    if (myShepherd.commitDBTransactionWithStatus()) {
+                        GridManager gm = GridManagerFactory.getGridManager();
+                        gm.removeMatchGraphEntry(request.getParameter("number"));
+                    }
 
                     // log it
                     log.info("Click to restore deleted encounter: <a href=\"" +

--- a/src/main/java/org/ecocean/servlet/EncounterRemoveSpots.java
+++ b/src/main/java/org/ecocean/servlet/EncounterRemoveSpots.java
@@ -44,6 +44,21 @@ public class EncounterRemoveSpots extends HttpServlet {
         boolean locked = false;
         boolean isOwner = true;
         GridManager gm = GridManagerFactory.getGridManager();
+        // Refuse spot removal while the match graph is rebuilding from the DB
+        // (only happens for ~15 min after a restart on spot-matching installs).
+        // A concurrent removal during the rebuild could be overwritten by the
+        // rebuild's stale read and resurrect the deleted spots. (#1608)
+        if (CommonConfiguration.useSpotPatternRecognition(context) &&
+            !GridManager.isMatchGraphReady()) {
+            myShepherd.closeDBTransaction(); // PM opened in ctor; no tx begun yet
+            out.println(ServletUtilities.getHeader(request));
+            out.println(
+                "<strong>Please wait:</strong> the match graph is rebuilding. Please try removing spot data again in a few minutes.");
+            out.println(ServletUtilities.getFooter(context));
+            response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            out.close();
+            return;
+        }
         // ConcurrentHashMap<String,EncounterLite> chm= gm.getMatchGraph();
         /*
            if(request.getParameter("number")!=null){
@@ -97,9 +112,27 @@ public class EncounterRemoveSpots extends HttpServlet {
                             "-side spot data.</p>");
                         // despotMe.setNumLeftSpots(0);
                     }
-                    gm.addMatchGraphEntry(request.getParameter("number"),
-                        new EncounterLite(despotMe));
-                    myShepherd.commitDBTransaction();
+                    // Build the lite snapshot while the encounter is still managed,
+                    // then update the in-memory match graph AFTER the DB commit so
+                    // (a) a failed commit can't leave the graph inconsistent with the
+                    // DB and (b) the startup rebuild's DB read can't overwrite this
+                    // change with pre-commit (still-spotted) state. (#1608)
+                    boolean stillHasSpots =
+                        ((despotMe.getSpots() != null) && (despotMe.getSpots().size() > 0)) ||
+                        ((despotMe.getRightSpots() != null) &&
+                        (despotMe.getRightSpots().size() > 0));
+                    EncounterLite updatedLite = stillHasSpots ? new EncounterLite(despotMe) : null;
+                    // Only touch the match graph once the DB change is confirmed
+                    // committed, so a swallowed commit failure can't leave the graph
+                    // inconsistent with the DB. (#1608)
+                    if (myShepherd.commitDBTransactionWithStatus()) {
+                        if (stillHasSpots) {
+                            gm.addMatchGraphEntry(request.getParameter("number"), updatedLite);
+                        } else {
+                            // fully de-spotted: drop it from the candidate set entirely
+                            gm.removeMatchGraphEntry(request.getParameter("number"));
+                        }
+                    }
                 } else {
                     locked = true;
                     myShepherd.rollbackDBTransaction();

--- a/src/main/java/org/ecocean/servlet/GrothMatchServlet.java
+++ b/src/main/java/org/ecocean/servlet/GrothMatchServlet.java
@@ -126,6 +126,11 @@ public class GrothMatchServlet extends HttpServlet {
             if (entry.getKey().equals(encNumber)) continue;
             EncounterLite el = entry.getValue();
 
+            // Skip candidates with no spots on the side being scanned. An encounter
+            // whose spot map was deleted must never surface as a match candidate. (#1608)
+            ArrayList candidateSpots = rightScan ? el.getRightSpots() : el.getSpots();
+            if ((candidateSpots == null) || candidateSpots.isEmpty()) continue;
+
             MatchObject mo = el.getPointsForBestMatch(
                 queryArray, epsilon, R, Sizelim, maxTriangleRotation, C,
                 true, rightScan);

--- a/src/main/java/org/ecocean/servlet/SubmitSpotsAndImage.java
+++ b/src/main/java/org/ecocean/servlet/SubmitSpotsAndImage.java
@@ -165,12 +165,20 @@ public class SubmitSpotsAndImage extends HttpServlet {
 	            enc.setSpots(spots);
 	            enc.setLeftReferenceSpots(refSpots);
 	        }
-	        // reset the entry in the GridManager graph
+	        // Build the lite snapshot while the encounter is still managed, then
+	        // update the in-memory match graph AFTER the DB commit so a failed commit
+	        // can't leave the graph inconsistent with the DB and the startup rebuild
+	        // can't overwrite it with pre-commit state. (#1608)
 	        GridManager gm = GridManagerFactory.getGridManager();
-	        gm.addMatchGraphEntry(encId, new EncounterLite(enc));
-	
-	        myShepherd.commitDBTransaction();
+	        EncounterLite updatedLite = new EncounterLite(enc);
+
+	        // Only add to the match graph once the spots are confirmed committed, so
+	        // a swallowed commit failure can't leave a phantom candidate. (#1608)
+	        boolean committed = myShepherd.commitDBTransactionWithStatus();
 	        myShepherd.closeDBTransaction();
+	        if (committed) {
+	            gm.addMatchGraphEntry(encId, updatedLite);
+	        }
 	
 	        JSONObject rtn = new JSONObject("{\"success\": true}");
 	        rtn.put("spotAssetId", crMa.getId());

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -3359,6 +3359,30 @@ public class Shepherd {
     }
 
     /**
+     * Commit and report whether the commit actually succeeded. Unlike
+     * {@link #commitDBTransaction()} (which swallows commit failures and returns
+     * void), this returns false if the transaction was inactive or the commit
+     * threw. Callers can use this to avoid mutating in-memory state after a commit
+     * that did not durably persist -- e.g. only update the GridManager match graph
+     * once the encounter change is confirmed committed. (#1608)
+     */
+    public boolean commitDBTransactionWithStatus() {
+        try {
+            if ((pm != null) && pm.currentTransaction().isActive()) {
+                pm.currentTransaction().commit();
+                ShepherdState.setShepherdState(action + "_" + shepherdID, "commit");
+                return true;
+            }
+            System.out.println("commitDBTransactionWithStatus: transaction was not active.");
+            return false;
+        } catch (Exception e) {
+            System.out.println("commitDBTransactionWithStatus: commit failed: " + e);
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
      * Since we call these together all over Wildbook
      */
     public void updateDBTransaction() {

--- a/src/test/java/org/ecocean/grid/MatchGraphCacheTest.java
+++ b/src/test/java/org/ecocean/grid/MatchGraphCacheTest.java
@@ -131,73 +131,10 @@ class MatchGraphCacheTest {
         assertNull(reloaded.getRightReferenceSpots());
     }
 
-    @Test
-    void testGridManagerCacheRoundTrip() {
-        JSONObject el1Json = makeElJson("enc-A", "ind-1", "2024-01-01", "male", 2.0,
-            new double[]{1.0, 2.0, 3.0, 4.0, 5.0},
-            new double[]{1.1, 2.1, 3.1, 4.1, 5.1},
-            null, null);
-
-        JSONObject el2Json = makeElJson("enc-B", "ind-2", "2024-06-15", "female", 4.0,
-            null, null,
-            new double[]{10.0, 20.0, 30.0},
-            new double[]{11.0, 21.0, 31.0});
-        el2Json.put("genus", "Rhincodon");
-        el2Json.put("specificEpithet", "typus");
-
-        EncounterLite el1 = EncounterLite.fromJSONObject(el1Json);
-        EncounterLite el2 = EncounterLite.fromJSONObject(el2Json);
-
-        // Clear and populate the matchGraph directly
-        GridManager gm = GridManagerFactory.getGridManager();
-        gm.resetMatchGraphWithInitialCapacity(10);
-        GridManager.getMatchGraph().put("enc-A", el1);
-        GridManager.getMatchGraph().put("enc-B", el2);
-
-        // Serialize the whole matchGraph to JSON (as cacheWrite does)
-        JSONObject cacheJson = GridManager.cacheToJSONObject();
-
-        // Verify structure
-        assertTrue(cacheJson.has("timestamp"));
-        assertTrue(cacheJson.has("matchGraph"));
-        assertEquals(2, cacheJson.getInt("count"));
-
-        JSONObject entries = cacheJson.getJSONObject("matchGraph");
-        assertTrue(entries.has("enc-A"));
-        assertTrue(entries.has("enc-B"));
-
-        // Simulate what cacheRead does: clear graph and reload from JSON
-        gm.resetMatchGraphWithInitialCapacity(10);
-        assertEquals(0, GridManager.getMatchGraph().size());
-
-        // Parse the JSON string back (simulates reading from file)
-        String jsonString = cacheJson.toString();
-        JSONObject parsed = new JSONObject(jsonString);
-        JSONObject reloadedEntries = parsed.getJSONObject("matchGraph");
-        for (String key : reloadedEntries.keySet()) {
-            EncounterLite el = EncounterLite.fromJSONObject(reloadedEntries.getJSONObject(key));
-            GridManager.getMatchGraph().put(key, el);
-        }
-
-        // Verify reloaded data
-        assertEquals(2, GridManager.getMatchGraph().size());
-
-        EncounterLite reloadedA = GridManager.getMatchGraphEncounterLiteEntry("enc-A");
-        assertNotNull(reloadedA);
-        assertEquals("enc-A", reloadedA.getEncounterNumber());
-        assertEquals("ind-1", reloadedA.getBelongsToMarkedIndividual());
-        assertNotNull(reloadedA.getSpots());
-        assertEquals(5, reloadedA.getSpots().size());
-
-        EncounterLite reloadedB = GridManager.getMatchGraphEncounterLiteEntry("enc-B");
-        assertNotNull(reloadedB);
-        assertEquals("enc-B", reloadedB.getEncounterNumber());
-        assertEquals("Rhincodon", reloadedB.getGenus());
-        assertEquals("typus", reloadedB.getSpecificEpithet());
-        assertNotNull(reloadedB.getRightSpots());
-        assertEquals(3, reloadedB.getRightSpots().size());
-        assertNull(reloadedB.getSpots());
-    }
+    // NOTE: the former testGridManagerCacheRoundTrip was removed: the MatchGraphCache.json
+    // serialize/reload mechanism (GridManager.cacheToJSONObject / cacheWrite / cacheRead) was
+    // deleted in #1608/#1610 in favor of always rebuilding the match graph from the DB at
+    // startup. The remaining tests cover EncounterLite round-trip and live matchGraph behavior.
 
     @Test
     void testGrothCompatibilityAfterRoundTrip() {


### PR DESCRIPTION
Closes #1608.

## Problem
Deleted spot maps were reappearing as Modified-Groth match candidates in new scans, weeks after deletion (e.g. South African *Carcharias taurus* surfacing for Australian sharks).

Groth candidates come only from the in-memory `GridManager.matchGraph`. Since "Optimized Modified Groth" (`bf6ab9b6ca`, 2026-02-20), that map is seeded at startup from the disk cache `WEB-INF/MatchGraphCache.json`. The cache is written **only** at graceful shutdown (`contextDestroyed → saveMatchGraph`) and is **never invalidated** when spots/encounters are deleted. So a non-graceful restart (OOM / `docker kill` / crash) skips the write, the next startup reloads the stale spotted entries, and deleted spot maps reappear as candidates — persisting across restarts until a clean shutdown finally overwrites the file. The DB was correct the whole time; only the matcher's in-memory view was stale.

## Fix
Make the database authoritative and harden the surrounding paths:

- **`StartupWildbook`** — always rebuild the match graph from the DB at startup (`setMatchGraphReady(false)` + `createMatchGraph()`); drop the disk-cache read and the shutdown cache write. Scans stay gated (503 "match graph is still loading") during the ~15-min rebuild, as before on a cold start.
- **`GridManager`** — remove the now-unused cache machinery (`cacheRead/cacheWrite/cacheToJSONObject/getCacheFilePath/CACHE_FILEPATH`) and unused imports; `resetMatchGraphWithInitialCapacity` is single-assignment (no transient `null` window).
- **`Shepherd`** — add `commitDBTransactionWithStatus()` (the existing `commitDBTransaction()` swallows commit failures). The three match-graph mutators build the `EncounterLite` while the object is still JDO-managed and update the graph **only after a confirmed commit**: `EncounterRemoveSpots`, `SubmitSpotsAndImage`, `EncounterDelete`.
- **`EncounterRemoveSpots` / `EncounterDelete`** — refuse with 503 while the graph is rebuilding, guarded by `useSpotPatternRecognition` so non-spot installs (where the graph is never built) aren't permanently blocked. This closes the delete-vs-rebuild race. The eagerly-opened `Shepherd` PM is closed before the early return.
- **`MatchGraphCreationThread`** — skip concurrently-deleted (`null`) encounters; genuine row errors propagate and abort the rebuild **without** marking the graph ready (no silently-incomplete graph).
- **`GrothMatchServlet`** — skip candidates with no spots on the scanned side.

## Trade-off
This removes the startup match-graph disk cache, so startups again take ~15 min to rebuild the graph from the DB. Accepted because restarts are rare and the database must be the source of truth for the candidate set.

## Verification
- `mvn compile` passes.
- Reviewed with `codex` across 3 rounds to convergence (no Critical/Major findings).

### Known minor / deferred (pre-existing, not introduced here)
- The delete/remove-spots servlets still report "success" even if the commit fails.
- `SubmitSpotsAndImage` closes the Shepherd then `finally` rolls back a closed PM.
- `Shepherd.getEncounter()` collapses transient fetch errors to `null`, so the rebuild could silently skip such a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)