### PR TITLE
Revive I3S spot matching in the live scan (one scan runs Groth + I3S)

### DIFF
--- a/src/main/java/org/ecocean/grid/I3SResultWriter.java
+++ b/src/main/java/org/ecocean/grid/I3SResultWriter.java
@@ -1,0 +1,175 @@
+package org.ecocean.grid;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Vector;
+
+import org.dom4j.Document;
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.ecocean.Encounter;
+import org.ecocean.SuperSpot;
+
+import com.reijns.I3S.Pair;
+
+/**
+ * Writes an I3S spot-match result file (<code>lastFull[Right]I3SScan.xml</code>) for the live
+ * synchronous scan. This revives the I3S output that was dropped when the asynchronous grid
+ * scan path (ScanWorkItem / WriteOutScanTask.i3sWriteThis) fell out of use and the scan was
+ * rewritten as the Groth-only {@link org.ecocean.servlet.GrothMatchServlet}.
+ *
+ * The XML shape matches what WriteOutScanTask.i3sWriteThis produced so that
+ * <code>encounters/i3sScanEndApplet.jsp</code> can render it unchanged. Two differences,
+ * deliberately, from the legacy writer:
+ * <ul>
+ *   <li>matched-spot coordinates are read from the exact {@link EncounterLite} objects that
+ *       {@code i3sScan} indexed (the query lite + the catalog lites captured during the scan and
+ *       passed in here) rather than by re-fetching from the DB or the mutable matchGraph, so
+ *       {@link Pair#getM1()}/{@link Pair#getM2()} indices always line up with the spot order I3S
+ *       actually compared even if the matchGraph entry is replaced mid-scan; and</li>
+ *   <li>the 0.001 &lt; score &le; 2.0 validity filter is applied <em>before</em> the 100-match
+ *       cap (the comparator sorts ascending and unscored candidates default to 0, so a
+ *       cap-then-filter would let zeros consume the cap and yield an empty file).</li>
+ * </ul>
+ */
+public final class I3SResultWriter {
+    private I3SResultWriter() {}
+
+    /**
+     * @param matches         the scan results (each MatchObject carries its I3S score + point map)
+     * @param queryLite       the query encounter as an EncounterLite (source of query spot coords)
+     * @param catalogLites    encounterNumber -&gt; the exact catalog EncounterLite i3sScan indexed
+     * @param num             the query encounter number
+     * @param newEncDate      query encounter date
+     * @param newEncSex       query encounter sex
+     * @param newEncShark     query encounter assigned individual
+     * @param newEncSize      query encounter size string
+     * @param rightSide       true for a right-side scan
+     * @param shepherdDataDir the Wildbook data directory
+     * @return true if the file was written
+     */
+    public static boolean write(MatchObject[] matches, EncounterLite queryLite,
+        Map<String, EncounterLite> catalogLites, String num,
+        String newEncDate, String newEncSex, String newEncShark, String newEncSize,
+        boolean rightSide, File shepherdDataDir) {
+        if ((matches == null) || (queryLite == null) || (catalogLites == null)) return false;
+        try {
+            Arrays.sort(matches, new NewI3SMatchComparator());
+
+            Document document = DocumentHelper.createDocument();
+            Element root = document.addElement("matchSet");
+            root.addAttribute("scanDate", (new java.util.Date()).toString());
+
+            ArrayList<SuperSpot> querySpots = rightSide
+                ? queryLite.getRightSpots() : queryLite.getSpots();
+            if ((querySpots == null) || querySpots.isEmpty()) {
+                // nothing to map query spots against; still write an (empty) file so the
+                // results link renders a "no matches" page rather than 404ing.
+                return writeDocument(document, num, rightSide, shepherdDataDir);
+            }
+
+            int emitted = 0;
+            for (int i = 0; (i < matches.length) && (emitted < 100); i++) {
+                MatchObject mo = matches[i];
+                // Filter THEN cap: only valid I3S matches count toward the 100 limit.
+                if (!((mo.getI3SMatchValue() > 0.001) && (mo.getI3SMatchValue() <= 2.0))) continue;
+                Vector map = mo.getMap2();
+                if ((map == null) || map.isEmpty()) continue;
+
+                // Source catalog spots from the exact EncounterLite i3sScan indexed (captured
+                // during the scan), not the live matchGraph which may have been replaced since.
+                EncounterLite catalogLite = catalogLites.get(mo.getEncounterNumber());
+                if (catalogLite == null) continue;
+                ArrayList<SuperSpot> catalogSpots = rightSide
+                    ? catalogLite.getRightSpots() : catalogLite.getSpots();
+                if ((catalogSpots == null) || catalogSpots.isEmpty()) continue;
+
+                try {
+                    // Build the <match> subtree detached and attach it to root only after BOTH
+                    // encounter spot loops succeed, so a mid-build failure (e.g. an unexpected
+                    // index) can't leave a one-encounter <match> that breaks the viewer's
+                    // encounters.get(1) assumption.
+                    Element match = DocumentHelper.createElement("match");
+                    String finalscore = Double.toString(mo.getI3SMatchValue());
+                    if (finalscore.length() > 7) finalscore = finalscore.substring(0, 6);
+                    match.addAttribute("finalscore", finalscore);
+                    match.addAttribute("evaluation", mo.getEvaluation());
+
+                    Element enc = match.addElement("encounter");
+                    enc.addAttribute("number", mo.getEncounterNumber());
+                    enc.addAttribute("date", mo.getDate());
+                    enc.addAttribute("sex", (mo.getSex() != null) ? mo.getSex() : "unknown");
+                    enc.addAttribute("assignedToShark", mo.getIndividualName());
+                    enc.addAttribute("size", Double.toString(mo.getSize()));
+
+                    int mapSize = map.size();
+                    for (int f = 0; f < mapSize; f++) {
+                        Pair tempPair = (Pair) map.get(f);
+                        int M1 = tempPair.getM1();
+                        Element spot = enc.addElement("spot");
+                        spot.addAttribute("x",
+                            Double.toString(catalogSpots.get(M1).getTheSpot().getCentroidX()));
+                        spot.addAttribute("y",
+                            Double.toString(catalogSpots.get(M1).getTheSpot().getCentroidY()));
+                    }
+
+                    Element enc2 = match.addElement("encounter");
+                    enc2.addAttribute("number", num);
+                    enc2.addAttribute("date", newEncDate);
+                    enc2.addAttribute("sex", (newEncSex != null) ? newEncSex : "unknown");
+                    enc2.addAttribute("assignedToShark", newEncShark);
+                    enc2.addAttribute("size", newEncSize);
+                    for (int g = 0; g < mapSize; g++) {
+                        Pair tempPair = (Pair) map.get(g);
+                        int M2 = tempPair.getM2();
+                        Element spot = enc2.addElement("spot");
+                        spot.addAttribute("x",
+                            Double.toString(querySpots.get(M2).getTheSpot().getCentroidX()));
+                        spot.addAttribute("y",
+                            Double.toString(querySpots.get(M2).getTheSpot().getCentroidY()));
+                    }
+                    // both encounters fully populated — now attach to the document
+                    root.add(match);
+                    emitted++;
+                } catch (Exception perMatch) {
+                    // a single malformed match (e.g. an index that no longer fits because the
+                    // catalog entry was re-spotted mid-scan) must not abort the whole file.
+                    perMatch.printStackTrace();
+                }
+            }
+
+            return writeDocument(document, num, rightSide, shepherdDataDir);
+        } catch (Exception e) {
+            System.out.println("I3SResultWriter: failed to write I3S results for " + num);
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    private static boolean writeDocument(Document document, String num, boolean rightSide,
+        File shepherdDataDir) throws java.io.IOException {
+        String fileAddition = rightSide ? "Right" : "";
+        File file = new File(Encounter.dir(shepherdDataDir, num)
+            + "/lastFull" + fileAddition + "I3SScan.xml");
+        FileWriter mywriter = new FileWriter(file);
+        org.dom4j.io.XMLWriter writer = null;
+        try {
+            org.dom4j.io.OutputFormat format = org.dom4j.io.OutputFormat.createPrettyPrint();
+            format.setLineSeparator(System.getProperty("line.separator"));
+            writer = new org.dom4j.io.XMLWriter(mywriter, format);
+            writer.write(document);
+        } finally {
+            // closing the XMLWriter closes the underlying FileWriter; if the XMLWriter never
+            // got constructed, close the FileWriter directly so the handle can't leak.
+            if (writer != null) {
+                writer.close();
+            } else {
+                mywriter.close();
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/ecocean/servlet/GrothMatchServlet.java
+++ b/src/main/java/org/ecocean/servlet/GrothMatchServlet.java
@@ -19,7 +19,11 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
@@ -80,6 +84,11 @@ public class GrothMatchServlet extends HttpServlet {
 
         // Phase 1: Short DB transaction to load query encounter spots
         SuperSpot[] queryArray;
+        // Query encounter as an EncounterLite — needed by the I3S matcher (i3sScan),
+        // which is run alongside Groth below to revive I3S results. Built while the
+        // encounter is still managed; EncounterLite copies the spot data so it stays
+        // usable after the transaction closes.
+        EncounterLite queryLite;
         String encDate, encSex, encIndividualID, encLocation, encLocationID, encSize;
         {
             Shepherd myShepherd = new Shepherd(context);
@@ -104,6 +113,7 @@ public class GrothMatchServlet extends HttpServlet {
                 }
 
                 queryArray = querySpots.toArray(new SuperSpot[0]);
+                queryLite = new EncounterLite(enc);
                 encDate = enc.getDate();
                 encSex = enc.getSex() != null ? enc.getSex() : "unknown";
                 encIndividualID = ServletUtilities.handleNullString(enc.getIndividualID());
@@ -121,15 +131,53 @@ public class GrothMatchServlet extends HttpServlet {
 
         ConcurrentHashMap<String, EncounterLite> matchGraph = GridManager.getMatchGraph();
         List<MatchObject> grothResults = new ArrayList<>();
+        // Capture the exact catalog EncounterLite each I3S match was scored against, so the
+        // I3S writer indexes the same spot order i3sScan used even if the live matchGraph
+        // entry is replaced mid-scan by a concurrent spot edit.
+        Map<String, EncounterLite> scannedI3SLites = new HashMap<>();
 
         for (ConcurrentHashMap.Entry<String, EncounterLite> entry : matchGraph.entrySet()) {
             if (entry.getKey().equals(encNumber)) continue;
             EncounterLite el = entry.getValue();
 
+            // I3S: run on the same candidate as Groth so one scan produces both Groth and
+            // I3S results (I3S was lost when the async grid scan path fell out of use).
+            // Computed before Groth (both are non-mutating on the EncounterLite). Gated on
+            // the scan-side spots being present; i3sScan synthesizes fiducial points from
+            // spot bounds when reference spots are absent, so no reference-spot requirement.
+            // Wrapped so one bad candidate can't abort the whole scan.
+            Vector i3sPoints = null;
+            double i3sValue = 0;
+            try {
+                ArrayList<SuperSpot> candSpots = rightScan ? el.getRightSpots() : el.getSpots();
+                ArrayList<SuperSpot> querySideSpots = rightScan ?
+                    queryLite.getRightSpots() : queryLite.getSpots();
+                if ((candSpots != null) && !candSpots.isEmpty() &&
+                    (querySideSpots != null) && !querySideSpots.isEmpty()) {
+                    I3SMatchObject i3sResult = el.i3sScan(queryLite, rightScan);
+                    TreeMap i3sMap = i3sResult.getMap();
+                    Vector pts = new Vector();
+                    if (i3sMap != null) {
+                        for (Object pair : i3sMap.values()) {
+                            pts.add(pair);
+                        }
+                    }
+                    i3sPoints = pts;
+                    i3sValue = i3sResult.getI3SMatchValue();
+                    // remember the exact lite used, keyed by encounter number
+                    scannedI3SLites.put(entry.getKey(), el);
+                }
+            } catch (Exception i3sEx) {
+                i3sPoints = null;
+            }
+
             MatchObject mo = el.getPointsForBestMatch(
                 queryArray, epsilon, R, Sizelim, maxTriangleRotation, C,
                 true, rightScan);
             mo.encounterNumber = entry.getKey();
+            if (i3sPoints != null) {
+                mo.setI3SValues(i3sPoints, i3sValue);
+            }
             grothResults.add(mo);
         }
 
@@ -266,6 +314,13 @@ public class GrothMatchServlet extends HttpServlet {
             org.dom4j.io.XMLWriter writer = new org.dom4j.io.XMLWriter(mywriter, format);
             writer.write(document);
             writer.close();
+
+            // Also write the I3S result file from the same scan so the I3S results link
+            // populates (resultsI3SLeft/Right in the encounter API keys off this file's
+            // existence). matchArray now carries the per-candidate I3S scores/point maps
+            // set above; the writer re-sorts by I3S score and keeps only valid matches.
+            I3SResultWriter.write(matchArray, queryLite, scannedI3SLites, encNumber, encDate,
+                encSex, encIndividualID, encSize, rightScan, shepherdDataDir);
 
             // Redirect to scanEndApplet.jsp
             String redirectUrl = "encounters/scanEndApplet.jsp?number=" + encNumber +


### PR DESCRIPTION
## Problem
The React `SpotMappingCard` (10.10) advertises "Modified Groth **and I3S**" and renders an "I3S scan results" link, but I3S results are never produced — a regression.

When the spot-matching scan was rewritten as the synchronous `GrothMatchServlet` (the "Optimized Modified Groth" work), only Modified Groth was ported. I3S stayed in the now-dead async grid path (`ScanWorkItem.execute`), which is never instantiated. Everything else still works — the I3S algorithm (`EncounterLite.i3sScan`), the viewer (`encounters/i3sScanEndApplet.jsp`), and the API flags (`Encounter.spotMappingJsonForApiGet()` checks for `lastFull[Right]I3SScan.xml`) — but nothing writes the I3S result file, so `resultsI3SLeft/Right` is always false and the link never appears.

## Fix
Have the single live scan produce **both** result files, mirroring the old `ScanWorkItem.execute` combine pattern:

- **`GrothMatchServlet` Phase 1** builds the query `EncounterLite` (the input `i3sScan` needs).
- **Phase 2** runs `el.i3sScan(queryLite, rightScan)` alongside Groth on each candidate and stores the I3S score + point-map on the same `MatchObject` via `setI3SValues`. Gated on the scan-side spots being present; **no reference-spot requirement** (the fiducial-point helpers fall back to spot bounds when reference spots are absent, matching the legacy behavior). Wrapped per-candidate so one bad candidate can't abort the scan. The exact `EncounterLite` each match scored against is captured (`scannedI3SLites`) so the writer indexes the same spot order even if the live `matchGraph` entry is replaced mid-scan.
- **Phase 3** writes `lastFull[Right]I3SScan.xml` after the Groth XML. The existing UI link lights up automatically.

New `org.ecocean.grid.I3SResultWriter` produces the I3S XML in the shape `i3sScanEndApplet.jsp` expects. Notable correctness details (caught in review):
- **Filters valid matches (`0.001 < score ≤ 2.0`) before the 100-match cap.** `NewI3SMatchComparator` sorts ascending and unscored candidates default to `0`, so a cap-then-filter would fill the cap with zeros and yield an empty file.
- **Sources spot coordinates from the captured `EncounterLite`s** (query + catalog), not a DB re-fetch — so `Pair.getM1()/getM2()` indices always line up with the spot order I3S actually compared.
- **Builds each `<match>` detached** and attaches it only after both `<encounter>` elements are fully populated, so a per-match failure can't leave a one-encounter `<match>` that breaks the viewer.
- Closes the writer in a `finally`.

`getPointsForBestMatch` and `i3sScan` were both confirmed non-mutating on the shared `EncounterLite`, so no spot reset is needed between them.

## Trade-off
Running both algorithms in one synchronous scan **~doubles per-candidate compute** over the catalog. Accepted (single "Start Scan" produces both, matching the UI); could move to async later if scan latency becomes a problem.

## Verification
- `mvn compile` passes.
- Reviewed with `codex` across plan + 2 implementation rounds to convergence (no Critical/Major findings).
- Independent of #1610; both touch `GrothMatchServlet` (expect a trivial merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)