### PR TITLE
feat(security): token-scoped read API — token issuance + canUserAccess + encounter/individual/annotation scoping (Artifacts B+D+Spec A; supersedes #1594)

### DIFF
--- a/docs/superpowers/plans/2026-05-29-integration-endpoints-b.md
+++ b/docs/superpowers/plans/2026-05-29-integration-endpoints-b.md
@@ -140,11 +140,23 @@ class JwtServiceTest {
     }
 
     @Test void wrongAudienceOrIssuer_rejected() throws Exception {
-        JwtService a = serviceWithFreshKeys();
-        String token = a.sign("u", "context0", 60_000L);
-        // a different service (different keys) cannot verify a's token
-        JwtService b = serviceWithFreshKeys();
-        assertThrows(JwtException.class, () -> b.verify(token), "token signed by other key must fail");
+        // SAME keypair (valid signature), but the verifier requires a different
+        // issuer/audience — this genuinely exercises requireIssuer/requireAudience
+        // (a different-key test would pass even if those checks were removed).
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+
+        JwtService signer = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+        String token = signer.sign("u", "context0", 60_000L);
+
+        JwtService wrongIssuer = JwtService.fromBase64Keys(privB64, pubB64, "evil-issuer", "wildbook-scoped-api");
+        assertThrows(JwtException.class, () -> wrongIssuer.verify(token), "mismatched issuer must be rejected");
+
+        JwtService wrongAudience = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "some-other-aud");
+        assertThrows(JwtException.class, () -> wrongAudience.verify(token), "mismatched audience must be rejected");
     }
 
     @Test void disabledWhenKeysMissing() {
@@ -202,16 +214,25 @@ public class JwtService {
     private final PublicKey publicKey;
     private final String issuer;
     private final String audience;
+    private final String keyId; // JWT header 'kid' for key rotation (Codex Medium); may be null
 
-    private JwtService(PrivateKey priv, PublicKey pub, String issuer, String audience) {
+    private JwtService(PrivateKey priv, PublicKey pub, String issuer, String audience,
+        String keyId) {
         this.privateKey = priv;
         this.publicKey = pub;
         this.issuer = issuer;
         this.audience = audience;
+        this.keyId = keyId;
+    }
+
+    // test/explicit overload without a keyId
+    public static JwtService fromBase64Keys(String privB64, String pubB64, String issuer,
+        String audience) {
+        return fromBase64Keys(privB64, pubB64, issuer, audience, null);
     }
 
     public static JwtService fromBase64Keys(String privB64, String pubB64, String issuer,
-        String audience) {
+        String audience, String keyId) {
         PrivateKey priv = null;
         PublicKey pub = null;
         try {
@@ -227,7 +248,7 @@ public class JwtService {
         } catch (Exception ex) {
             System.out.println("JwtService: failed to load keys: " + ex);
         }
-        return new JwtService(priv, pub, issuer, audience);
+        return new JwtService(priv, pub, issuer, audience, keyId);
     }
 
     public static JwtService fromConfig(String context) {
@@ -236,7 +257,8 @@ public class JwtService {
             CommonConfiguration.getProperty("jwtPublicKeyBase64", context),
             orDefault(CommonConfiguration.getProperty("jwtIssuer", context), "wildbook"),
             orDefault(CommonConfiguration.getProperty("jwtAudience", context),
-                "wildbook-scoped-api"));
+                "wildbook-scoped-api"),
+            CommonConfiguration.getProperty("jwtKeyId", context)); // may be null
     }
 
     private static String orDefault(String v, String d) {
@@ -250,16 +272,16 @@ public class JwtService {
     public String sign(String userUuid, String context, long ttlMillis) {
         if (!isEnabled()) throw new IllegalStateException("JwtService not enabled (no private key)");
         long now = System.currentTimeMillis();
-        return Jwts.builder()
+        io.jsonwebtoken.JwtBuilder b = Jwts.builder()
             .issuer(issuer)
             .audience().add(audience).and()
             .subject(userUuid)
             .claim("context", context)
             .id(Util.generateUUID())
             .issuedAt(new Date(now))
-            .expiration(new Date(now + ttlMillis))
-            .signWith(privateKey, Jwts.SIG.RS256)
-            .compact();
+            .expiration(new Date(now + ttlMillis));
+        if (Util.stringExists(keyId)) b.header().keyId(keyId).and(); // 'kid' for rotation
+        return b.signWith(privateKey, Jwts.SIG.RS256).compact();
     }
 
     public Jws<Claims> verify(String token) {
@@ -332,13 +354,20 @@ public class AuthToken extends ApiBase {
                 writeError(response, 401, "unauthenticated");
                 return;
             }
-            JwtService jwt = JwtService.fromConfig(context);
+            // SECURITY (Codex High #1): pin the token context SERVER-SIDE. Do NOT
+            // sign ServletUtilities.getContext(request) — it honors a caller's
+            // ?context=, while Basic auth authenticates only against context0, so a
+            // caller-influenced context claim would let a user mint a token for a
+            // context they didn't authenticate in. v1 is single-context.
+            String tokenContext = org.ecocean.CommonConfiguration.getProperty("jwtContext", context);
+            if (!Util.stringExists(tokenContext)) tokenContext = "context0";
+            JwtService jwt = JwtService.fromConfig(tokenContext);
             if (!jwt.isEnabled()) {
                 writeError(response, 503, "token issuance not configured");
                 return;
             }
-            long ttl = ttlFromConfig(context);
-            String token = jwt.sign(user.getId(), context, ttl);
+            long ttl = ttlFromConfig(tokenContext);
+            String token = jwt.sign(user.getId(), tokenContext, ttl);
             JSONObject out = new JSONObject();
             out.put("token", token);
             out.put("tokenType", "Bearer");
@@ -357,7 +386,12 @@ public class AuthToken extends ApiBase {
     private long ttlFromConfig(String context) {
         String v = org.ecocean.CommonConfiguration.getProperty("jwtTtlSeconds", context);
         if (Util.stringExists(v)) {
-            try { return Long.parseLong(v.trim()) * 1000L; } catch (NumberFormatException ignore) {}
+            try {
+                long secs = Long.parseLong(v.trim());
+                // Codex Low: clamp to a sane range (1 min .. 24 h)
+                secs = Math.max(60L, Math.min(secs, 24L * 3600L));
+                return secs * 1000L;
+            } catch (NumberFormatException ignore) {}
         }
         return DEFAULT_TTL_MILLIS;
     }
@@ -444,6 +478,7 @@ import org.json.JSONObject;
  */
 public class CanUserAccess extends ApiBase {
     private static final int MAX_IDS = 200;
+    private static final long MAX_BODY_BYTES = 64L * 1024L; // cap request body (Codex Medium)
 
     @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
@@ -459,6 +494,16 @@ public class CanUserAccess extends ApiBase {
             }
             if (!caller.isAdmin(myShepherd)) {
                 writeError(response, 403, "admin required");
+                return;
+            }
+            // Codex Medium: validate content-type + cap body size BEFORE reading/parsing.
+            String ctype = request.getContentType();
+            if (ctype == null || !ctype.toLowerCase().contains("application/json")) {
+                writeError(response, 415, "Content-Type must be application/json");
+                return;
+            }
+            if (request.getContentLengthLong() > MAX_BODY_BYTES) {
+                writeError(response, 413, "request body too large");
                 return;
             }
             JSONObject body = readBody(request);
@@ -504,7 +549,10 @@ public class CanUserAccess extends ApiBase {
             StringBuilder sb = new StringBuilder();
             BufferedReader r = request.getReader();
             String line;
-            while ((line = r.readLine()) != null) sb.append(line);
+            while ((line = r.readLine()) != null) {
+                sb.append(line);
+                if (sb.length() > MAX_BODY_BYTES) return null; // cap even if Content-Length lied
+            }
             return new JSONObject(sb.toString());
         } catch (Exception ex) {
             return null;
@@ -571,18 +619,19 @@ Create `docs/superpowers/runbooks/jwt-keypair-setup.md` documenting:
   openssl pkcs8 -topk8 -nocrypt -in jwt_private.pem -outform DER | base64 -w0   # -> jwtPrivateKeyBase64
   openssl rsa -in jwt_private.pem -pubout -outform DER | base64 -w0             # -> jwtPublicKeyBase64
   ```
-- The `commonConfiguration.properties` keys: `jwtPrivateKeyBase64`, `jwtPublicKeyBase64`, `jwtIssuer` (default `wildbook`), `jwtAudience` (default `wildbook-scoped-api`), `jwtTtlSeconds` (default 1800).
+- The `commonConfiguration.properties` keys: `jwtPrivateKeyBase64`, `jwtPublicKeyBase64`, `jwtIssuer` (default `wildbook`), `jwtAudience` (default `wildbook-scoped-api`), `jwtTtlSeconds` (default 1800, clamped to [60, 86400]), `jwtKeyId` (optional, sets the JWT `kid` header for rotation), `jwtContext` (optional, default `context0` — the single context tokens are pinned to; do NOT derive from the request).
 - Wildbook needs the PRIVATE key (to sign); the external kernel is given the PUBLIC key only. If `jwtPrivateKeyBase64` is unset, `/api/v3/auth/token` returns 503.
-- Key rotation note (swap keys; old tokens expire within TTL).
+- **Key rotation:** set a distinct `jwtKeyId` per key. To rotate: deploy the new private key + bump `jwtKeyId`; the kernel keeps BOTH old and new public keys (selected by `kid`) for at least one TTL so in-flight tokens keep verifying, then drops the old one.
+- **Secret hygiene (Codex Low):** the private key (and any `.pem`/Base64 form) must NEVER be committed to git or written to logs. If stored as a file, restrict perms (`chmod 600`). The Base64 value lives only in the Docker-mounted `commonConfiguration.properties`. Never log token strings.
 
 - [ ] **Step 2: Add test auth rules**
 
-In `src/test/resources/shiro.ini` `[urls]`, add (matching the file's style) so tests exercise the auth gates:
+In `src/test/resources/shiro.ini` `[urls]`, add these — **and they MUST be inserted BEFORE the `/** = anon` catch-all** (Shiro `[urls]` is first-match-wins; rules placed after `/**` are dead, Codex Medium):
 ```
 /api/v3/auth/token = authcBasicWildbook
 /api/v3/can-user-access = authcBasicWildbook, roles[admin]
 ```
-(Read the existing test shiro.ini to use the exact filter names defined there; if `authcBasicWildbook` isn't defined in the test ini, use the test ini's available auth filter equivalent.)
+Read the existing test shiro.ini to (a) use the exact filter names defined there (if `authcBasicWildbook` isn't defined in the test ini, use the test ini's available auth filter equivalent), and (b) place these lines physically above the `/** = anon` line. After editing, eyeball the ordering to confirm the catch-all is last.
 
 - [ ] **Step 3: Normalize + commit**
 
@@ -611,7 +660,14 @@ Expected: BUILD SUCCESS.
 Run: `cd /mnt/c/Wildbook-integration-b && for f in $(git diff --name-only main); do n=$(grep -cP '\r$' "$f" 2>/dev/null||echo 0); [ "$n" != "0" ] && echo "CRLF: $f"; done; echo done`
 Expected: only "done".
 
-- [ ] **Step 4: Confirm no stray files staged across commits**
+- [ ] **Step 4: Wiring-assertion test (Codex High #2 — Mockito can't prove the gate)**
+
+Because new paths are OPEN unless matched by a Shiro `[urls]` rule, and the unit tests do not load `web.xml`, add a guard test `src/test/java/org/ecocean/api/EndpointAuthWiringTest.java` that reads `src/main/webapp/WEB-INF/web.xml` and asserts: (a) both servlets + mappings exist for `/api/v3/auth/token` and `/api/v3/can-user-access`; (b) the Shiro `[urls]` section contains a non-`anon` constraint for each, with `roles[admin]` on can-user-access, positioned before any `/** ` catch-all. This is a cheap regression guard against the open-by-default footgun. (The PRIMARY enforcement is the in-code check in each endpoint — B1 returns 401 when `getUser(request)==null`, B2 returns 403 unless `caller.isAdmin` — so the endpoints are self-protecting even if Shiro is misconfigured; this test guards the defense-in-depth layer.)
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=EndpointAuthWiringTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS.
+
+- [ ] **Step 5: Confirm no stray files staged across commits**
 
 Run: `cd /mnt/c/Wildbook-integration-b && git diff --name-only main..HEAD`
 Expected: only the intended source/test/doc/pom/web.xml files; NO logs/ or runtime artifacts.

--- a/docs/superpowers/plans/2026-05-29-integration-endpoints-b.md
+++ b/docs/superpowers/plans/2026-05-29-integration-endpoints-b.md
@@ -1,0 +1,632 @@
+# Artifact B — Integration Endpoints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add the two Wildbook-side endpoints the external scoped-query kernel depends on: (B1) short-lived asymmetric-signed token issuance, and (B2) a live `canUserAccess` check computed from live Collaboration/role objects.
+
+**Architecture:** A pure, unit-testable `JwtService` (RSA keypair load + sign + verify) underpins a thin `AuthToken` servlet (`POST /api/v3/auth/token`) gated by existing Shiro Basic auth that mints a token carrying only identity (uuid + context + iss/aud/jti/exp). A separate `CanUserAccess` servlet (`POST /api/v3/can-user-access`), admin-gated, resolves a target user UUID + encounter IDs and returns the subset that user may view via `Encounter.canUserView`. Both follow the existing manual-servlet + web.xml pattern.
+
+**Tech Stack:** Java 17, Apache Shiro (existing), **jjwt 0.12.6** (new, locked), `java.security` RSA. JUnit5 + Mockito (mockito-inline present); JwtService gets pure unit tests, endpoints get Mockito unit tests.
+
+**Branch/worktree:** `integration-token-canaccess` at `/mnt/c/Wildbook-integration-b` (off `main`). Independent of Artifact A.
+
+**Design source:** `docs/superpowers/specs/2026-05-29-wildbook-acl-prereqs-design.md` (Artifact B section).
+
+---
+
+## Key facts (verified in this worktree)
+- Endpoints are manual servlets extending `org.ecocean.api.ApiBase` (only dispatches PATCH; **no** response/error helpers — each endpoint defines its own `writeError`, see `MatchInspection.java:145-153`). URIs are parsed by hand from `request.getRequestURI().split("/")`.
+- Registration: explicit `<servlet>` + `<servlet-mapping>` in `web.xml`. **A new path is OPEN unless added to the Shiro `[urls]` section** (`web.xml` ~lines 101-106). `authcBasicWildbook` = Basic auth; `authc` = session; `roles[...]` adds role gating.
+- Current user inside an endpoint: `myShepherd.getUser(request)` → `User` or null (uses `request.getUserPrincipal()`).
+- `Shepherd.getUserByUUID(String)` (Shepherd.java:1184), `Shepherd.getUser(String username)`, `Shepherd.getEncounter(String)` (Shepherd.java:495).
+- `Encounter.canUserView(User, Shepherd)` (Encounter.java:3316) = `user != null && (user.isAdmin(shepherd) || canUserAccess(user, context))`.
+- Config: `CommonConfiguration.getProperty(name, context)`. Per-deploy props in the Docker-mounted `commonConfiguration.properties`.
+- No JWT lib in pom.xml. Tests: pure Mockito unit (`EncounterApiTest`) or Testcontainers+Jetty+RestAssured integration (`EncounterExportImagesTest`).
+
+## File structure
+- **Modify** `pom.xml` — add jjwt 0.12.6 (api/impl/jackson), locked.
+- **Create** `src/main/java/org/ecocean/api/auth/JwtService.java` — keypair load (from config), `String sign(claims)`, `Jws<Claims> verify(token)`, helpers; isEnabled() when keys present.
+- **Create** `src/main/java/org/ecocean/api/AuthToken.java` — B1 servlet.
+- **Create** `src/main/java/org/ecocean/api/CanUserAccess.java` — B2 servlet.
+- **Modify** `src/main/webapp/WEB-INF/web.xml` — 2 servlet defs + mappings + 2 Shiro url constraints.
+- **Create** `src/test/java/org/ecocean/api/auth/JwtServiceTest.java` — pure unit tests.
+- **Create** `src/test/java/org/ecocean/api/AuthTokenTest.java`, `CanUserAccessTest.java` — Mockito unit tests.
+- **Create** `docs/superpowers/runbooks/jwt-keypair-setup.md` — keypair generation + config.
+- **Modify** `src/test/resources/shiro.ini` — add test auth rules for the two paths.
+
+---
+
+## Task 1: Add jjwt dependency
+
+**Files:** Modify `pom.xml`
+
+- [ ] **Step 1: Add the three jjwt artifacts (locked 0.12.6)**
+
+In `pom.xml` `<dependencies>`, add:
+```xml
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.12.6</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.12.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.12.6</version>
+      <scope>runtime</scope>
+    </dependency>
+```
+(Match the file's existing indentation/version-property conventions; if the project pins versions in `<properties>`, follow that convention with a `jjwt.version` property instead.)
+
+- [ ] **Step 2: Resolve dependencies**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn -q -DskipTests dependency:resolve 2>&1 | tail -5; mvn -q -DskipTests compile`
+Expected: BUILD SUCCESS (jjwt downloaded; project still compiles).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /mnt/c/Wildbook-integration-b add pom.xml
+git -C /mnt/c/Wildbook-integration-b commit -m "build: add jjwt 0.12.6 (JWT signing for scoped-access tokens)"
+```
+
+---
+
+## Task 2: JwtService (keypair load + sign + verify) — pure unit-tested core
+
+**Files:** Create `src/main/java/org/ecocean/api/auth/JwtService.java`; Test `src/test/java/org/ecocean/api/auth/JwtServiceTest.java`
+
+The JwtService is the security-critical, fully unit-testable core. Keys are RSA. Private key signs (Wildbook = issuer); public key verifies (the external kernel holds the public key; JwtService.verify exists for round-trip testing and any future Wildbook-side verification).
+
+- [ ] **Step 1: Write failing tests (round-trip, expiry, tamper, wrong aud/iss, disabled)**
+
+Create `JwtServiceTest.java`:
+```java
+package org.ecocean.api.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.Test;
+
+class JwtServiceTest {
+
+    private JwtService serviceWithFreshKeys() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()); // PKCS8
+        String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());   // X.509
+        return JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+    }
+
+    @Test void signThenVerify_roundTrip() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("user-uuid-123", "context0", 60_000L); // 60s TTL
+        Jws<Claims> jws = svc.verify(token);
+        Claims c = jws.getPayload();
+        assertEquals("user-uuid-123", c.getSubject(), "subject = user uuid");
+        assertEquals("context0", c.get("context", String.class), "context claim");
+        assertEquals("wildbook", c.getIssuer(), "issuer");
+        assertNotNull(c.getId(), "jti present");
+        assertTrue(c.getExpiration().getTime() > System.currentTimeMillis(), "exp in future");
+        assertNull(c.get("admin"), "no admin claim");
+        assertNull(c.get("roles"), "no roles claim");
+    }
+
+    @Test void expiredToken_rejected() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("u", "context0", -1000L); // already expired
+        assertThrows(JwtException.class, () -> svc.verify(token), "expired token must be rejected");
+    }
+
+    @Test void tamperedToken_rejected() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("u", "context0", 60_000L);
+        String tampered = token.substring(0, token.length() - 2) + (token.endsWith("a") ? "bb" : "aa");
+        assertThrows(JwtException.class, () -> svc.verify(tampered), "bad signature must be rejected");
+    }
+
+    @Test void wrongAudienceOrIssuer_rejected() throws Exception {
+        JwtService a = serviceWithFreshKeys();
+        String token = a.sign("u", "context0", 60_000L);
+        // a different service (different keys) cannot verify a's token
+        JwtService b = serviceWithFreshKeys();
+        assertThrows(JwtException.class, () -> b.verify(token), "token signed by other key must fail");
+    }
+
+    @Test void disabledWhenKeysMissing() {
+        JwtService svc = JwtService.fromBase64Keys(null, null, "wildbook", "wildbook-scoped-api");
+        assertFalse(svc.isEnabled(), "service disabled without keys");
+        assertThrows(IllegalStateException.class, () -> svc.sign("u", "context0", 1000L),
+            "signing while disabled must throw");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=JwtServiceTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: FAIL — `JwtService` does not exist.
+
+- [ ] **Step 3: Implement JwtService**
+
+Create `src/main/java/org/ecocean/api/auth/JwtService.java`:
+```java
+package org.ecocean.api.auth;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+
+import org.ecocean.CommonConfiguration;
+import org.ecocean.Util;
+
+/**
+ * Issues and verifies short-lived RS256 JWTs that carry ONLY identity
+ * (subject = user UUID, context). No admin/role claims — the consumer
+ * resolves privileges fresh. Wildbook holds the private (signing) key;
+ * the external scoped-access kernel holds the public key.
+ *
+ * Keys are RSA, supplied as Base64 of the encoded key bytes (private = PKCS8,
+ * public = X.509), via commonConfiguration.properties:
+ *   jwtPrivateKeyBase64=...   (signing; required to mint tokens)
+ *   jwtPublicKeyBase64=...    (verify; optional Wildbook-side)
+ *   jwtIssuer=wildbook
+ *   jwtAudience=wildbook-scoped-api
+ * If the private key is absent, the service is "disabled" and the token
+ * endpoint returns 503.
+ */
+public class JwtService {
+    private final PrivateKey privateKey;
+    private final PublicKey publicKey;
+    private final String issuer;
+    private final String audience;
+
+    private JwtService(PrivateKey priv, PublicKey pub, String issuer, String audience) {
+        this.privateKey = priv;
+        this.publicKey = pub;
+        this.issuer = issuer;
+        this.audience = audience;
+    }
+
+    public static JwtService fromBase64Keys(String privB64, String pubB64, String issuer,
+        String audience) {
+        PrivateKey priv = null;
+        PublicKey pub = null;
+        try {
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            if (Util.stringExists(privB64)) {
+                priv = kf.generatePrivate(
+                    new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privB64.trim())));
+            }
+            if (Util.stringExists(pubB64)) {
+                pub = kf.generatePublic(
+                    new X509EncodedKeySpec(Base64.getDecoder().decode(pubB64.trim())));
+            }
+        } catch (Exception ex) {
+            System.out.println("JwtService: failed to load keys: " + ex);
+        }
+        return new JwtService(priv, pub, issuer, audience);
+    }
+
+    public static JwtService fromConfig(String context) {
+        return fromBase64Keys(
+            CommonConfiguration.getProperty("jwtPrivateKeyBase64", context),
+            CommonConfiguration.getProperty("jwtPublicKeyBase64", context),
+            orDefault(CommonConfiguration.getProperty("jwtIssuer", context), "wildbook"),
+            orDefault(CommonConfiguration.getProperty("jwtAudience", context),
+                "wildbook-scoped-api"));
+    }
+
+    private static String orDefault(String v, String d) {
+        return Util.stringExists(v) ? v : d;
+    }
+
+    public boolean isEnabled() {
+        return privateKey != null;
+    }
+
+    public String sign(String userUuid, String context, long ttlMillis) {
+        if (!isEnabled()) throw new IllegalStateException("JwtService not enabled (no private key)");
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
+            .issuer(issuer)
+            .audience().add(audience).and()
+            .subject(userUuid)
+            .claim("context", context)
+            .id(Util.generateUUID())
+            .issuedAt(new Date(now))
+            .expiration(new Date(now + ttlMillis))
+            .signWith(privateKey, Jwts.SIG.RS256)
+            .compact();
+    }
+
+    public Jws<Claims> verify(String token) {
+        if (publicKey == null) throw new IllegalStateException("JwtService cannot verify (no public key)");
+        return Jwts.parser()
+            .requireIssuer(issuer)
+            .requireAudience(audience)
+            .verifyWith(publicKey)
+            .build()
+            .parseSignedClaims(token);
+    }
+}
+```
+(Note: this uses the jjwt 0.12.x builder API — `audience().add(...).and()`, `Jwts.SIG.RS256`, `parseSignedClaims`. If the resolved jjwt version's API differs, adapt to that version's signatures and report.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=JwtServiceTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' src/main/java/org/ecocean/api/auth/JwtService.java src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+git -C /mnt/c/Wildbook-integration-b add src/main/java/org/ecocean/api/auth/JwtService.java src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+git -C /mnt/c/Wildbook-integration-b commit -m "feat(api): JwtService — RS256 sign/verify for scoped-access tokens"
+```
+
+---
+
+## Task 3: AuthToken endpoint (B1)
+
+**Files:** Create `src/main/java/org/ecocean/api/AuthToken.java`; Modify `web.xml`; Test `src/test/java/org/ecocean/api/AuthTokenTest.java`
+
+- [ ] **Step 1: Implement the servlet**
+
+Create `src/main/java/org/ecocean/api/AuthToken.java`:
+```java
+package org.ecocean.api;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.User;
+import org.ecocean.Util;
+import org.ecocean.api.auth.JwtService;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+
+/**
+ * POST /api/v3/auth/token
+ * Gated by existing Shiro auth (authcBasicWildbook). Mints a short-lived
+ * RS256 token carrying only the caller's identity (uuid + context). The
+ * external scoped-access kernel validates it with the public key.
+ */
+public class AuthToken extends ApiBase {
+    private static final long DEFAULT_TTL_MILLIS = 30L * 60L * 1000L; // 30 min
+
+    @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+        String context = ServletUtilities.getContext(request);
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("api.AuthToken.doPost");
+        myShepherd.beginDBTransaction();
+        try {
+            User user = myShepherd.getUser(request);
+            if (user == null) {
+                writeError(response, 401, "unauthenticated");
+                return;
+            }
+            JwtService jwt = JwtService.fromConfig(context);
+            if (!jwt.isEnabled()) {
+                writeError(response, 503, "token issuance not configured");
+                return;
+            }
+            long ttl = ttlFromConfig(context);
+            String token = jwt.sign(user.getId(), context, ttl);
+            JSONObject out = new JSONObject();
+            out.put("token", token);
+            out.put("tokenType", "Bearer");
+            out.put("expiresInSeconds", ttl / 1000L);
+            response.setStatus(200);
+            response.setContentType("application/json");
+            response.getWriter().write(out.toString());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            writeError(response, 500, "token issuance failed");
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private long ttlFromConfig(String context) {
+        String v = org.ecocean.CommonConfiguration.getProperty("jwtTtlSeconds", context);
+        if (Util.stringExists(v)) {
+            try { return Long.parseLong(v.trim()) * 1000L; } catch (NumberFormatException ignore) {}
+        }
+        return DEFAULT_TTL_MILLIS;
+    }
+
+    private void writeError(HttpServletResponse response, int code, String message)
+        throws IOException {
+        response.setStatus(code);
+        response.setContentType("application/json");
+        response.getWriter().write(new JSONObject().put("success", false)
+            .put("error", message).toString());
+    }
+}
+```
+(Confirm `ServletUtilities.getContext(request)` exists — used by MatchInspection; if the helper signature differs, match the real one. Confirm `User.getId()` returns the UUID.)
+
+- [ ] **Step 2: Register + protect in web.xml**
+
+In `web.xml`, add a `<servlet>` + `<servlet-mapping>` (next to the other `/api/v3` servlets):
+```xml
+  <servlet>
+    <servlet-name>AuthToken</servlet-name>
+    <servlet-class>org.ecocean.api.AuthToken</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>AuthToken</servlet-name>
+    <url-pattern>/api/v3/auth/token</url-pattern>
+  </servlet-mapping>
+```
+And in the Shiro `[urls]` section (near line 101-106), add (so it is NOT open):
+```
+/api/v3/auth/token = authcBasicWildbook
+```
+(Basic auth so non-browser clients can bootstrap username/password → token. Read the existing `[urls]` entries to match exact filter names available in this web.xml.)
+
+- [ ] **Step 3: Write a Mockito unit test**
+
+Create `src/test/java/org/ecocean/api/AuthTokenTest.java` following the `EncounterApiTest` MockedConstruction idiom: mock `Shepherd` so `getUser(request)` returns null → assert 401 (capture response via a mocked `HttpServletResponse` + `StringWriter`). (Full token-mint path needs keys/config; cover the 401 unauthenticated path and the 503 disabled path here — the happy path is covered by JwtServiceTest + the integration smoke in Task 5. Read EncounterApiTest for the exact mocking setup.)
+
+- [ ] **Step 4: Run test + compile**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=AuthTokenTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** (normalize LF on all touched files first)
+
+```bash
+git -C /mnt/c/Wildbook-integration-b add src/main/java/org/ecocean/api/AuthToken.java src/main/webapp/WEB-INF/web.xml src/test/java/org/ecocean/api/AuthTokenTest.java
+git -C /mnt/c/Wildbook-integration-b commit -m "feat(api): POST /api/v3/auth/token — short-lived scoped-access token issuance"
+```
+
+---
+
+## Task 4: CanUserAccess endpoint (B2)
+
+**Files:** Create `src/main/java/org/ecocean/api/CanUserAccess.java`; Modify `web.xml`; Test `src/test/java/org/ecocean/api/CanUserAccessTest.java`
+
+- [ ] **Step 1: Implement the servlet**
+
+Create `src/main/java/org/ecocean/api/CanUserAccess.java`:
+```java
+package org.ecocean.api;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.Encounter;
+import org.ecocean.User;
+import org.ecocean.Util;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * POST /api/v3/can-user-access
+ * Admin/service-scoped. Body: {"userUuid": "...", "encounterIds": ["...", ...]}.
+ * Returns {"accessible": ["...", ...]} — the subset of encounterIds the target
+ * user may VIEW, computed from LIVE Collaboration/role objects (not the indexed
+ * viewUsers). Defense-in-depth backstop for the scoped-query kernel.
+ */
+public class CanUserAccess extends ApiBase {
+    private static final int MAX_IDS = 200;
+
+    @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+        String context = ServletUtilities.getContext(request);
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("api.CanUserAccess.doPost");
+        myShepherd.beginDBTransaction();
+        try {
+            User caller = myShepherd.getUser(request);
+            if (caller == null) {
+                writeError(response, 401, "unauthenticated");
+                return;
+            }
+            if (!caller.isAdmin(myShepherd)) {
+                writeError(response, 403, "admin required");
+                return;
+            }
+            JSONObject body = readBody(request);
+            if (body == null) { writeError(response, 400, "invalid JSON body"); return; }
+            String userUuid = body.optString("userUuid", null);
+            JSONArray idsArr = body.optJSONArray("encounterIds");
+            if (!Util.stringExists(userUuid) || idsArr == null) {
+                writeError(response, 400, "userUuid and encounterIds required");
+                return;
+            }
+            if (idsArr.length() > MAX_IDS) {
+                writeError(response, 400, "too many encounterIds (max " + MAX_IDS + ")");
+                return;
+            }
+            User target = myShepherd.getUserByUUID(userUuid);
+            JSONArray accessible = new JSONArray();
+            // target==null -> empty accessible set (unknown user sees nothing)
+            if (target != null) {
+                for (int i = 0; i < idsArr.length(); i++) {
+                    String encId = idsArr.optString(i, null);
+                    if (!Util.stringExists(encId)) continue;
+                    Encounter enc = myShepherd.getEncounter(encId);
+                    if (enc != null && enc.canUserView(target, myShepherd)) {
+                        accessible.put(encId);
+                    }
+                }
+            }
+            JSONObject out = new JSONObject();
+            out.put("accessible", accessible);
+            response.setStatus(200);
+            response.setContentType("application/json");
+            response.getWriter().write(out.toString());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            writeError(response, 500, "canUserAccess failed");
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private JSONObject readBody(HttpServletRequest request) {
+        try {
+            StringBuilder sb = new StringBuilder();
+            BufferedReader r = request.getReader();
+            String line;
+            while ((line = r.readLine()) != null) sb.append(line);
+            return new JSONObject(sb.toString());
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    private void writeError(HttpServletResponse response, int code, String message)
+        throws IOException {
+        response.setStatus(code);
+        response.setContentType("application/json");
+        response.getWriter().write(new JSONObject().put("success", false)
+            .put("error", message).toString());
+    }
+}
+```
+
+- [ ] **Step 2: Register + protect in web.xml**
+
+Add servlet + mapping:
+```xml
+  <servlet>
+    <servlet-name>CanUserAccess</servlet-name>
+    <servlet-class>org.ecocean.api.CanUserAccess</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>CanUserAccess</servlet-name>
+    <url-pattern>/api/v3/can-user-access</url-pattern>
+  </servlet-mapping>
+```
+Shiro `[urls]` (admin-gated — read the file to confirm the exact filter name for admin role; pattern is `authcBasicWildbook, roles[admin]`):
+```
+/api/v3/can-user-access = authcBasicWildbook, roles[admin]
+```
+(The in-code `caller.isAdmin` check is belt-and-suspenders alongside the role constraint.)
+
+- [ ] **Step 3: Mockito unit tests**
+
+Create `CanUserAccessTest.java`: (a) non-admin caller → 403; (b) admin caller + a target user where one encounter `canUserView`==true and another ==false → `accessible` contains only the true one; (c) unknown target uuid → empty accessible. Mock `Shepherd`, `User` (caller `isAdmin`→true/false; target), `Encounter` (`canUserView`→true/false). Follow EncounterApiTest mocking; capture the written JSON via a mocked response + StringWriter and parse it.
+
+- [ ] **Step 4: Run + compile**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=CanUserAccessTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** (LF-normalize first)
+
+```bash
+git -C /mnt/c/Wildbook-integration-b add src/main/java/org/ecocean/api/CanUserAccess.java src/main/webapp/WEB-INF/web.xml src/test/java/org/ecocean/api/CanUserAccessTest.java
+git -C /mnt/c/Wildbook-integration-b commit -m "feat(api): POST /api/v3/can-user-access — live per-user encounter access check"
+```
+
+---
+
+## Task 5: Keypair runbook + test shiro.ini + config docs
+
+**Files:** Create `docs/superpowers/runbooks/jwt-keypair-setup.md`; Modify `src/test/resources/shiro.ini`
+
+- [ ] **Step 1: Write the keypair/config runbook**
+
+Create `docs/superpowers/runbooks/jwt-keypair-setup.md` documenting:
+- Generate an RSA-2048 keypair and the Base64 (PKCS8 private / X.509 public) forms, e.g.:
+  ```
+  openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out jwt_private.pem
+  openssl pkcs8 -topk8 -nocrypt -in jwt_private.pem -outform DER | base64 -w0   # -> jwtPrivateKeyBase64
+  openssl rsa -in jwt_private.pem -pubout -outform DER | base64 -w0             # -> jwtPublicKeyBase64
+  ```
+- The `commonConfiguration.properties` keys: `jwtPrivateKeyBase64`, `jwtPublicKeyBase64`, `jwtIssuer` (default `wildbook`), `jwtAudience` (default `wildbook-scoped-api`), `jwtTtlSeconds` (default 1800).
+- Wildbook needs the PRIVATE key (to sign); the external kernel is given the PUBLIC key only. If `jwtPrivateKeyBase64` is unset, `/api/v3/auth/token` returns 503.
+- Key rotation note (swap keys; old tokens expire within TTL).
+
+- [ ] **Step 2: Add test auth rules**
+
+In `src/test/resources/shiro.ini` `[urls]`, add (matching the file's style) so tests exercise the auth gates:
+```
+/api/v3/auth/token = authcBasicWildbook
+/api/v3/can-user-access = authcBasicWildbook, roles[admin]
+```
+(Read the existing test shiro.ini to use the exact filter names defined there; if `authcBasicWildbook` isn't defined in the test ini, use the test ini's available auth filter equivalent.)
+
+- [ ] **Step 3: Normalize + commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' docs/superpowers/runbooks/jwt-keypair-setup.md src/test/resources/shiro.ini
+git -C /mnt/c/Wildbook-integration-b add docs/superpowers/runbooks/jwt-keypair-setup.md src/test/resources/shiro.ini
+git -C /mnt/c/Wildbook-integration-b commit -m "docs(api): JWT keypair setup runbook + test auth rules"
+```
+
+---
+
+## Task 6: Verification + final review
+
+- [ ] **Step 1: Unit tests**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn test -Dtest=JwtServiceTest,AuthTokenTest,CanUserAccessTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: all pass.
+
+- [ ] **Step 2: Full compile**
+
+Run: `cd /mnt/c/Wildbook-integration-b && mvn -q -DskipTests compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: CRLF check on branch files**
+
+Run: `cd /mnt/c/Wildbook-integration-b && for f in $(git diff --name-only main); do n=$(grep -cP '\r$' "$f" 2>/dev/null||echo 0); [ "$n" != "0" ] && echo "CRLF: $f"; done; echo done`
+Expected: only "done".
+
+- [ ] **Step 4: Confirm no stray files staged across commits**
+
+Run: `cd /mnt/c/Wildbook-integration-b && git diff --name-only main..HEAD`
+Expected: only the intended source/test/doc/pom/web.xml files; NO logs/ or runtime artifacts.
+
+---
+
+## Notes for the implementer
+- jjwt 0.12.x API specifics (builder `.audience().add().and()`, `Jwts.SIG.RS256`, `.parseSignedClaims`, `.verifyWith`) — if the resolved version's API differs, adapt and report which version/API you used.
+- `writeError` is defined per-endpoint (no ApiBase helper) — matches `MatchInspection`.
+- Always LF-normalize after each edit (`perl -i -pe 's/\r\n/\n/g'`); never stage `logs/application.json` — add only explicit paths.
+- Do NOT log token values or private keys anywhere.
+- Security stance: the token carries NO admin/role claims; the kernel resolves privileges fresh. B2 requires the CALLER to be admin and computes access for the TARGET user — never trust a caller-supplied "isAdmin".
+
+## Open questions for review
+1. jjwt 0.12.6 vs an alternative (nimbus-jose-jwt) — any packaging/transitive-dep concern in this WAR? (Dependabot/system-test per repo policy.)
+2. B2 caller gating: full `admin` role for v1 vs a dedicated narrow service role (`rest`?) — admin is simplest now; dedicated service role is a follow-up.
+3. Public-key distribution to the kernel: out-of-band config for v1 vs a `GET /api/v3/auth/jwks` endpoint (follow-up).
+4. Key storage: Base64-in-properties (this plan) vs file-path vs a secrets manager — properties is simplest for the Docker-mounted config; revisit for production secret hygiene.

--- a/docs/superpowers/plans/2026-06-06-token-auth-scoped-search-plan.md
+++ b/docs/superpowers/plans/2026-06-06-token-auth-scoped-search-plan.md
@@ -634,14 +634,35 @@ Then change the top-level auth branch (currently `if ((currentUser == null) || (
         } else {
 ```
 
-Next, inside the `else` block, add the encounter-only index gate and stored-query owner check as two new `else if` branches in the existing guard ladder — insert them **immediately after** the existing `"annotation".equals(indexName) && !currentUser.isAdmin(...)` branch (after `SearchApi:56`) and **before** the `((query == null) && !"POST".equals(...))` 405 branch (`:59`). At this point in the ladder, for a stored query `query` is the loaded full object (it still has `indexName`/`creator`; scrubbing happens later in the execute block), and for a direct query `query` is null:
+Next, inside the `else` block, add the token-path guards as new `else if` branches in the existing guard ladder. **Order matters (Codex):** the method allowlist must come **first** — before the invalid-id (404), index (403), and owner (403) checks — so a wrong-method request returns 405 and never leaks via a 403/404 whether a stored query exists or who owns it. Insert these branches **immediately after** the top-level `if/else if (bearerPresent && !tokenAuth)` opening and the existing `(searchQueryId != null) && (query == null)` invalid-id branch is *re-sequenced after* the method gates. Concretely, replace the head of the guard ladder (the branches from the invalid-id 404 down to the existing 405) so it reads:
 
 ```java
+            // --- token method allowlist FIRST (no existence/ownership leak via 403/404) ---
+            } else if (tokenAuth && (searchQueryId != null)
+                && !"GET".equals(request.getMethod())) {
+                // stored-query replay is GET-only on the token path
+                response.setStatus(405);
+                res.put("error", "method not allowed");
+            } else if (tokenAuth && (searchQueryId == null)
+                && !"POST".equals(request.getMethod())) {
+                // direct index search is POST-only on the token path
+                response.setStatus(405);
+                res.put("error", "method not allowed");
+            // --- existing validity checks ---
+            } else if ((searchQueryId != null) && (query == null)) {
+                response.setStatus(404);
+                res.put("error", "invalid searchQueryId " + searchQueryId);
+            } else if ((searchQueryId == null) && !OpenSearch.isValidIndexName(indexName)) {
+                response.setStatus(404);
+                res.put("error", "unknown index");
+            } else if ("annotation".equals(indexName) && !currentUser.isAdmin(myShepherd)) {
+                response.setStatus(403);
+                res.put("error", 403);
+            // --- token encounter-only index gate + stored-query owner check ---
             } else if (tokenAuth && !"encounter".equals(
                 (searchQueryId != null) ? (query != null ? query.optString("indexName", null) : null)
                                         : indexName)) {
-                // token search is encounter-index only (covers stored queries whose real index
-                // is read from the stored doc, not from the {uuid} URL)
+                // covers stored queries whose real index is read from the stored doc, not the URL
                 response.setStatus(403);
                 res.put("error", "token search is limited to the encounter index");
             } else if (tokenAuth && (searchQueryId != null) && (query != null)
@@ -650,15 +671,15 @@ Next, inside the `else` block, add the encounter-only index gate and stored-quer
                 // replaying someone else's stored query is not allowed (admin bypasses)
                 response.setStatus(403);
                 res.put("error", "not the owner of this stored query");
-            } else if (tokenAuth && (searchQueryId != null) && !"GET".equals(request.getMethod())) {
-                // token method allowlist: stored-query replay is GET-only (direct index is
-                // POST-only, already enforced by the existing query==null && !POST -> 405 branch)
+            } else if ((query == null) && !"POST".equals(request.getMethod())) {
                 response.setStatus(405);
                 res.put("error", "method not allowed");
-            } else if ((query == null) && !"POST".equals(request.getMethod())) {
+            } else {
+                // ... existing execute block (query parse/store/scrub, sanitize, ACL inject, queryPit) ...
+            }
 ```
 
-(The last line is the existing 405 branch — shown for placement; do not duplicate it.)
+This re-sequences the *existing* invalid-id / unknown-index / annotation-admin / 405 branches (do not duplicate them elsewhere) and inserts the four new token branches in the shown order. The method gates fire first; the index/owner gates fire before execution; the execute block is unchanged except for Step 3's ACL injection.
 
 - [ ] **Step 3: Inject the ACL pre-filter after sanitize**
 
@@ -886,6 +907,32 @@ class SearchApiTokenAuthTest {
         verify(response).setStatus(405);
     }
 
+    @Test void storedQuery_postOtherOwner_is405NotOwnership403() throws Exception {
+        // method gate fires FIRST: wrong method must not leak ownership via a 403
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = storedQuery("encounter", "someoneElse")) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(405);
+        verify(response, never()).setStatus(403);
+    }
+
+    @Test void directIndex_getMethod_returns405() throws Exception {
+        // token direct index search is POST-only; a GET to /encounter must be 405
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(405);
+    }
+
     @Test void storedQuery_ownEncounter_succeeds() throws Exception {
         when(request.getMethod()).thenReturn("GET");
         when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
@@ -924,7 +971,7 @@ class SearchApiTokenAuthTest {
 - [ ] **Step 5: Run the test**
 
 Run: `mvn test -Dtest=SearchApiTokenAuthTest`
-Expected: PASS (9 tests: direct non-encounter 403, unmarked Bearer 401, lowercase-Bearer-unmarked 401, ACL injection, admin no-injection, stored other-owner 403, stored non-encounter 403, stored POST 405, stored own-encounter scoped 200). Iterate on the SearchApi edits (not the tests) until green. Also re-run any existing SearchApi test to confirm no regression: `mvn test -Dtest=SearchApi*`.
+Expected: PASS (11 tests: direct non-encounter 403, unmarked Bearer 401, lowercase-Bearer-unmarked 401, ACL injection, admin no-injection, stored other-owner GET 403, stored non-encounter GET 403, stored POST 405, stored POST other-owner 405-not-403, direct GET 405, stored own-encounter scoped 200). Iterate on the SearchApi edits (not the tests) until green. Also re-run any existing SearchApi test to confirm no regression: `mvn test -Dtest=SearchApi*`.
 
 - [ ] **Step 6: Normalize and commit**
 
@@ -965,11 +1012,11 @@ This is the only rule for the search path; no `authc`/`roles` is chained (the fi
 
 - [ ] **Step 3: Update / add the wiring-guard test**
 
-If `src/test/java/org/ecocean/api/EndpointAuthWiringTest.java` exists (added by Artifact B to assert `web.xml` Shiro rules), add an assertion that the search rule is present and maps only to `tokenAuthSearch`. Mirror the existing assertion style in that file. Representative addition:
+If `src/test/java/org/ecocean/api/EndpointAuthWiringTest.java` exists (added by Artifact B to assert `web.xml` Shiro rules), add an assertion that the search rule is present and maps only to `tokenAuthSearch`. Mirror the existing assertion style in that file — it exposes the `web.xml` contents via a helper named **`fullText()`** (`EndpointAuthWiringTest.java:35-36`), so use that (not a new `readWebXml()`):
 
 ```java
     @Test void searchPath_wiredToTokenFilterOnly() throws Exception {
-        String webXml = readWebXml(); // existing helper in this test
+        String webXml = fullText(); // existing helper in EndpointAuthWiringTest
         assertTrue(webXml.contains("tokenAuthSearch = org.ecocean.security.WildbookTokenAuthenticationFilter"),
             "token filter declared in [main]");
         assertTrue(webXml.contains("/api/v3/search/** = tokenAuthSearch"),
@@ -980,10 +1027,10 @@ If `src/test/java/org/ecocean/api/EndpointAuthWiringTest.java` exists (added by 
     }
 ```
 
-If `EndpointAuthWiringTest` does not exist, create `src/test/java/org/ecocean/api/SearchWiringTest.java` with the same assertions and a `readWebXml()` helper that reads `src/main/webapp/WEB-INF/web.xml` from the project basedir:
+If `EndpointAuthWiringTest` does not exist (verify first with a quick `ls src/test/java/org/ecocean/api/`), create `src/test/java/org/ecocean/api/SearchWiringTest.java` with the same assertions and a local `fullText()` helper that reads `src/main/webapp/WEB-INF/web.xml` from the project basedir:
 
 ```java
-    private String readWebXml() throws Exception {
+    private String fullText() throws Exception {
         return new String(java.nio.file.Files.readAllBytes(
             java.nio.file.Paths.get("src/main/webapp/WEB-INF/web.xml")),
             java.nio.charset.StandardCharsets.UTF_8);
@@ -1099,6 +1146,36 @@ Create `src/test/java/org/ecocean/api/SearchTokenScopeTest.java` modeled on `Enc
             .when().post("/api/v3/search/encounter")
             .then().statusCode(401);
     }
+
+    // Spec Critical: a token request must NOT mint a session, so it can never be parlayed
+    // into a write. Assert no JSESSIONID is set, and a follow-up no-Bearer request on the
+    // same client is unauthenticated (does not inherit the token user).
+    @Test void tokenSearch_mintsNoSession() throws Exception {
+        String token = testJwtService.sign(aliceUuid, "context0", 60_000L);
+        io.restassured.response.Response r = given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/encounter")
+            .then().statusCode(200)
+            .extract().response();
+
+        // no session cookie minted
+        String setCookie = r.header("Set-Cookie");
+        assertFalse((setCookie != null) && setCookie.contains("JSESSIONID"),
+            "token search must not mint a JSESSIONID");
+        assertTrue(r.getCookies() == null || r.getCookie("JSESSIONID") == null,
+            "no JSESSIONID cookie returned");
+
+        // a follow-up request with no Bearer (and any cookies the prior response set) is anon:
+        // SearchApi self-401s because there is no session principal
+        given()
+            .cookies(r.getCookies() == null ? new java.util.HashMap<>() : r.getCookies())
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/encounter")
+            .then().statusCode(401);
+    }
 ```
 
 The JwtService keypair must match between the filter (loads from `CommonConfiguration` `jwtPublicKeyBase64`) and the test signer. Set the test config keys (`jwtPrivateKeyBase64`/`jwtPublicKeyBase64`/`jwtIssuer`/`jwtAudience`) to a generated test keypair in `@BeforeAll` (the harness already loads a test `commonConfiguration.properties`; write the test keys there or via the same mechanism `AuthTokenTest`/the B integration tests use). Reuse the keypair-generation snippet from `JwtServiceTest`/Task 3.
@@ -1106,7 +1183,7 @@ The JwtService keypair must match between the filter (loads from `CommonConfigur
 - [ ] **Step 3: Run the integration test**
 
 Run: `mvn test -Dtest=SearchTokenScopeTest`
-Expected: PASS (4 tests: scoped non-admin, admin unscoped, non-encounter 403, context-drift-via-cookie 401). This pulls the Testcontainers OpenSearch image; allow time on first run. The `*Test` suffix means a plain `mvn test` also runs it (matching the repo's `EncounterExportImagesTest` convention). If the environment cannot run Testcontainers, mark this class `@org.junit.jupiter.api.Disabled("requires Docker/Testcontainers")` with a comment and rely on Tasks 1/3/4 unit tests + a manual run note — but do not delete it.
+Expected: PASS (5 tests: scoped non-admin, admin unscoped, non-encounter 403, context-drift-via-cookie 401, no-session-minted). This pulls the Testcontainers OpenSearch image; allow time on first run. The `*Test` suffix means a plain `mvn test` also runs it (matching the repo's `EncounterExportImagesTest` convention). If the environment cannot run Testcontainers, mark this class `@org.junit.jupiter.api.Disabled("requires Docker/Testcontainers")` with a comment and rely on Tasks 1/3/4 unit tests + a manual run note — but do not delete it.
 
 - [ ] **Step 4: Normalize and commit**
 

--- a/docs/superpowers/plans/2026-06-06-token-auth-scoped-search-plan.md
+++ b/docs/superpowers/plans/2026-06-06-token-auth-scoped-search-plan.md
@@ -634,11 +634,11 @@ Then change the top-level auth branch (currently `if ((currentUser == null) || (
         } else {
 ```
 
-Next, inside the `else` block, add the token-path guards as new `else if` branches in the existing guard ladder. **Order matters (Codex):** the method allowlist must come **first** — before the invalid-id (404), index (403), and owner (403) checks — so a wrong-method request returns 405 and never leaks via a 403/404 whether a stored query exists or who owns it. Insert these branches **immediately after** the top-level `if/else if (bearerPresent && !tokenAuth)` opening and the existing `(searchQueryId != null) && (query == null)` invalid-id branch is *re-sequenced after* the method gates. Concretely, replace the head of the guard ladder (the branches from the invalid-id 404 down to the existing 405) so it reads:
+Next, inside the `else` block, add the token-path guards as new `else if` branches in the existing guard ladder. **Order matters (Codex):** the method allowlist must come **first** — before the invalid-id (404), index (403), and owner (403) checks — so a wrong-method request returns 405 and never leaks via a 403/404 whether a stored query exists or who owns it. Insert these branches **immediately after** the top-level `if/else if (bearerPresent && !tokenAuth)` opening and the existing `(searchQueryId != null) && (query == null)` invalid-id branch is *re-sequenced after* the method gates. Concretely, replace the head of the guard ladder (the branches from the invalid-id 404 down to the existing 405) so it reads. **Note the first branch is `if` (it is the head of the ladder, immediately following the `Util.isUUID(...)`/`queryLoad` block), not `} else if`:**
 
 ```java
             // --- token method allowlist FIRST (no existence/ownership leak via 403/404) ---
-            } else if (tokenAuth && (searchQueryId != null)
+            if (tokenAuth && (searchQueryId != null)
                 && !"GET".equals(request.getMethod())) {
                 // stored-query replay is GET-only on the token path
                 response.setStatus(405);

--- a/docs/superpowers/plans/2026-06-06-token-auth-scoped-search-plan.md
+++ b/docs/superpowers/plans/2026-06-06-token-auth-scoped-search-plan.md
@@ -124,6 +124,11 @@ Insert this method immediately after `querySanitize` (after `OpenSearch.java:923
      * encounter ACL (mirrors Encounter.opensearchAccess for a non-admin user). Applied on the
      * token-authenticated path BEFORE execution so totals, pagination, and hits are all scoped.
      * Admins are not passed through here (caller skips the call for admins).
+     *
+     * Decision (documented, safe): a request with no inner "query" yields a filter-only bool,
+     * i.e. "all encounters this user may see" — still fully scoped, never a bypass. A truly
+     * malformed (non-JSON) body fails earlier in ServletUtilities.jsonFromHttpServletRequest,
+     * before reaching this method, so the spec's "fail closed on malformed" is satisfied upstream.
      */
     public static JSONObject applyEncounterAclFilter(JSONObject query, String userId)
     throws IOException {
@@ -282,7 +287,8 @@ public class WildbookTokenAuthenticationFilter extends OncePerRequestFilter {
         HttpServletResponse response = (HttpServletResponse) resp;
 
         String authz = request.getHeader("Authorization");
-        if ((authz == null) || !authz.startsWith("Bearer ")) {
+        // HTTP auth scheme tokens are case-insensitive: accept "Bearer"/"bearer"/etc.
+        if ((authz == null) || !authz.regionMatches(true, 0, "Bearer ", 0, 7)) {
             chain.doFilter(request, response); // no token: leave session/anon path intact
             return;
         }
@@ -292,7 +298,7 @@ public class WildbookTokenAuthenticationFilter extends OncePerRequestFilter {
             deny(response, 405, "method not allowed");
             return;
         }
-        String token = authz.substring("Bearer ".length()).trim();
+        String token = authz.substring(7).trim();
         String expected = expectedContext();
 
         JwtService jwt = jwtService(expected);
@@ -533,14 +539,47 @@ class WildbookTokenAuthenticationFilterTest {
         verify(response).setStatus(401);
         verify(chain, never()).doFilter(any(), any());
     }
+
+    @Test void lowercaseBearerScheme_stillAuthenticates() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("bearer " + token); // lowercase scheme
+        when(request.getMethod()).thenReturn("POST");
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(chain).doFilter(any(), eq(response)); // wrapped + forwarded, not treated as no-token
+        verify(response, never()).setStatus(anyInt());
+    }
+
+    @Test void notConfigured_returns503() throws Exception {
+        JwtService noKeys = JwtService.fromBase64Keys(null, null, "wildbook", "wildbook-scoped-api");
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        WildbookTokenAuthenticationFilter f = new WildbookTokenAuthenticationFilter() {
+            @Override protected String expectedContext() {
+                return "context0";
+            }
+            @Override protected String requestContext(HttpServletRequest r) {
+                return "context0";
+            }
+            @Override protected JwtService jwtService(String context) {
+                return noKeys; // canVerify() == false
+            }
+            @Override protected String lookupUsername(String context, String uuid) {
+                return "alice";
+            }
+        };
+        f.doFilterInternal(request, response, chain);
+        verify(response).setStatus(503);
+        verify(chain, never()).doFilter(any(), any());
+    }
 }
 ```
 
 - [ ] **Step 3: Run the test to verify it fails (then passes)**
 
 Run: `mvn test -Dtest=WildbookTokenAuthenticationFilterTest`
-Expected first run: the test compiles against the Step-1 class. If Step 1 was committed, this should PASS directly. If any assertion fails, fix the filter (not the test) until all 8 tests pass.
-Expected: PASS (8 tests).
+Expected first run: the test compiles against the Step-1 class. If Step 1 was committed, this should PASS directly. If any assertion fails, fix the filter (not the test) until all tests pass.
+Expected: PASS (10 tests).
 
 > Note: `doFilterInternal` is `protected`; the test is in the same package (`org.ecocean.security`), so it can call it directly.
 
@@ -577,7 +616,9 @@ Edit `SearchApi.java`. First, just after the user is resolved and the `JSONObjec
         boolean tokenAuth = Boolean.TRUE.equals(
             request.getAttribute(org.ecocean.security.WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR));
         String authzHeader = request.getHeader("Authorization");
-        boolean bearerPresent = (authzHeader != null) && authzHeader.startsWith("Bearer ");
+        // case-insensitive scheme match (matches the filter); avoids fall-through on "bearer ..."
+        boolean bearerPresent = (authzHeader != null)
+            && authzHeader.regionMatches(true, 0, "Bearer ", 0, 7);
 ```
 
 Then change the top-level auth branch (currently `if ((currentUser == null) || (currentUser.getId() == null)) { 401 } else { ... }` at `:33`) to fail closed when a Bearer arrived unmarked:
@@ -609,6 +650,11 @@ Next, inside the `else` block, add the encounter-only index gate and stored-quer
                 // replaying someone else's stored query is not allowed (admin bypasses)
                 response.setStatus(403);
                 res.put("error", "not the owner of this stored query");
+            } else if (tokenAuth && (searchQueryId != null) && !"GET".equals(request.getMethod())) {
+                // token method allowlist: stored-query replay is GET-only (direct index is
+                // POST-only, already enforced by the existing query==null && !POST -> 405 branch)
+                response.setStatus(405);
+                res.put("error", "method not allowed");
             } else if ((query == null) && !"POST".equals(request.getMethod())) {
 ```
 
@@ -651,17 +697,23 @@ import javax.servlet.http.HttpServletResponse;
 import org.ecocean.OpenSearch;
 import org.ecocean.User;
 import org.ecocean.security.WildbookTokenAuthenticationFilter;
+import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
 import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 
 class SearchApiTokenAuthTest {
 
     HttpServletRequest request;
     HttpServletResponse response;
     StringWriter out;
+    // getContext() on a Mockito request would NPE (reads serverName/cookies/context props);
+    // stub it for ALL tests. jsonFromHttpServletRequest is stubbed per-test as needed.
+    MockedStatic<ServletUtilities> su;
 
     @BeforeEach void setUp() throws Exception {
         request = mock(HttpServletRequest.class);
@@ -670,28 +722,46 @@ class SearchApiTokenAuthTest {
         when(response.getWriter()).thenReturn(new PrintWriter(out));
         when(request.getServletContext()).thenReturn(null);
         when(request.getContextPath()).thenReturn("");
+        when(request.getParameter(anyString())).thenReturn(null);
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(Boolean.TRUE); // default: token request (override per-test where needed)
+        su = mockStatic(ServletUtilities.class);
+        su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+        su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+            .thenReturn(new JSONObject("{\"query\":{\"match_all\":{}}}"));
+    }
+
+    @AfterEach void tearDown() {
+        su.close();
     }
 
     private User mockUser(String id, boolean admin) {
         User u = mock(User.class);
         when(u.getId()).thenReturn(id);
+        when(u.getUUID()).thenReturn(id); // queryStore reads getUUID(); == getId() in source
         return u;
     }
+
+    /** Shepherd mock with the standard tx stubs + a resolved user. */
+    private MockedConstruction<Shepherd> shepherdReturning(User user, boolean admin) {
+        return mockConstruction(Shepherd.class, (m, c) -> {
+            doNothing().when(m).beginDBTransaction();
+            doNothing().when(m).setAction(anyString());
+            doNothing().when(m).rollbackAndClose();
+            when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
+            when(user.isAdmin(m)).thenReturn(admin);
+        });
+    }
+
+    private static final JSONObject EMPTY_HITS =
+        new JSONObject("{\"hits\":{\"total\":{\"value\":0},\"hits\":[]}}");
 
     @Test void tokenRequest_nonEncounterIndex_returns403() throws Exception {
         when(request.getMethod()).thenReturn("POST");
         when(request.getPathInfo()).thenReturn("/individual");
         when(request.getHeader("Authorization")).thenReturn("Bearer x");
-        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
-            .thenReturn(Boolean.TRUE);
         User user = mockUser("u1", false);
-        try (MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
-            doNothing().when(m).beginDBTransaction();
-            doNothing().when(m).setAction(anyString());
-            doNothing().when(m).rollbackAndClose();
-            when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
-            when(user.isAdmin(m)).thenReturn(false);
-        })) {
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false)) {
             new SearchApi().doPost(request, response);
         }
         verify(response).setStatus(403);
@@ -704,12 +774,21 @@ class SearchApiTokenAuthTest {
         when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
             .thenReturn(null); // filter did NOT mark it
         User user = mockUser("u1", false);
-        try (MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
-            doNothing().when(m).beginDBTransaction();
-            doNothing().when(m).setAction(anyString());
-            doNothing().when(m).rollbackAndClose();
-            when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
-        })) {
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(401);
+    }
+
+    @Test void lowercaseBearerWithoutMarker_returns401() throws Exception {
+        // case-insensitive bearerPresent: "bearer ..." with no marker must still fail closed
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("bearer x");
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null);
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false)) {
             new SearchApi().doPost(request, response);
         }
         verify(response).setStatus(401);
@@ -719,44 +798,19 @@ class SearchApiTokenAuthTest {
         when(request.getMethod()).thenReturn("POST");
         when(request.getPathInfo()).thenReturn("/encounter");
         when(request.getHeader("Authorization")).thenReturn("Bearer x");
-        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
-            .thenReturn(Boolean.TRUE);
-        when(request.getParameter(anyString())).thenReturn(null);
         User user = mockUser("u1", false);
-
-        // capture the query passed to queryPit
-        JSONObject queryResponse = new JSONObject(
-            "{\"hits\":{\"total\":{\"value\":0},\"hits\":[]}}");
-        try (MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
-                doNothing().when(m).beginDBTransaction();
-                doNothing().when(m).setAction(anyString());
-                doNothing().when(m).rollbackAndClose();
-                when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
-                when(user.isAdmin(m)).thenReturn(false);
-            });
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
             MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
                 doNothing().when(m).deletePit(anyString());
                 when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
                     any(), any())).thenAnswer(inv -> {
                         JSONObject q = inv.getArgument(1);
-                        // ACL filter must be present BEFORE execution
                         JSONObject bool = q.getJSONObject("query").getJSONObject("bool");
                         assertTrue(bool.has("filter"), "ACL filter injected before queryPit");
-                        return queryResponse;
+                        return EMPTY_HITS;
                     });
             })) {
-            // request body provides the inner query
-            org.mockito.MockedStatic<org.ecocean.servlet.ServletUtilities> su =
-                mockStatic(org.ecocean.servlet.ServletUtilities.class);
-            su.when(() -> org.ecocean.servlet.ServletUtilities.getContext(any()))
-                .thenReturn("context0");
-            su.when(() -> org.ecocean.servlet.ServletUtilities.jsonFromHttpServletRequest(any()))
-                .thenReturn(new JSONObject("{\"query\":{\"match_all\":{}}}"));
-            try {
-                new SearchApi().doPost(request, response);
-            } finally {
-                su.close();
-            }
+            new SearchApi().doPost(request, response);
         }
         verify(response).setStatus(200);
     }
@@ -765,19 +819,8 @@ class SearchApiTokenAuthTest {
         when(request.getMethod()).thenReturn("POST");
         when(request.getPathInfo()).thenReturn("/encounter");
         when(request.getHeader("Authorization")).thenReturn("Bearer x");
-        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
-            .thenReturn(Boolean.TRUE);
-        when(request.getParameter(anyString())).thenReturn(null);
         User user = mockUser("admin1", true);
-        JSONObject queryResponse = new JSONObject(
-            "{\"hits\":{\"total\":{\"value\":0},\"hits\":[]}}");
-        try (MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
-                doNothing().when(m).beginDBTransaction();
-                doNothing().when(m).setAction(anyString());
-                doNothing().when(m).rollbackAndClose();
-                when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
-                when(user.isAdmin(m)).thenReturn(true);
-            });
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, true);
             MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
                 doNothing().when(m).deletePit(anyString());
                 when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
@@ -786,32 +829,102 @@ class SearchApiTokenAuthTest {
                         JSONObject inner = q.getJSONObject("query");
                         assertFalse(inner.has("bool") && inner.getJSONObject("bool").has("filter"),
                             "admin token must NOT have an injected ACL filter");
-                        return queryResponse;
+                        return EMPTY_HITS;
                     });
             })) {
-            org.mockito.MockedStatic<org.ecocean.servlet.ServletUtilities> su =
-                mockStatic(org.ecocean.servlet.ServletUtilities.class);
-            su.when(() -> org.ecocean.servlet.ServletUtilities.getContext(any()))
-                .thenReturn("context0");
-            su.when(() -> org.ecocean.servlet.ServletUtilities.jsonFromHttpServletRequest(any()))
-                .thenReturn(new JSONObject("{\"query\":{\"match_all\":{}}}"));
-            try {
-                new SearchApi().doPost(request, response);
-            } finally {
-                su.close();
-            }
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+    }
+
+    // ---- stored-query gating (token path) ----
+
+    /** Stub OpenSearch.queryLoad to return a stored-query doc (with indexName + creator). */
+    private MockedStatic<OpenSearch> storedQuery(String indexName, String creator) {
+        MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class);
+        osStatic.when(() -> OpenSearch.queryLoad(anyString())).thenReturn(
+            new JSONObject().put("indexName", indexName).put("creator", creator)
+                .put("query", new JSONObject().put("match_all", new JSONObject())));
+        osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(true);
+        return osStatic;
+    }
+
+    @Test void storedQuery_otherOwner_returns403() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = storedQuery("encounter", "someoneElse")) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(403);
+    }
+
+    @Test void storedQuery_nonEncounterIndex_returns403() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = storedQuery("individual", "u1")) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(403); // own query, but wrong index
+    }
+
+    @Test void storedQuery_postMethod_returns405() throws Exception {
+        // token stored-query replay is GET-only
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = storedQuery("encounter", "u1")) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(405);
+    }
+
+    @Test void storedQuery_ownEncounter_succeeds() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = storedQuery("encounter", "u1");
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenAnswer(inv -> {
+                        JSONObject q = inv.getArgument(1);
+                        assertTrue(q.getJSONObject("query").getJSONObject("bool").has("filter"),
+                            "own stored encounter query is ACL-scoped before execution");
+                        return EMPTY_HITS;
+                    });
+            })) {
+            // queryScrubStored is static too; stub it to extract the inner query
+            osStatic.when(() -> OpenSearch.queryScrubStored(any())).thenAnswer(inv -> {
+                JSONObject stored = inv.getArgument(0);
+                return new JSONObject().put("query", stored.optJSONObject("query"));
+            });
+            osStatic.when(() -> OpenSearch.querySanitize(any(), any(), any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+            osStatic.when(() -> OpenSearch.applyEncounterAclFilter(any(), anyString()))
+                .thenCallRealMethod();
+            new SearchApi().doPost(request, response);
         }
         verify(response).setStatus(200);
     }
 }
 ```
 
-> Note on `queryStore`: the ACL-injection test relies on `OpenSearch.queryStore` writing to `/tmp` (its default `QUERY_STORAGE_DIR`). If `queryStore` (a static, not on the mocked instance) interferes in CI, additionally `mockStatic(OpenSearch.class, CALLS_REAL_METHODS)` and stub `queryStore`/`querySanitize` to pass-through, or assert via the `applyEncounterAclFilter` unit test (Task 1) plus a lighter SearchApi test that stops at the 403/401 branches. Keep the instance-method capture as the primary assertion.
+> Note on combining `mockStatic(OpenSearch)` + `mockConstruction(OpenSearch)`: Mockito supports both on one class concurrently (static-method mock vs constructed-instance mock are independent). In `storedQuery_ownEncounter_succeeds`, the static mock must explicitly stub `queryScrubStored`/`querySanitize`/`applyEncounterAclFilter` (they're static and otherwise return null/Mockito-default when the class is statically mocked). For the direct-query tests (no `mockStatic(OpenSearch)`), `queryStore`/`querySanitize`/`applyEncounterAclFilter` run for real — `queryStore` writes to `/tmp` (writable in the test env) and `applyEncounterAclFilter` is the real builder, which is what the assertion captures.
 
 - [ ] **Step 5: Run the test**
 
 Run: `mvn test -Dtest=SearchApiTokenAuthTest`
-Expected: PASS (4 tests). Iterate on the SearchApi edits (not the tests) until green. Also re-run any existing SearchApi test to confirm no regression: `mvn test -Dtest=SearchApi*`.
+Expected: PASS (9 tests: direct non-encounter 403, unmarked Bearer 401, lowercase-Bearer-unmarked 401, ACL injection, admin no-injection, stored other-owner 403, stored non-encounter 403, stored POST 405, stored own-encounter scoped 200). Iterate on the SearchApi edits (not the tests) until green. Also re-run any existing SearchApi test to confirm no regression: `mvn test -Dtest=SearchApi*`.
 
 - [ ] **Step 6: Normalize and commit**
 
@@ -899,7 +1012,7 @@ Prove the scoping for real: a token-authenticated `/api/v3/search/encounter` ret
 
 **Files:**
 - Modify: `src/test/resources/shiro.ini` — add the same `[main]`/`[urls]` token-filter wiring as `web.xml`.
-- Modify/Create: `src/test/java/org/ecocean/api/SearchTokenScopeIT.java` (new, or a method group in `EncounterExportImagesTest`).
+- Modify/Create: `src/test/java/org/ecocean/api/SearchTokenScopeTest.java` (new, or a method group in `EncounterExportImagesTest`).
 
 - [ ] **Step 1: Mirror the Shiro wiring into the test `shiro.ini`**
 
@@ -917,7 +1030,7 @@ and to `[urls]` (before any catch-all):
 
 - [ ] **Step 2: Write the integration test**
 
-Create `src/test/java/org/ecocean/api/SearchTokenScopeIT.java` modeled on `EncounterExportImagesTest`'s `@BeforeAll` server/Testcontainers setup (copy its server bring-up: `Server`, `ServletContextHandler`, `IniShiroFilter` from `classpath:shiro.ini`, register `new SearchApi()` at `/api/v3/search/*`, REST Assured base URI/port). Seed data + token, then assert scoping:
+Create `src/test/java/org/ecocean/api/SearchTokenScopeTest.java` modeled on `EncounterExportImagesTest`'s `@BeforeAll` server/Testcontainers setup (copy its server bring-up: `Server`, `ServletContextHandler`, `IniShiroFilter` from `classpath:shiro.ini`, register `new SearchApi()` at `/api/v3/search/*`, REST Assured base URI/port). Seed data + token, then assert scoping:
 
 ```java
     @Test void tokenSearch_scopesToPermittedEncountersAndTotals() throws Exception {
@@ -970,21 +1083,37 @@ Create `src/test/java/org/ecocean/api/SearchTokenScopeIT.java` modeled on `Encou
             .when().post("/api/v3/search/individual")
             .then().statusCode(403);
     }
+
+    // Real-stack context-drift: token says context0, but the wildbookContext cookie aims
+    // elsewhere. This drives the REAL ServletUtilities.getContext (the cookie branch returns
+    // the cookie value unconditionally — ServletUtilities.java:786-794), so it reliably forces
+    // a non-context0 resolved context without needing context1 configured in the test env.
+    // (The ?context= branch only honors *configured* contexts, so the cookie is the robust
+    // trigger; query-param/host drift logic is also covered by the filter seam unit tests.)
+    @Test void tokenSearch_contextDriftViaCookie_401() throws Exception {
+        String token = testJwtService.sign(aliceUuid, "context0", 60_000L);
+        given().header("Authorization", "Bearer " + token)
+            .cookie("wildbookContext", "context1")
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/encounter")
+            .then().statusCode(401);
+    }
 ```
 
 The JwtService keypair must match between the filter (loads from `CommonConfiguration` `jwtPublicKeyBase64`) and the test signer. Set the test config keys (`jwtPrivateKeyBase64`/`jwtPublicKeyBase64`/`jwtIssuer`/`jwtAudience`) to a generated test keypair in `@BeforeAll` (the harness already loads a test `commonConfiguration.properties`; write the test keys there or via the same mechanism `AuthTokenTest`/the B integration tests use). Reuse the keypair-generation snippet from `JwtServiceTest`/Task 3.
 
 - [ ] **Step 3: Run the integration test**
 
-Run: `mvn test -Dtest=SearchTokenScopeIT`
-Expected: PASS (3 tests). This pulls the Testcontainers OpenSearch image; allow time on first run. If the environment cannot run Testcontainers, mark this class `@org.junit.jupiter.api.Disabled("requires Docker/Testcontainers")` with a comment and rely on Tasks 1/3/4 unit tests + a manual run note — but do not delete it.
+Run: `mvn test -Dtest=SearchTokenScopeTest`
+Expected: PASS (4 tests: scoped non-admin, admin unscoped, non-encounter 403, context-drift-via-cookie 401). This pulls the Testcontainers OpenSearch image; allow time on first run. The `*Test` suffix means a plain `mvn test` also runs it (matching the repo's `EncounterExportImagesTest` convention). If the environment cannot run Testcontainers, mark this class `@org.junit.jupiter.api.Disabled("requires Docker/Testcontainers")` with a comment and rely on Tasks 1/3/4 unit tests + a manual run note — but do not delete it.
 
 - [ ] **Step 4: Normalize and commit**
 
 ```bash
 cd /mnt/c/Wildbook-token-auth
-grep -lU $'\r' src/test/resources/shiro.ini src/test/java/org/ecocean/api/SearchTokenScopeIT.java | xargs -r sed -i 's/\r$//'
-git add src/test/resources/shiro.ini src/test/java/org/ecocean/api/SearchTokenScopeIT.java
+grep -lU $'\r' src/test/resources/shiro.ini src/test/java/org/ecocean/api/SearchTokenScopeTest.java | xargs -r sed -i 's/\r$//'
+git add src/test/resources/shiro.ini src/test/java/org/ecocean/api/SearchTokenScopeTest.java
 git commit -m "test(search): end-to-end token-scoped encounter search enforcement"
 ```
 
@@ -1000,7 +1129,7 @@ cd /mnt/c/Wildbook-token-auth
 mvn -q -DskipTests compile
 mvn test -Dtest=OpenSearchAclFilterTest,JwtServiceTest,WildbookTokenAuthenticationFilterTest,SearchApiTokenAuthTest,EndpointAuthWiringTest
 ```
-Expected: BUILD SUCCESS; all tests green. (Run `SearchTokenScopeIT` separately if Docker is available.)
+Expected: BUILD SUCCESS; all tests green. (Run `SearchTokenScopeTest` separately if Docker is available.)
 
 - [ ] **Step 2: Verify no CRLF crept in across all touched files**
 

--- a/docs/superpowers/plans/2026-06-06-token-auth-scoped-search-plan.md
+++ b/docs/superpowers/plans/2026-06-06-token-auth-scoped-search-plan.md
@@ -1,0 +1,1052 @@
+# Token-Authenticated Scoped Search (Artifact D) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Java the hard permission boundary for user-facing scoped encounter search — an external client presents a Bearer JWT (issued by Artifact B) to `/api/v3/search/encounter`, and Wildbook verifies it, resolves the user, and runs a permission-filtered search whose totals, pagination, and hits are all scoped to what that user may see.
+
+**Architecture:** A new Shiro `OncePerRequestFilter` (`WildbookTokenAuthenticationFilter`) verifies the JWT (reusing B's `JwtService`), rejects context drift, resolves the user by UUID, and **wraps the request** so `Shepherd.getUser(request)` returns the token user — **without** calling `subject.login` (no session is minted, so a token can never be parlayed into a write). `SearchApi` then, on the token path, enforces encounter-only index gating + stored-query ownership and **injects a real ACL pre-filter** (`publiclyReadable OR submitterUserId==uuid OR viewUsers==uuid`) into the OpenSearch query *before execution*. Admins get no pre-filter. The session/browser path is untouched.
+
+**Tech Stack:** Java 17, Apache Shiro (`org.apache.shiro.web.servlet.OncePerRequestFilter`), jjwt 0.12.6 (via B's `JwtService`), `org.json` (JSONObject/JSONArray), DataNucleus JDO (`Shepherd`), JUnit 5 + Mockito 5 (unit), embedded Jetty + Testcontainers OpenSearch (integration). Build: Maven (`mvn test`).
+
+**Branch / worktree:** `token-auth-scoped-search` at `/mnt/c/Wildbook-token-auth` (off the A+B integration base; B's `JwtService`/`AuthToken` are present). All paths below are relative to that worktree.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-token-auth-scoped-search-design.md` (Codex-converged, 2 rounds).
+
+---
+
+## File Structure
+
+**Create:**
+- `src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java` — the Shiro filter (verify → context checks → wrap request → mark token-auth → forward). The only new auth code.
+- `src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java` — filter unit tests (Mockito).
+- `src/test/java/org/ecocean/OpenSearchAclFilterTest.java` — pure unit tests for the ACL-filter builder.
+
+**Modify:**
+- `src/main/java/org/ecocean/api/auth/JwtService.java` — add a tiny `canVerify()` accessor (public-key presence).
+- `src/main/java/org/ecocean/OpenSearch.java` — add `applyEncounterAclFilter(query, userId)` (pure query rewriter).
+- `src/main/java/org/ecocean/api/SearchApi.java` — token-path enforcement: fail-closed-on-unmarked-Bearer, encounter-only index gate, stored-query owner check, ACL injection after sanitize.
+- `src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java` — **create** (new file) for SearchApi token-path unit tests.
+- `src/main/webapp/WEB-INF/web.xml` — register the filter in Shiro `[main]` and map `/api/v3/search/**` to it in `[urls]`.
+- `src/test/java/org/ecocean/api/EncounterExportImagesTest.java` (or a sibling) — add a token-scoped enforcement integration test (real OpenSearch).
+- `src/test/.../EndpointAuthWiringTest.java` (B's wiring guard, if present) — assert the new search rule.
+
+**Key facts locked in (verified against current source on this branch):**
+- `SearchApi` is mapped to `/api/v3/search/*` in `web.xml`; `doGet` delegates to `doPost`.
+- `SearchApi:31` resolves the user via `myShepherd.getUser(request)`; `SearchApi:34` self-401s when that user is null.
+- `Shepherd.getUser(request)` → `getUsername(request)` → `request.getUserPrincipal().toString()` → `getUser(username)` (DB lookup **by username**). So the wrapper's `getUserPrincipal().toString()` must return the **username**, not the UUID.
+- `User.getId()` and `User.getUUID()` both return the `uuid` field (`User.java:400-401`) — interchangeable for the owner/ACL comparisons.
+- `OpenSearch.querySanitize` (`OpenSearch:918-923`) is a **no-op**; `sanitizeDoc` (`OpenSearch:926-970`) post-sanitizes encounter hits but leaks metadata as `access:"none"` and does NOT scope totals — hence D injects a real pre-filter instead of relying on it.
+- `SearchApi` query lifecycle: parse/`queryLoad` → (stored) re-read `indexName` + `queryScrubStored` (`SearchApi:81-82`) → `querySanitize` (`:84`, no-op) → `os.queryPit(indexName, query, ...)` (`:91-92`). `queryPit` mutates the passed `query` JSONObject in place (adds `from`/`size`/`sort`/`pit`) and POSTs it.
+- `Encounter.opensearchAccess` (`Encounter.java:4753-4765`) grants on: `publiclyReadable` OR `submitterUserId==user.getId()` OR `user.isAdmin()` OR `viewUsers[]` contains `user.getId()`. `editUsers` is NOT consulted; orgAdmin access is carried through `viewUsers`. → the 3-term pre-filter (+ admin bypass) is complete.
+- `JwtService.verify(token)` returns `Jws<Claims>`, enforces iss/aud/exp + pins RS256, throws `JwtException` on bad token and `IllegalStateException` if no public key. It does **not** check the `context` claim — D's filter does. Read claims via `jws.getPayload()` → `c.getSubject()`, `c.get("context", String.class)`.
+- Shiro is configured via embedded `IniShiroFilter` in `web.xml`; existing filter `authcBasicWildbook = org.ecocean.security.WildbookBasicHttpAuthenticationFilter` is declared in `[main]`. `/api/v3/search/*` currently has **no** `[urls]` rule.
+
+---
+
+### Task 1: ACL-filter query builder (`OpenSearch.applyEncounterAclFilter`)
+
+A pure function that wraps a search query's top-level `query` clause in a `bool` whose `filter` is the encounter ACL predicate, so OpenSearch scopes totals + pagination + hits. No I/O — fully unit-testable.
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/OpenSearch.java`
+- Test: `src/test/java/org/ecocean/OpenSearchAclFilterTest.java` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/java/org/ecocean/OpenSearchAclFilterTest.java`:
+
+```java
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchAclFilterTest {
+
+    @Test void wrapsInnerQueryWithAclFilter() throws Exception {
+        JSONObject original = new JSONObject("{\"query\":{\"match\":{\"name\":\"x\"}}}");
+        JSONObject out = OpenSearch.applyEncounterAclFilter(original, "user-uuid-1");
+
+        JSONObject bool = out.getJSONObject("query").getJSONObject("bool");
+        // original inner query preserved as a must clause
+        JSONArray must = bool.getJSONArray("must");
+        assertEquals(1, must.length(), "one must clause (the original query)");
+        assertTrue(must.getJSONObject(0).has("match"), "original match preserved");
+
+        // ACL is a filter clause: should[publiclyReadable, submitterUserId, viewUsers], msm=1
+        JSONArray filter = bool.getJSONArray("filter");
+        JSONObject aclBool = filter.getJSONObject(0).getJSONObject("bool");
+        assertEquals(1, aclBool.getInt("minimum_should_match"), "minimum_should_match=1");
+        JSONArray should = aclBool.getJSONArray("should");
+        assertEquals(3, should.length(), "three should clauses");
+        assertTrue(should.getJSONObject(0).getJSONObject("term").getBoolean("publiclyReadable"),
+            "publiclyReadable term");
+        assertEquals("user-uuid-1",
+            should.getJSONObject(1).getJSONObject("term").getString("submitterUserId"),
+            "submitterUserId term = uuid");
+        assertEquals("user-uuid-1",
+            should.getJSONObject(2).getJSONObject("term").getString("viewUsers"),
+            "viewUsers term = uuid");
+    }
+
+    @Test void filterOnlyWhenNoInnerQuery() throws Exception {
+        JSONObject original = new JSONObject("{}"); // no "query" field
+        JSONObject out = OpenSearch.applyEncounterAclFilter(original, "user-uuid-1");
+        JSONObject bool = out.getJSONObject("query").getJSONObject("bool");
+        assertFalse(bool.has("must"), "no must clause when there was no inner query");
+        assertTrue(bool.has("filter"), "ACL filter still applied (fail-closed scope)");
+    }
+
+    @Test void rejectsNullUser() {
+        JSONObject original = new JSONObject("{\"query\":{\"match_all\":{}}}");
+        assertThrows(java.io.IOException.class,
+            () -> OpenSearch.applyEncounterAclFilter(original, null),
+            "null/empty userId must throw (fail closed)");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -Dtest=OpenSearchAclFilterTest`
+Expected: FAIL — `applyEncounterAclFilter` does not exist (compile error / method not found).
+
+- [ ] **Step 3: Add the implementation to `OpenSearch.java`**
+
+Insert this method immediately after `querySanitize` (after `OpenSearch.java:923`). Use the existing `org.json` imports already in the file:
+
+```java
+    /**
+     * Wrap a search query's top-level "query" clause in a bool whose filter enforces the
+     * encounter ACL (mirrors Encounter.opensearchAccess for a non-admin user). Applied on the
+     * token-authenticated path BEFORE execution so totals, pagination, and hits are all scoped.
+     * Admins are not passed through here (caller skips the call for admins).
+     */
+    public static JSONObject applyEncounterAclFilter(JSONObject query, String userId)
+    throws IOException {
+        if ((query == null) || !Util.stringExists(userId))
+            throw new IOException("applyEncounterAclFilter: null query or userId");
+        JSONArray should = new JSONArray();
+        should.put(new JSONObject().put("term", new JSONObject().put("publiclyReadable", true)));
+        should.put(new JSONObject().put("term", new JSONObject().put("submitterUserId", userId)));
+        should.put(new JSONObject().put("term", new JSONObject().put("viewUsers", userId)));
+        JSONObject aclBool = new JSONObject();
+        aclBool.put("should", should);
+        aclBool.put("minimum_should_match", 1);
+        JSONObject acl = new JSONObject().put("bool", aclBool);
+
+        JSONObject wrapBool = new JSONObject();
+        JSONObject inner = query.optJSONObject("query");
+        if (inner != null) {
+            JSONArray must = new JSONArray();
+            must.put(inner);
+            wrapBool.put("must", must);
+        }
+        wrapBool.put("filter", new JSONArray().put(acl));
+
+        JSONObject out = new JSONObject(query.toString()); // shallow copy via re-parse
+        out.put("query", new JSONObject().put("bool", wrapBool));
+        return out;
+    }
+```
+
+Confirm `org.json.JSONArray` is imported at the top of `OpenSearch.java` (it is used elsewhere in the file). `Util.stringExists` is already used throughout `OpenSearch.java`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn test -Dtest=OpenSearchAclFilterTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Normalize line endings and commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/java/org/ecocean/OpenSearch.java src/test/java/org/ecocean/OpenSearchAclFilterTest.java | xargs -r sed -i 's/\r$//'
+git add src/main/java/org/ecocean/OpenSearch.java src/test/java/org/ecocean/OpenSearchAclFilterTest.java
+git commit -m "feat(search): add encounter ACL pre-filter builder for token-scoped search"
+```
+
+---
+
+### Task 2: `JwtService.canVerify()` accessor
+
+The filter must distinguish "bad token → 401" from "token auth not configured on this server → 503". `verify()` throws `IllegalStateException` when there's no public key; expose a clean predicate instead of catching that.
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/api/auth/JwtService.java`
+- Test: `src/test/java/org/ecocean/api/auth/JwtServiceTest.java` (existing)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/test/java/org/ecocean/api/auth/JwtServiceTest.java` (mirror the existing key-setup helper `serviceWithFreshKeys()` already in that file):
+
+```java
+    @Test void canVerify_trueWhenPublicKeyPresent() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        assertTrue(svc.canVerify(), "service built with a keypair can verify");
+    }
+
+    @Test void canVerify_falseWhenNoKeys() {
+        JwtService svc = JwtService.fromBase64Keys(null, null, "wildbook", "wildbook-scoped-api");
+        assertFalse(svc.canVerify(), "service with no public key cannot verify");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -Dtest=JwtServiceTest#canVerify_trueWhenPublicKeyPresent+canVerify_falseWhenNoKeys`
+Expected: FAIL — `canVerify` not defined.
+
+- [ ] **Step 3: Add the accessor**
+
+In `src/main/java/org/ecocean/api/auth/JwtService.java`, immediately after `isEnabled()` (after line 92):
+
+```java
+    public boolean canVerify() {
+        return publicKey != null;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn test -Dtest=JwtServiceTest`
+Expected: PASS (all existing JwtService tests + the 2 new ones).
+
+- [ ] **Step 5: Normalize and commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/java/org/ecocean/api/auth/JwtService.java src/test/java/org/ecocean/api/auth/JwtServiceTest.java | xargs -r sed -i 's/\r$//'
+git add src/main/java/org/ecocean/api/auth/JwtService.java src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+git commit -m "feat(auth): add JwtService.canVerify() (public-key presence)"
+```
+
+---
+
+### Task 3: `WildbookTokenAuthenticationFilter`
+
+A Shiro `OncePerRequestFilter` that, on a Bearer-bearing request: verifies the JWT, enforces the context claim and rejects request-context drift, resolves the user by UUID, wraps the request so `getUserPrincipal().toString()` returns the **username**, marks the request token-authenticated, and forwards. No Bearer → pass through unchanged (session/anon path intact). Bad token → 401. Not configured → 503. The filter exposes protected seams (`expectedContext`, `requestContext`, `jwtService`, `lookupUsername`) so unit tests inject fakes without static mocking.
+
+**Files:**
+- Create: `src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java`
+- Test: `src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java` (create)
+
+- [ ] **Step 1: Write the filter (no test-first here — the test in Step 2 needs the protected seams to exist; write the class, then the test drives behavior)**
+
+Create `src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java`:
+
+```java
+package org.ecocean.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jws;
+import java.io.IOException;
+import java.security.Principal;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.shiro.web.servlet.OncePerRequestFilter;
+import org.ecocean.CommonConfiguration;
+import org.ecocean.User;
+import org.ecocean.Util;
+import org.ecocean.api.auth.JwtService;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+
+/**
+ * Token-authenticated read path for /api/v3/search/* (encounter index only; gated in SearchApi).
+ *
+ * Verifies a B-issued RS256 JWT, enforces the context claim + rejects request-context drift,
+ * resolves the user by UUID, and WRAPS the request so Shepherd.getUser(request) returns the
+ * token user. It deliberately does NOT call subject.login: Wildbook is session-based, and a
+ * login on a bearer request could mint a session reusable on write endpoints. No Bearer => the
+ * chain proceeds unchanged (browser/session path intact).
+ */
+public class WildbookTokenAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String TOKEN_AUTH_ATTR = "org.ecocean.tokenAuth";
+
+    @Override
+    protected void doFilterInternal(ServletRequest req, ServletResponse resp, FilterChain chain)
+    throws ServletException, IOException {
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) resp;
+
+        String authz = request.getHeader("Authorization");
+        if ((authz == null) || !authz.startsWith("Bearer ")) {
+            chain.doFilter(request, response); // no token: leave session/anon path intact
+            return;
+        }
+        // method allowlist (defence in depth): only safe read methods reach search
+        String method = request.getMethod();
+        if (!"GET".equals(method) && !"POST".equals(method)) {
+            deny(response, 405, "method not allowed");
+            return;
+        }
+        String token = authz.substring("Bearer ".length()).trim();
+        String expected = expectedContext();
+
+        JwtService jwt = jwtService(expected);
+        if (!jwt.canVerify()) {
+            deny(response, 503, "token auth not configured");
+            return;
+        }
+        Claims claims;
+        try {
+            Jws<Claims> jws = jwt.verify(token);
+            claims = jws.getPayload();
+        } catch (JwtException | IllegalStateException ex) {
+            deny(response, 401, "invalid token");
+            return;
+        }
+        // context claim must equal server context, AND request-resolved context must not drift
+        String tokenContext = claims.get("context", String.class);
+        String reqContext = requestContext(request);
+        if (!expected.equals(tokenContext) || !expected.equals(reqContext)) {
+            deny(response, 401, "context mismatch");
+            return;
+        }
+        String uuid = claims.getSubject();
+        if (!Util.stringExists(uuid)) {
+            deny(response, 401, "invalid token subject");
+            return;
+        }
+        final String username = lookupUsername(expected, uuid);
+        if (username == null) {
+            deny(response, 401, "unknown user");
+            return;
+        }
+        // wrap so getUser(request) -> getUsername(request) -> getUserPrincipal().toString() == username
+        final Principal principal = new Principal() {
+            public String getName() {
+                return username;
+            }
+
+            public String toString() {
+                return username;
+            }
+        };
+        HttpServletRequestWrapper wrapped = new HttpServletRequestWrapper(request) {
+            @Override public Principal getUserPrincipal() {
+                return principal;
+            }
+
+            @Override public String getRemoteUser() {
+                return username;
+            }
+        };
+        wrapped.setAttribute(TOKEN_AUTH_ATTR, Boolean.TRUE);
+        chain.doFilter(wrapped, response);
+    }
+
+    // ----- protected seams (overridden in unit tests) -----
+
+    protected String expectedContext() {
+        String c = CommonConfiguration.getProperty("jwtContext", "context0");
+        return Util.stringExists(c) ? c : "context0";
+    }
+
+    protected String requestContext(HttpServletRequest request) {
+        return ServletUtilities.getContext(request);
+    }
+
+    protected JwtService jwtService(String context) {
+        return JwtService.fromConfig(context);
+    }
+
+    protected String lookupUsername(String context, String uuid) {
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("WildbookTokenAuthenticationFilter");
+        myShepherd.beginDBTransaction();
+        try {
+            User user = myShepherd.getUserByUUID(uuid);
+            return (user != null) ? user.getUsername() : null;
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private void deny(HttpServletResponse response, int status, String message)
+    throws IOException {
+        response.setStatus(status);
+        response.setHeader("Content-Type", "application/json");
+        response.setCharacterEncoding("UTF-8");
+        JSONObject err = new JSONObject();
+        err.put("success", false);
+        err.put("error", message);
+        response.getWriter().write(err.toString());
+        response.getWriter().close();
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing unit test**
+
+Create `src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java`. It subclasses the filter to inject a real `JwtService` built from fresh test keys (so verification is genuine) and a canned username, and uses Mockito mocks for request/response/chain:
+
+```java
+package org.ecocean.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Principal;
+import java.util.Base64;
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.ecocean.api.auth.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class WildbookTokenAuthenticationFilterTest {
+
+    private JwtService realService; // genuine RS256 keypair; sign + verify both work
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain chain;
+    private StringWriter out;
+
+    /** Filter with seams overridden: fixed context, real JwtService, canned username. */
+    private WildbookTokenAuthenticationFilter filterFor(String requestContext,
+        String resolvedUsername) {
+        return new WildbookTokenAuthenticationFilter() {
+            @Override protected String expectedContext() {
+                return "context0";
+            }
+            @Override protected String requestContext(HttpServletRequest r) {
+                return requestContext;
+            }
+            @Override protected JwtService jwtService(String context) {
+                return realService;
+            }
+            @Override protected String lookupUsername(String context, String uuid) {
+                return resolvedUsername;
+            }
+        };
+    }
+
+    @BeforeEach void setUp() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String priv = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pub = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+        realService = JwtService.fromBase64Keys(priv, pub, "wildbook", "wildbook-scoped-api");
+
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        chain = mock(FilterChain.class);
+        out = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(out));
+    }
+
+    @Test void noBearer_passesThroughUnchanged() throws Exception {
+        when(request.getHeader("Authorization")).thenReturn(null);
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(chain).doFilter(request, response); // original request, untouched
+        verify(response, never()).setStatus(anyInt());
+    }
+
+    @Test void validBearer_wrapsRequestWithUsernamePrincipal() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+
+        ArgumentCaptor<javax.servlet.ServletRequest> cap =
+            ArgumentCaptor.forClass(javax.servlet.ServletRequest.class);
+        verify(chain).doFilter(cap.capture(), eq(response));
+        HttpServletRequest wrapped = (HttpServletRequest) cap.getValue();
+        Principal p = wrapped.getUserPrincipal();
+        assertEquals("alice", p.toString(), "principal.toString() must yield the username");
+        assertEquals(Boolean.TRUE, wrapped.getAttribute(
+            WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR), "token-auth marker set");
+    }
+
+    @Test void expiredToken_returns401() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", -1_000L); // already expired
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(response).setStatus(401);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void wrongContextClaim_returns401() throws Exception {
+        String token = realService.sign("user-uuid-1", "contextX", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(response).setStatus(401);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void requestContextDrift_returns401() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        // token says context0, but the resolved request context is context1 (e.g. ?context=, cookie, host)
+        filterFor("context1", "alice").doFilterInternal(request, response, chain);
+        verify(response).setStatus(401);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void unknownUser_returns401() throws Exception {
+        String token = realService.sign("ghost-uuid", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        filterFor("context0", null).doFilterInternal(request, response, chain); // lookup -> null
+        verify(response).setStatus(401);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void disallowedMethod_returns405() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("DELETE");
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(response).setStatus(405);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void tamperedToken_returns401() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L) + "tamper";
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(response).setStatus(401);
+        verify(chain, never()).doFilter(any(), any());
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails (then passes)**
+
+Run: `mvn test -Dtest=WildbookTokenAuthenticationFilterTest`
+Expected first run: the test compiles against the Step-1 class. If Step 1 was committed, this should PASS directly. If any assertion fails, fix the filter (not the test) until all 8 tests pass.
+Expected: PASS (8 tests).
+
+> Note: `doFilterInternal` is `protected`; the test is in the same package (`org.ecocean.security`), so it can call it directly.
+
+- [ ] **Step 4: Normalize and commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java | xargs -r sed -i 's/\r$//'
+git add src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java
+git commit -m "feat(auth): add WildbookTokenAuthenticationFilter (verify JWT, wrap request, no session)"
+```
+
+---
+
+### Task 4: `SearchApi` token-path enforcement
+
+On the token path (request marked by the filter), `SearchApi` must: (a) fail closed if a Bearer header arrived without the marker (filter misconfig); (b) gate to the `encounter` index only — for both direct and stored-query paths; (c) require stored-query ownership (admin bypasses); (d) inject the ACL pre-filter after sanitize for non-admins. The session path is untouched.
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/api/SearchApi.java`
+- Test: `src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java` (create)
+
+- [ ] **Step 1: Read the current `doPost` ladder**
+
+Open `src/main/java/org/ecocean/api/SearchApi.java` and confirm the structure around lines 31–92 matches the facts in the File Structure section (user resolution at :31, 401 at :34, index parse at :43, `queryLoad` at :48, the guard ladder at :49–59, the execute block from :60, `querySanitize` at :84, `queryPit` at :91). The edits below target those exact points.
+
+- [ ] **Step 2: Add the token marker + fail-closed-unmarked guard + index/owner guards**
+
+Edit `SearchApi.java`. First, just after the user is resolved and the `JSONObject res = new JSONObject();` line (around `:32`), add the marker read:
+
+```java
+        User currentUser = myShepherd.getUser(request);
+        JSONObject res = new JSONObject();
+        boolean tokenAuth = Boolean.TRUE.equals(
+            request.getAttribute(org.ecocean.security.WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR));
+        String authzHeader = request.getHeader("Authorization");
+        boolean bearerPresent = (authzHeader != null) && authzHeader.startsWith("Bearer ");
+```
+
+Then change the top-level auth branch (currently `if ((currentUser == null) || (currentUser.getId() == null)) { 401 } else { ... }` at `:33`) to fail closed when a Bearer arrived unmarked:
+
+```java
+        if ((currentUser == null) || (currentUser.getId() == null)) {
+            response.setStatus(401);
+            res.put("error", 401);
+        } else if (bearerPresent && !tokenAuth) {
+            // a Bearer reached SearchApi without the token filter marking it -> filter misconfig
+            response.setStatus(401);
+            res.put("error", "token auth misconfiguration");
+        } else {
+```
+
+Next, inside the `else` block, add the encounter-only index gate and stored-query owner check as two new `else if` branches in the existing guard ladder — insert them **immediately after** the existing `"annotation".equals(indexName) && !currentUser.isAdmin(...)` branch (after `SearchApi:56`) and **before** the `((query == null) && !"POST".equals(...))` 405 branch (`:59`). At this point in the ladder, for a stored query `query` is the loaded full object (it still has `indexName`/`creator`; scrubbing happens later in the execute block), and for a direct query `query` is null:
+
+```java
+            } else if (tokenAuth && !"encounter".equals(
+                (searchQueryId != null) ? (query != null ? query.optString("indexName", null) : null)
+                                        : indexName)) {
+                // token search is encounter-index only (covers stored queries whose real index
+                // is read from the stored doc, not from the {uuid} URL)
+                response.setStatus(403);
+                res.put("error", "token search is limited to the encounter index");
+            } else if (tokenAuth && (searchQueryId != null) && (query != null)
+                && !currentUser.isAdmin(myShepherd)
+                && !currentUser.getId().equals(query.optString("creator", null))) {
+                // replaying someone else's stored query is not allowed (admin bypasses)
+                response.setStatus(403);
+                res.put("error", "not the owner of this stored query");
+            } else if ((query == null) && !"POST".equals(request.getMethod())) {
+```
+
+(The last line is the existing 405 branch — shown for placement; do not duplicate it.)
+
+- [ ] **Step 3: Inject the ACL pre-filter after sanitize**
+
+Still in `SearchApi.java`, find the `querySanitize` call (`:84`):
+
+```java
+                query = OpenSearch.querySanitize(query, currentUser, myShepherd);
+```
+
+Immediately after it, add:
+
+```java
+                if (tokenAuth && !currentUser.isAdmin(myShepherd)) {
+                    // Java is the hard boundary: scope totals + pagination + hits before execution
+                    query = OpenSearch.applyEncounterAclFilter(query, currentUser.getId());
+                }
+```
+
+This runs after `queryScrubStored` (so stored queries are scoped too) and before `os.queryPit(...)` — the only place that scopes totals.
+
+- [ ] **Step 4: Write the failing unit test**
+
+Create `src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java`. It uses the repo's dominant pattern (Mockito mocks + `mockConstruction<Shepherd>`), and `mockConstruction<OpenSearch>` to capture the query handed to `queryPit` so the ACL injection is asserted without a live cluster:
+
+```java
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.ecocean.OpenSearch;
+import org.ecocean.User;
+import org.ecocean.security.WildbookTokenAuthenticationFilter;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+class SearchApiTokenAuthTest {
+
+    HttpServletRequest request;
+    HttpServletResponse response;
+    StringWriter out;
+
+    @BeforeEach void setUp() throws Exception {
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        out = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(out));
+        when(request.getServletContext()).thenReturn(null);
+        when(request.getContextPath()).thenReturn("");
+    }
+
+    private User mockUser(String id, boolean admin) {
+        User u = mock(User.class);
+        when(u.getId()).thenReturn(id);
+        return u;
+    }
+
+    @Test void tokenRequest_nonEncounterIndex_returns403() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/individual");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(Boolean.TRUE);
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+            doNothing().when(m).beginDBTransaction();
+            doNothing().when(m).setAction(anyString());
+            doNothing().when(m).rollbackAndClose();
+            when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
+            when(user.isAdmin(m)).thenReturn(false);
+        })) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(403);
+    }
+
+    @Test void bearerWithoutMarker_returns401() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null); // filter did NOT mark it
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+            doNothing().when(m).beginDBTransaction();
+            doNothing().when(m).setAction(anyString());
+            doNothing().when(m).rollbackAndClose();
+            when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
+        })) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(401);
+    }
+
+    @Test void tokenEncounterSearch_injectsAclFilterBeforeExecution() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(Boolean.TRUE);
+        when(request.getParameter(anyString())).thenReturn(null);
+        User user = mockUser("u1", false);
+
+        // capture the query passed to queryPit
+        JSONObject queryResponse = new JSONObject(
+            "{\"hits\":{\"total\":{\"value\":0},\"hits\":[]}}");
+        try (MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                doNothing().when(m).beginDBTransaction();
+                doNothing().when(m).setAction(anyString());
+                doNothing().when(m).rollbackAndClose();
+                when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
+                when(user.isAdmin(m)).thenReturn(false);
+            });
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenAnswer(inv -> {
+                        JSONObject q = inv.getArgument(1);
+                        // ACL filter must be present BEFORE execution
+                        JSONObject bool = q.getJSONObject("query").getJSONObject("bool");
+                        assertTrue(bool.has("filter"), "ACL filter injected before queryPit");
+                        return queryResponse;
+                    });
+            })) {
+            // request body provides the inner query
+            org.mockito.MockedStatic<org.ecocean.servlet.ServletUtilities> su =
+                mockStatic(org.ecocean.servlet.ServletUtilities.class);
+            su.when(() -> org.ecocean.servlet.ServletUtilities.getContext(any()))
+                .thenReturn("context0");
+            su.when(() -> org.ecocean.servlet.ServletUtilities.jsonFromHttpServletRequest(any()))
+                .thenReturn(new JSONObject("{\"query\":{\"match_all\":{}}}"));
+            try {
+                new SearchApi().doPost(request, response);
+            } finally {
+                su.close();
+            }
+        }
+        verify(response).setStatus(200);
+    }
+
+    @Test void adminTokenEncounterSearch_doesNotInjectAclFilter() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(Boolean.TRUE);
+        when(request.getParameter(anyString())).thenReturn(null);
+        User user = mockUser("admin1", true);
+        JSONObject queryResponse = new JSONObject(
+            "{\"hits\":{\"total\":{\"value\":0},\"hits\":[]}}");
+        try (MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                doNothing().when(m).beginDBTransaction();
+                doNothing().when(m).setAction(anyString());
+                doNothing().when(m).rollbackAndClose();
+                when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
+                when(user.isAdmin(m)).thenReturn(true);
+            });
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenAnswer(inv -> {
+                        JSONObject q = inv.getArgument(1);
+                        JSONObject inner = q.getJSONObject("query");
+                        assertFalse(inner.has("bool") && inner.getJSONObject("bool").has("filter"),
+                            "admin token must NOT have an injected ACL filter");
+                        return queryResponse;
+                    });
+            })) {
+            org.mockito.MockedStatic<org.ecocean.servlet.ServletUtilities> su =
+                mockStatic(org.ecocean.servlet.ServletUtilities.class);
+            su.when(() -> org.ecocean.servlet.ServletUtilities.getContext(any()))
+                .thenReturn("context0");
+            su.when(() -> org.ecocean.servlet.ServletUtilities.jsonFromHttpServletRequest(any()))
+                .thenReturn(new JSONObject("{\"query\":{\"match_all\":{}}}"));
+            try {
+                new SearchApi().doPost(request, response);
+            } finally {
+                su.close();
+            }
+        }
+        verify(response).setStatus(200);
+    }
+}
+```
+
+> Note on `queryStore`: the ACL-injection test relies on `OpenSearch.queryStore` writing to `/tmp` (its default `QUERY_STORAGE_DIR`). If `queryStore` (a static, not on the mocked instance) interferes in CI, additionally `mockStatic(OpenSearch.class, CALLS_REAL_METHODS)` and stub `queryStore`/`querySanitize` to pass-through, or assert via the `applyEncounterAclFilter` unit test (Task 1) plus a lighter SearchApi test that stops at the 403/401 branches. Keep the instance-method capture as the primary assertion.
+
+- [ ] **Step 5: Run the test**
+
+Run: `mvn test -Dtest=SearchApiTokenAuthTest`
+Expected: PASS (4 tests). Iterate on the SearchApi edits (not the tests) until green. Also re-run any existing SearchApi test to confirm no regression: `mvn test -Dtest=SearchApi*`.
+
+- [ ] **Step 6: Normalize and commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/java/org/ecocean/api/SearchApi.java src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java | xargs -r sed -i 's/\r$//'
+git add src/main/java/org/ecocean/api/SearchApi.java src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java
+git commit -m "feat(search): enforce encounter-only token scope + ACL pre-filter in SearchApi"
+```
+
+---
+
+### Task 5: Shiro `web.xml` wiring
+
+Register the filter in Shiro `[main]` and map `/api/v3/search/**` to it — token filter only, no `authc`/`roles` chained.
+
+**Files:**
+- Modify: `src/main/webapp/WEB-INF/web.xml`
+- Test: `src/test/java/org/ecocean/api/EndpointAuthWiringTest.java` (B's wiring-guard test, if present)
+
+- [ ] **Step 1: Add the filter to `[main]`**
+
+In `web.xml`, in the Shiro `config` `[main]` block, after the existing line `authcBasicWildbook = org.ecocean.security.WildbookBasicHttpAuthenticationFilter`, add:
+
+```
+            tokenAuthSearch = org.ecocean.security.WildbookTokenAuthenticationFilter
+```
+
+- [ ] **Step 2: Add the `[urls]` rule**
+
+In the `[urls]` section, in the `# ===== v3 API Security =====` group (after `/api/v3/match-inspection/** = authc`, around line 109), add:
+
+```
+            /api/v3/search/** = tokenAuthSearch
+```
+
+This is the only rule for the search path; no `authc`/`roles` is chained (the filter itself handles auth, and a no-Bearer request passes through to `SearchApi`, which self-401s if there is no session principal). Rules are first-match-wins and processed in order — confirm no earlier rule already matches `/api/v3/search/**`.
+
+- [ ] **Step 3: Update / add the wiring-guard test**
+
+If `src/test/java/org/ecocean/api/EndpointAuthWiringTest.java` exists (added by Artifact B to assert `web.xml` Shiro rules), add an assertion that the search rule is present and maps only to `tokenAuthSearch`. Mirror the existing assertion style in that file. Representative addition:
+
+```java
+    @Test void searchPath_wiredToTokenFilterOnly() throws Exception {
+        String webXml = readWebXml(); // existing helper in this test
+        assertTrue(webXml.contains("tokenAuthSearch = org.ecocean.security.WildbookTokenAuthenticationFilter"),
+            "token filter declared in [main]");
+        assertTrue(webXml.contains("/api/v3/search/** = tokenAuthSearch"),
+            "search path mapped to token filter only");
+        assertFalse(webXml.replaceAll("\\s+", " ")
+            .contains("/api/v3/search/** = tokenAuthSearch, "),
+            "search path must NOT chain authc/roles after the token filter");
+    }
+```
+
+If `EndpointAuthWiringTest` does not exist, create `src/test/java/org/ecocean/api/SearchWiringTest.java` with the same assertions and a `readWebXml()` helper that reads `src/main/webapp/WEB-INF/web.xml` from the project basedir:
+
+```java
+    private String readWebXml() throws Exception {
+        return new String(java.nio.file.Files.readAllBytes(
+            java.nio.file.Paths.get("src/main/webapp/WEB-INF/web.xml")),
+            java.nio.charset.StandardCharsets.UTF_8);
+    }
+```
+
+- [ ] **Step 4: Run the wiring test**
+
+Run: `mvn test -Dtest=EndpointAuthWiringTest` (or `SearchWiringTest`)
+Expected: PASS.
+
+- [ ] **Step 5: Normalize and commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/webapp/WEB-INF/web.xml | xargs -r sed -i 's/\r$//'
+git add src/main/webapp/WEB-INF/web.xml src/test/java/org/ecocean/api/
+git commit -m "feat(search): wire WildbookTokenAuthenticationFilter onto /api/v3/search/**"
+```
+
+---
+
+### Task 6: End-to-end enforcement integration test (real OpenSearch)
+
+Prove the scoping for real: a token-authenticated `/api/v3/search/encounter` returns only the token user's permitted encounters AND the reported `total` reflects the scoped set (guards against the post-sanitize leak). Reuse the embedded-Jetty + Testcontainers harness in `EncounterExportImagesTest`, which already registers `SearchApi` at `/api/v3/search/*` and `IniShiroFilter` from `classpath:shiro.ini`.
+
+**Files:**
+- Modify: `src/test/resources/shiro.ini` — add the same `[main]`/`[urls]` token-filter wiring as `web.xml`.
+- Modify/Create: `src/test/java/org/ecocean/api/SearchTokenScopeIT.java` (new, or a method group in `EncounterExportImagesTest`).
+
+- [ ] **Step 1: Mirror the Shiro wiring into the test `shiro.ini`**
+
+In `src/test/resources/shiro.ini`, add to `[main]`:
+
+```
+tokenAuthSearch = org.ecocean.security.WildbookTokenAuthenticationFilter
+```
+
+and to `[urls]` (before any catch-all):
+
+```
+/api/v3/search/** = tokenAuthSearch
+```
+
+- [ ] **Step 2: Write the integration test**
+
+Create `src/test/java/org/ecocean/api/SearchTokenScopeIT.java` modeled on `EncounterExportImagesTest`'s `@BeforeAll` server/Testcontainers setup (copy its server bring-up: `Server`, `ServletContextHandler`, `IniShiroFilter` from `classpath:shiro.ini`, register `new SearchApi()` at `/api/v3/search/*`, REST Assured base URI/port). Seed data + token, then assert scoping:
+
+```java
+    @Test void tokenSearch_scopesToPermittedEncountersAndTotals() throws Exception {
+        // Arrange (in setUp/seed): index three encounters in the test OpenSearch:
+        //   encA: submitterUserId = aliceUuid                  (alice can see)
+        //   encB: viewUsers = [aliceUuid]                      (alice can see via collaboration)
+        //   encC: submitterUserId = bobUuid, no viewUsers      (alice must NOT see)
+        // Mint a real token for alice via the test JwtService (same keypair the filter loads).
+        String token = testJwtService.sign(aliceUuid, "context0", 60_000L);
+
+        io.restassured.response.Response r = given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when()
+            .post("/api/v3/search/encounter")
+            .then()
+            .statusCode(200)
+            .extract().response();
+
+        // hits contain only encA + encB; encC absent
+        org.json.JSONObject body = new org.json.JSONObject(r.asString());
+        org.json.JSONArray hits = body.getJSONArray("hits");
+        java.util.Set<String> ids = new java.util.HashSet<>();
+        for (int i = 0; i < hits.length(); i++) ids.add(hits.getJSONObject(i).optString("id"));
+        assertTrue(ids.contains(encAId), "alice sees her own encounter");
+        assertTrue(ids.contains(encBId), "alice sees the collaboration encounter");
+        assertFalse(ids.contains(encCId), "alice must NOT see bob's private encounter");
+
+        // total is scoped (not the raw 3) — guards against the post-sanitize leak
+        assertEquals("2", r.header("X-Wildbook-Total-Hits"), "total reflects scoped set");
+    }
+
+    @Test void adminTokenSearch_seesAll() throws Exception {
+        String token = testJwtService.sign(adminUuid, "context0", 60_000L);
+        io.restassured.response.Response r = given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/encounter")
+            .then().statusCode(200).extract().response();
+        assertEquals("3", r.header("X-Wildbook-Total-Hits"), "admin token is unscoped");
+    }
+
+    @Test void tokenSearch_nonEncounterIndex_403() throws Exception {
+        String token = testJwtService.sign(aliceUuid, "context0", 60_000L);
+        given().header("Authorization", "Bearer " + token)
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/individual")
+            .then().statusCode(403);
+    }
+```
+
+The JwtService keypair must match between the filter (loads from `CommonConfiguration` `jwtPublicKeyBase64`) and the test signer. Set the test config keys (`jwtPrivateKeyBase64`/`jwtPublicKeyBase64`/`jwtIssuer`/`jwtAudience`) to a generated test keypair in `@BeforeAll` (the harness already loads a test `commonConfiguration.properties`; write the test keys there or via the same mechanism `AuthTokenTest`/the B integration tests use). Reuse the keypair-generation snippet from `JwtServiceTest`/Task 3.
+
+- [ ] **Step 3: Run the integration test**
+
+Run: `mvn test -Dtest=SearchTokenScopeIT`
+Expected: PASS (3 tests). This pulls the Testcontainers OpenSearch image; allow time on first run. If the environment cannot run Testcontainers, mark this class `@org.junit.jupiter.api.Disabled("requires Docker/Testcontainers")` with a comment and rely on Tasks 1/3/4 unit tests + a manual run note — but do not delete it.
+
+- [ ] **Step 4: Normalize and commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/test/resources/shiro.ini src/test/java/org/ecocean/api/SearchTokenScopeIT.java | xargs -r sed -i 's/\r$//'
+git add src/test/resources/shiro.ini src/test/java/org/ecocean/api/SearchTokenScopeIT.java
+git commit -m "test(search): end-to-end token-scoped encounter search enforcement"
+```
+
+---
+
+### Task 7: Full build, self-review, and Codex code review
+
+- [ ] **Step 1: Compile and run the full affected test set**
+
+Run:
+```bash
+cd /mnt/c/Wildbook-token-auth
+mvn -q -DskipTests compile
+mvn test -Dtest=OpenSearchAclFilterTest,JwtServiceTest,WildbookTokenAuthenticationFilterTest,SearchApiTokenAuthTest,EndpointAuthWiringTest
+```
+Expected: BUILD SUCCESS; all tests green. (Run `SearchTokenScopeIT` separately if Docker is available.)
+
+- [ ] **Step 2: Verify no CRLF crept in across all touched files**
+
+Run:
+```bash
+cd /mnt/c/Wildbook-token-auth
+git diff --name-only origin/main | xargs -r grep -lU $'\r' || echo "LF-clean"
+```
+Expected: `LF-clean`.
+
+- [ ] **Step 3: Self-review against the spec**
+
+Re-read `docs/superpowers/specs/2026-06-06-token-auth-scoped-search-design.md` components 1–8 and confirm each maps to a task: token verify + context check (Task 3), request wrapper not subject.login (Task 3), web.xml scope (Task 5), context-drift (Task 3), ACL pre-filter + exact injection point (Tasks 1+4), stored-query + index gating (Task 4), fail-closed-unmarked (Task 4), method allowlist (Task 3). Confirm the two flagged follow-ups (global SearchApi metadata leak; orgAdmin `viewUsers` coverage) are NOT implemented here (out of scope) and are noted in the PR description.
+
+- [ ] **Step 4: Codex code review (per project convention — see memory `feedback-codex-review`, `feedback-codex-takeseriously`)**
+
+Produce the full diff and run a read-only Codex review:
+```bash
+cd /mnt/c/Wildbook-token-auth
+git diff origin/main > /tmp/artifact-d-diff.patch
+cat > /tmp/codex-d-code-review.txt <<'PROMPT'
+Adversarial code review of Artifact D (token-authenticated scoped encounter search) for Wildbook.
+Read /tmp/artifact-d-diff.patch and verify against real source in /mnt/c/Wildbook-token-auth.
+Focus: (1) can a token request reach queryPit unscoped (fail-open) for a non-admin? (2) is the
+ACL predicate complete vs Encounter.opensearchAccess (publiclyReadable/submitterUserId/viewUsers,
+admin bypass; editUsers correctly omitted)? (3) does the wrapper truly make getUser(request)
+resolve the token user, and is there any SecurityUtils.getSubject() path it misses? (4) does the
+filter avoid minting a session (no subject.login, no Set-Cookie)? (5) stored-query index+owner
+gating for both direct and {uuid} paths; (6) context-drift coverage; (7) any Shiro [urls]
+ordering issue. Take Low/Medium findings seriously. Write findings to /tmp/codex-d-code-review-out.md
+with Severity | Finding | Evidence (file:line) | Fix, then a verdict: SAFE TO MERGE or FIX-FIRST.
+PROMPT
+codex exec --sandbox read-only -c approval_policy="never" - < /tmp/codex-d-code-review.txt > /tmp/codex-d-code-review-console.log 2>&1; echo "EXIT=$?"
+```
+Read the findings, fold in any High/Medium (and seriously weigh Low), commit fixes, and re-review until the verdict is SAFE TO MERGE.
+
+- [ ] **Step 5: Final commit + push decision**
+
+Once Codex is SAFE TO MERGE, stop and report to the user: summarize the diff, test counts, the Codex verdict, and the two flagged follow-ups. Do NOT push or open a PR without explicit user go-ahead (project convention). The PR depends on Artifact B (#1594) — note the stack/branch decision (open question 4 in the spec) for the user.
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:** Components 1–8 each map to a task (see Task 7 Step 3). Scope (encounter-only) → Tasks 4+5. Security section (read-only, stateless, Java-enforces, context isolation) → Tasks 3+4. Testing section → Tasks 1,3,4,6. Kernel-retirement is a separate tracked task in the `wildbook-coscientist` repo (not this plan).
+
+**Placeholder scan:** No TBD/TODO/"add validation"-style placeholders; every code step shows complete code. The one conditional note (Task 6 `@Disabled` if no Docker) is an explicit, justified fallback, not a placeholder.
+
+**Type/name consistency:** `TOKEN_AUTH_ATTR` constant referenced identically in the filter (Task 3) and `SearchApi`/tests (Task 4). `applyEncounterAclFilter(JSONObject, String)` signature identical in Task 1 definition and Task 4 call. Filter protected seams (`expectedContext`/`requestContext`/`jwtService`/`lookupUsername`) defined in Task 3 and overridden in the Task 3 test. `User.getId()` used consistently for ACL value + owner check (== `getUUID()`, verified). `JwtService.canVerify()` defined in Task 2, used in Task 3.

--- a/docs/superpowers/plans/2026-06-07-token-scoped-individual-annotation-plan.md
+++ b/docs/superpowers/plans/2026-06-07-token-scoped-individual-annotation-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Extend the token-scoped read boundary (Artifact D) from the `encounter` index to the `individual` and `annotation` indices — gated by encounter access — so an agent on a user's token sees individuals/annotations exactly as that user would on Wildbook's own pages, and an admin token sees all.
 
-**Architecture:** The encounter is the ACL unit. We denormalize the encounter ACL (`publiclyReadable`/`submitterUserId(s)`/`viewUsers`) onto the annotation index (union over parent encounter(s)) and the individual index (union over member encounters), computed from **one** centralized source on the `Encounter` (`computeViewUsers` + `isPubliclyReadable` + submitter). The token pre-filter from D then enforces all three indices (index-aware field names); admin bypasses. Individual results pass an allowlist sanitizer (identity only); all responses get a universal ACL-field scrub. Sync triggers re-index children on ACL **and** membership changes; a one-time corrective reindex backfills existing data.
+**Architecture:** The encounter is the ACL unit. We denormalize the encounter ACL (`publiclyReadable`/`submitterUserId(s)`/`viewUsers`) onto the annotation index (its **single** parent encounter's ACL; 0 or >1 parents → fail-closed) and the individual index (union over member encounters), computed from **one** centralized source on the `Encounter` (`computeViewUsers` + `isPubliclyReadable` + submitter). The token pre-filter from D then enforces all three indices (index-aware field names); admin bypasses. Individual results pass an allowlist sanitizer (identity only); all responses get a universal ACL-field scrub. Sync triggers re-index children on ACL **and** membership changes; a one-time corrective reindex backfills existing data.
 
 **Tech Stack:** Java 17, OpenSearch (`org.json`, Jackson `JsonGenerator` serializers, knn_vector mapping), DataNucleus JDO (`Shepherd`), Apache Shiro (D's `WildbookTokenAuthenticationFilter`), JUnit 5 + Mockito 5 (unit), embedded Jetty + Testcontainers OpenSearch (integration). Build: Maven.
 
@@ -813,15 +813,16 @@ git commit -m "feat(search): universal ACL-field scrub + token individual allowl
 
 where `EFFECTIVE_INDEX` is the resolved index expression already used there: `(searchQueryId != null) ? query.optString("indexName", null) : indexName`. Introduce a local `String effectiveIndex = (searchQueryId != null) ? query.optString("indexName", null) : indexName;` right after the stored query is loaded (before the guard ladder) and use it in BOTH this gate and the annotation-admin gate (Edit B).
 
-**Edit A.1 — guard a missing/invalid effective index (Codex Medium).** A stored query whose saved `indexName` is null or not a valid index currently slips past the validity checks and 500s at `queryPit`. Add, as an early branch in the ladder (after the token method gates, before the annotation/token gates):
+**Edit A.1 — guard a missing/invalid effective index (Codex Medium), with correct ladder order + null-safety.** Compute `effectiveIndex` null-safely (it is `null` when a stored query failed to load): `String effectiveIndex = (searchQueryId != null) ? (query != null ? query.optString("indexName", null) : null) : indexName;`. Sequence the ladder branches in this exact order so a wrong-method/missing/not-owned request never leaks index validity, and a failed stored-query load returns the right 404:
 
-```java
-                } else if (!OpenSearch.isValidIndexName(effectiveIndex)) {
-                    response.setStatus(404);
-                    res.put("error", "unknown index");
-```
+1. token method gates (stored=GET, direct=POST) — unchanged
+2. **missing stored query**: `(searchQueryId != null) && (query == null)` → 404 `"invalid searchQueryId"` (unchanged existing branch — keep it BEFORE the effective-index check so a failed load doesn't fall into "unknown index")
+3. **token stored-query owner check** (unchanged) — before revealing index validity, so a non-owner can't probe whether someone else's stored query has a valid index
+4. **effective-index validity**: `else if (!OpenSearch.isValidIndexName(effectiveIndex)) { 404 "unknown index"; }` — replaces the old `(searchQueryId == null) && !isValidIndexName(indexName)` branch (it subsumes both direct and stored; keep ONE)
+5. non-token annotation-admin gate (Edit B) — uses `effectiveIndex`
+6. token index allowlist gate (Edit A) — uses `effectiveIndex`
 
-(For a direct request `effectiveIndex == indexName`, so this also subsumes the existing `(searchQueryId == null) && !isValidIndexName(indexName)` check — keep one, not both.)
+Add tests: stored-query that fails to load → 404 "invalid searchQueryId" (not "unknown index"); other-owner stored query whose indexName is invalid → 403 owner (not 404), proving the owner check precedes index validity.
 
 - [ ] **Step 3: Edit B — resolve effective index before the annotation-admin gate (Codex Medium).** Change the existing annotation-admin gate (`:85`) so it (a) uses `effectiveIndex` not the raw `indexName`, and (b) applies only on the **non-token** path (token path is governed by the ACL filter):
 
@@ -1040,9 +1041,9 @@ cd /mnt/c/Wildbook-token-auth
 git diff --name-only origin/token-auth-scoped-search..HEAD | xargs -r grep -lU $'\r' || echo "LF-clean"
 ```
 
-- [ ] **Step 3: Self-review vs spec** — confirm each spec section maps to a task: ACL fields (T1-3), index-aware filter (T4), universal scrub + allowlist (T5), SearchApi widen + effective-index + token sanitize (T6), triggers incl. membership (T7), mapping/reindex runbook (T8), e2e proof (T9). Confirm parity edges: annotation union/0-parent (T2), individual 0-encounter world-readable (T3), anonymous-vs-invalid owner in the single source (T1).
+- [ ] **Step 3: Self-review vs spec** — confirm each spec section maps to a task: ACL fields (T1-3), index-aware filter (T4), universal scrub + allowlist (T5), SearchApi widen + effective-index + token sanitize (T6), triggers incl. membership (T7), mapping/reindex runbook (T8), e2e proof (T9). Confirm parity edges: annotation single-parent ACL / 0-or-many-parents fail-closed (T2), individual 0-encounter world-readable (T3), anonymous-vs-invalid owner in the single source (T1).
 
-- [ ] **Step 4: Codex code review** on the full Spec-A diff (`git diff <task-1-parent>..HEAD`), per project convention. Prompt Codex (read-only, may read files) to specifically check: no fail-open for non-admin token on the new indices; allowlist completeness vs the live individual serializer; universal ACL scrub covers session AND token on all three indices; membership-trigger coverage (old+new individual); annotation union over all parents (not just first); anonymous-vs-invalid-owner correctness. Fold findings, re-review until SAFE TO MERGE.
+- [ ] **Step 4: Codex code review** on the full Spec-A diff (`git diff <task-1-parent>..HEAD`), per project convention. Prompt Codex (read-only, may read files) to specifically check: no fail-open for non-admin token on the new indices; allowlist completeness vs the live individual serializer; universal ACL scrub covers session AND token on all three indices; membership-trigger coverage (old+new individual); annotation single-parent ACL with 0/>1 parents failing closed (no first-parent metadata leak); anonymous-vs-invalid-owner correctness. Fold findings, re-review until SAFE TO MERGE.
 
 - [ ] **Step 5: Report** to the user: diff summary, test counts, Codex verdict, the carried-forward follow-ups (global session metadata leak; orgAdmin viewUsers verification — now also covers the individual unions), and the reindex-cost note. Await push/PR decision.
 
@@ -1050,7 +1051,7 @@ git diff --name-only origin/token-auth-scoped-search..HEAD | xargs -r grep -lU $
 
 ## Self-Review (plan author)
 
-**Spec coverage:** every spec section maps to a task (see Task 10 Step 3). The four Codex-High spec items are implemented: annotation union (T2), universal ACL scrub (T5), allowlist sanitizer (T5), membership-change triggers (T7).
+**Spec coverage:** every spec section maps to a task (see Task 10 Step 3). The four Codex-High spec items are implemented: annotation single-parent ACL with 0/>1 fail-closed (T2), universal ACL scrub (T5), allowlist sanitizer (T5), membership-change triggers (T7).
 
 **Placeholder scan:** Task 6's test bodies and Task 9's integration test are described as method stubs with explicit assertions to fill — they reference concrete patterns (`SearchApiTokenAuthTest`/`SearchTokenScopeTest`) and exact fields to assert. Task 7 Step 2 carries an explicit engineer verification (shallow-vs-deep indexing) rather than a guess — this is a flagged real uncertainty, not a placeholder; the implementer must confirm against `IndexingManager`.
 

--- a/docs/superpowers/plans/2026-06-07-token-scoped-individual-annotation-plan.md
+++ b/docs/superpowers/plans/2026-06-07-token-scoped-individual-annotation-plan.md
@@ -18,7 +18,7 @@
 
 **Modify (main):**
 - `src/main/java/org/ecocean/Encounter.java` — add `opensearchAclFields(Shepherd)` single-source helper; add `findAllByAnnotation(...)`.
-- `src/main/java/org/ecocean/Annotation.java` — serializer writes union ACL over parent encounter(s); mapping adds the 3 ACL fields.
+- `src/main/java/org/ecocean/Annotation.java` — serializer writes its single parent encounter's ACL (0 or >1 parents → fail-closed); mapping adds the ACL fields.
 - `src/main/java/org/ecocean/MarkedIndividual.java` — serializer writes union ACL over member encounters; mapping adds the 3 ACL fields.
 - `src/main/java/org/ecocean/OpenSearch.java` — generalize `applyEncounterAclFilter`→`applyAclFilter(query,uuid,indexName)`; `sanitizeDoc` gains a `tokenAuth` param, a universal ACL-field scrub, and the individual allowlist.
 - `src/main/java/org/ecocean/api/SearchApi.java` — widen token index allowlist; resolve effective index before the annotation-admin gate; index-aware filter; pass `tokenAuth` to `sanitizeDoc`.
@@ -341,7 +341,7 @@ Expected: PASS (2 tests).
 cd /mnt/c/Wildbook-token-auth
 grep -lU $'\r' src/main/java/org/ecocean/Encounter.java src/main/java/org/ecocean/Annotation.java src/test/java/org/ecocean/AnnotationAclSerializerTest.java | xargs -r sed -i 's/\r$//'
 git add src/main/java/org/ecocean/Encounter.java src/main/java/org/ecocean/Annotation.java src/test/java/org/ecocean/AnnotationAclSerializerTest.java
-git commit -m "feat(acl): denormalize encounter ACL union onto annotation index"
+git commit -m "feat(acl): denormalize single-parent encounter ACL onto annotation index (0/>1 parents fail closed)"
 ```
 
 ---
@@ -545,7 +545,8 @@ In `OpenSearch.java`, replace `applyEncounterAclFilter` with a delegator and add
     throws IOException {
         if ((query == null) || !Util.stringExists(userId))
             throw new IOException("applyAclFilter: null query or userId");
-        // encounter docs carry a single submitterUserId; annotation/individual carry the union set submitterUserIds
+        // encounter docs carry a single submitterUserId; annotation (its single parent's submitter) and
+        // individual (union over members) carry the set field submitterUserIds
         String submitterField = "encounter".equals(indexName) ? "submitterUserId" : "submitterUserIds";
         JSONArray should = new JSONArray();
         should.put(new JSONObject().put("term", new JSONObject().put("publiclyReadable", true)));
@@ -811,7 +812,7 @@ git commit -m "feat(search): universal ACL-field scrub + token individual allowl
                     res.put("error", "token search is limited to encounter, annotation, individual");
 ```
 
-where `EFFECTIVE_INDEX` is the resolved index expression already used there: `(searchQueryId != null) ? query.optString("indexName", null) : indexName`. Introduce a local `String effectiveIndex = (searchQueryId != null) ? query.optString("indexName", null) : indexName;` right after the stored query is loaded (before the guard ladder) and use it in BOTH this gate and the annotation-admin gate (Edit B).
+where `EFFECTIVE_INDEX` is the local `effectiveIndex` defined null-safely in Edit A.1 below. Introduce that local right after the stored query is loaded (before the guard ladder) and use it in BOTH this gate and the annotation-admin gate (Edit B). (Do not use the unguarded `query.optString(...)` form — see Edit A.1 for the null-safe expression that handles a failed stored-query load.)
 
 **Edit A.1 — guard a missing/invalid effective index (Codex Medium), with correct ladder order + null-safety.** Compute `effectiveIndex` null-safely (it is `null` when a stored query failed to load): `String effectiveIndex = (searchQueryId != null) ? (query != null ? query.optString("indexName", null) : null) : indexName;`. Sequence the ladder branches in this exact order so a wrong-method/missing/not-owned request never leaks index validity, and a failed stored-query load returns the right 404:
 
@@ -869,6 +870,19 @@ Add tests: stored-query that fails to load → 404 "invalid searchQueryId" (not 
 
     // session (non-token) POST /individual, non-admin -> NOT blocked by token gate (proceeds)
     @Test void sessionIndividualSearch_notBlocked() throws Exception { /* status 200 */ }
+
+    // Edit A.1: a stored query that fails to load -> 404 "invalid searchQueryId" (NOT "unknown index")
+    @Test void storedQueryMissing_returns404InvalidId() throws Exception {
+        /* mockStatic OpenSearch.queryLoad -> null; GET /{uuid}; assert status 404 and error contains
+           "invalid searchQueryId" (the missing-stored-query branch precedes effective-index validity) */
+    }
+
+    // Edit A.1: token stored query owned by someone else whose indexName is invalid -> 403 owner,
+    // NOT 404 (owner check precedes index validity, so a non-owner can't probe index validity)
+    @Test void tokenStoredQuery_otherOwnerInvalidIndex_returns403() throws Exception {
+        /* mockStatic OpenSearch.queryLoad -> {creator:"someoneElse", indexName:"bogus"}; GET /{uuid} with
+           token; assert status 403 (owner), never 404 */
+    }
 ```
 
 (Use the `EMPTY_HITS` + `mockConstruction<OpenSearch>` capture pattern from `SearchApiTokenAuthTest`; for the individual ACL-filter assertion, check `q.getJSONObject("query").getJSONObject("bool").getJSONArray("filter")...` contains a `submitterUserIds` term.)
@@ -1055,4 +1069,4 @@ git diff --name-only origin/token-auth-scoped-search..HEAD | xargs -r grep -lU $
 
 **Placeholder scan:** Task 6's test bodies and Task 9's integration test are described as method stubs with explicit assertions to fill — they reference concrete patterns (`SearchApiTokenAuthTest`/`SearchTokenScopeTest`) and exact fields to assert. Task 7 Step 2 carries an explicit engineer verification (shallow-vs-deep indexing) rather than a guess — this is a flagged real uncertainty, not a placeholder; the implementer must confirm against `IndexingManager`.
 
-**Type/name consistency:** `opensearchAclFields` (T1) returns `{publiclyReadable, submitterUserId?, viewUsers[]}` and is consumed by `writeAclFields` in T2/T3 (which emit `submitterUserIds` plural unions). `applyAclFilter(query,uuid,indexName)` (T4) uses `submitterUserId` for encounter, `submitterUserIds` for annotation/individual — matching the serializers. `sanitizeDoc(...,tokenAuth)` (T5) is called with `tokenAuth` in T6. `INDIVIDUAL_TOKEN_KEEP` allowlist matches the identity fields the individual serializer emits.
+**Type/name consistency:** `opensearchAclFields` (T1) returns `{publiclyReadable, submitterUserId?, viewUsers[]}` and is consumed by `writeAclFields` in T2 (annotation: single parent's ACL, 0/>1 → fail-closed) and T3 (individual: union over members), both emitting the set field `submitterUserIds`. `applyAclFilter(query,uuid,indexName)` (T4) uses `submitterUserId` for encounter, `submitterUserIds` for annotation/individual — matching the serializers. `sanitizeDoc(...,tokenAuth)` (T5) is called with `tokenAuth` in T6. `INDIVIDUAL_TOKEN_KEEP` allowlist matches the identity fields the individual serializer emits.

--- a/docs/superpowers/plans/2026-06-07-token-scoped-individual-annotation-plan.md
+++ b/docs/superpowers/plans/2026-06-07-token-scoped-individual-annotation-plan.md
@@ -1,0 +1,984 @@
+# Token-Scoped Individual + Annotation Reads (Spec A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the token-scoped read boundary (Artifact D) from the `encounter` index to the `individual` and `annotation` indices — gated by encounter access — so an agent on a user's token sees individuals/annotations exactly as that user would on Wildbook's own pages, and an admin token sees all.
+
+**Architecture:** The encounter is the ACL unit. We denormalize the encounter ACL (`publiclyReadable`/`submitterUserId(s)`/`viewUsers`) onto the annotation index (union over parent encounter(s)) and the individual index (union over member encounters), computed from **one** centralized source on the `Encounter` (`computeViewUsers` + `isPubliclyReadable` + submitter). The token pre-filter from D then enforces all three indices (index-aware field names); admin bypasses. Individual results pass an allowlist sanitizer (identity only); all responses get a universal ACL-field scrub. Sync triggers re-index children on ACL **and** membership changes; a one-time corrective reindex backfills existing data.
+
+**Tech Stack:** Java 17, OpenSearch (`org.json`, Jackson `JsonGenerator` serializers, knn_vector mapping), DataNucleus JDO (`Shepherd`), Apache Shiro (D's `WildbookTokenAuthenticationFilter`), JUnit 5 + Mockito 5 (unit), embedded Jetty + Testcontainers OpenSearch (integration). Build: Maven.
+
+**Branch / worktree:** continue on `token-auth-scoped-search` at `/mnt/c/Wildbook-token-auth` (builds on A+B+D), or branch off it. All paths relative to that worktree.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-token-scoped-individual-annotation-design.md` (Codex-reviewed).
+
+---
+
+## File Structure
+
+**Modify (main):**
+- `src/main/java/org/ecocean/Encounter.java` — add `opensearchAclFields(Shepherd)` single-source helper; add `findAllByAnnotation(...)`.
+- `src/main/java/org/ecocean/Annotation.java` — serializer writes union ACL over parent encounter(s); mapping adds the 3 ACL fields.
+- `src/main/java/org/ecocean/MarkedIndividual.java` — serializer writes union ACL over member encounters; mapping adds the 3 ACL fields.
+- `src/main/java/org/ecocean/OpenSearch.java` — generalize `applyEncounterAclFilter`→`applyAclFilter(query,uuid,indexName)`; `sanitizeDoc` gains a `tokenAuth` param, a universal ACL-field scrub, and the individual allowlist.
+- `src/main/java/org/ecocean/api/SearchApi.java` — widen token index allowlist; resolve effective index before the annotation-admin gate; index-aware filter; pass `tokenAuth` to `sanitizeDoc`.
+- Reindex triggers: extend ACL-change enqueues + add membership-change enqueues (sites in `IndividualRemoveEncounter.java`, `Encounter.setIndividual`, `MarkedIndividual.addEncounter/removeEncounter/mergeIndividual`).
+
+**Create (test):**
+- `src/test/java/org/ecocean/EncounterAclFieldsTest.java`
+- `src/test/java/org/ecocean/OpenSearchAclFilterIndexAwareTest.java` (or extend `OpenSearchAclFilterTest`)
+- `src/test/java/org/ecocean/OpenSearchSanitizeDocTest.java`
+- `src/test/java/org/ecocean/api/SearchApiChildIndexTest.java`
+- `src/test/java/org/ecocean/api/SearchTokenScopeChildIndexTest.java` (integration; sibling of `SearchTokenScopeTest`)
+- Serializer unit tests for annotation/individual ACL fields.
+
+**Docs:**
+- `docs/superpowers/runbooks/childindex-acl-reindex.md` (mapping migration + corrective reindex).
+
+**Key verified facts (current source):**
+- `Encounter.computeViewUsers(Shepherd)` → `List<String>` of user UUIDs; returns `[]` when `isPubliclyReadable()` or submitter is null/unresolved (fail-closed). (`Encounter.java:3356`). `userIdsWithViewAccess` delegates to it (`:3391`).
+- `Encounter.isPubliclyReadable()` = security-disabled OR `User.isUsernameAnonymous(submitterID)` (`Encounter.java:4109`); `User.isUsernameAnonymous` = null/blank/`"N/A"`/`"public"` (`User.java:392`).
+- `submitterUserId` = `getSubmitterUser(myShepherd).getId()` (`Encounter.java:4402`).
+- Encounter `viewUsers` is written by the background `opensearchIndexPermissions` pass (`os.indexUpdate`, `Encounter.java:4281`), NOT normally by the serializer — but both compute the same value via `computeViewUsers`, so synchronous child computation matches.
+- `MarkedIndividual.opensearchDocumentSerializer(JsonGenerator, Shepherd)` already loops `for (Encounter enc : this.encounters)` (`MarkedIndividual.java:2813`); fields emitted: `id,version,indexTimestamp,sex,displayName,taxonomy,timeOfBirth,timeOfDeath,names,nameMap,socialUnits,relationships,numberEncounters,encounterIds,users,numberOccurrences,cooccurrenceIndividualIds,cooccurrenceIndividualMap,locationGeoPoints,numberMediaAssets`. Mapping at `:2694`.
+- `Annotation.opensearchDocumentSerializer(JsonGenerator, Shepherd)` (`Annotation.java:206`) resolves parent via `findEncounter(myShepherd)` → `Encounter.findByAnnotation` (`:3650`) which **returns first of possibly many, null if none**. Mapping at `:163`. Embeddings written `:241`.
+- `OpenSearch.sanitizeDoc(sourceDoc, indexName, myShepherd, user)` (`:964`): annotation/individual return raw `_source` (`:969`); encounter strips `viewUsers` + sets `access` (`:972`). No `tokenAuth` param today.
+- `OpenSearch.applyEncounterAclFilter(query, userId)` (`:936`) hardcodes encounter field names.
+- `SearchApi.doPost` (post-D): token index gate `!"encounter".equals(...)` (`:97`); annotation-admin-only gate `"annotation".equals(indexName) && !isAdmin` (`:85`) runs BEFORE the stored-query owner/encounter gates; ACL filter call (`:129`); `sanitizeDoc` call (`:155`).
+- `IndexingManager.addIndexingQueueEntry(Base, boolean unindex)` (`IndexingManager.java:67`) enqueues a reindex of a `Base` object. `Encounter.opensearchIndexDeep()` already reindexes its annotations + individual (`Encounter.java:4680`); `MarkedIndividual.opensearchIndexDeep()` reindexes its encounters. The permissions pass is **encounter-only** today.
+
+---
+
+### Task 1: Centralized ACL source on `Encounter`
+
+One method that returns the three ACL fields, so encounter/annotation/individual indexing agree and the anonymous-vs-invalid-owner distinction lives in one place.
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/Encounter.java`
+- Test: `src/test/java/org/ecocean/EncounterAclFieldsTest.java` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import org.json.JSONObject;
+import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.Test;
+
+class EncounterAclFieldsTest {
+
+    // A private (non-anonymous, valid submitter) encounter -> publiclyReadable=false,
+    // submitterUserId set, viewUsers = computeViewUsers result.
+    @Test void privateEncounter_emitsSubmitterAndViewUsers() {
+        Encounter enc = spy(new Encounter());
+        Shepherd sh = mock(Shepherd.class);
+        User submitter = mock(User.class);
+        when(submitter.getId()).thenReturn("owner-uuid");
+        doReturn(false).when(enc).isPubliclyReadable();
+        doReturn(submitter).when(enc).getSubmitterUser(sh);
+        doReturn(Arrays.asList("collab-uuid")).when(enc).computeViewUsers(sh);
+
+        JSONObject acl = enc.opensearchAclFields(sh);
+        assertFalse(acl.getBoolean("publiclyReadable"), "private -> not public");
+        assertEquals("owner-uuid", acl.getString("submitterUserId"), "submitter uuid");
+        assertEquals(1, acl.getJSONArray("viewUsers").length(), "one viewUser");
+        assertEquals("collab-uuid", acl.getJSONArray("viewUsers").getString(0));
+    }
+
+    // An anonymous/public encounter -> publiclyReadable=true, no submitterUserId, empty viewUsers.
+    @Test void publicEncounter_isWorldReadable() {
+        Encounter enc = spy(new Encounter());
+        Shepherd sh = mock(Shepherd.class);
+        doReturn(true).when(enc).isPubliclyReadable();
+        JSONObject acl = enc.opensearchAclFields(sh);
+        assertTrue(acl.getBoolean("publiclyReadable"), "anonymous -> world readable");
+        assertFalse(acl.has("submitterUserId"), "no submitter on public");
+        assertEquals(0, acl.getJSONArray("viewUsers").length(), "no viewUsers on public");
+    }
+
+    // Invalid/deleted (non-anonymous) submitter -> fail closed: not public, no submitter, empty viewUsers (admin-only).
+    @Test void invalidOwner_failsClosed() {
+        Encounter enc = spy(new Encounter());
+        Shepherd sh = mock(Shepherd.class);
+        doReturn(false).when(enc).isPubliclyReadable();
+        doReturn(null).when(enc).getSubmitterUser(sh);
+        doReturn(java.util.Collections.emptyList()).when(enc).computeViewUsers(sh);
+        JSONObject acl = enc.opensearchAclFields(sh);
+        assertFalse(acl.getBoolean("publiclyReadable"), "not public");
+        assertFalse(acl.has("submitterUserId"), "no resolvable submitter -> admin-only");
+        assertEquals(0, acl.getJSONArray("viewUsers").length(), "no viewUsers -> admin-only");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn test -Dtest=EncounterAclFieldsTest`
+Expected: FAIL — `opensearchAclFields` not defined.
+
+- [ ] **Step 3: Implement `opensearchAclFields`**
+
+Add to `Encounter.java` (near `computeViewUsers`, ~`:3389`):
+
+```java
+    /**
+     * Single source of this encounter's OpenSearch ACL fields, reused by the encounter,
+     * annotation, and individual indexing so all three agree. publiclyReadable mirrors
+     * isPubliclyReadable() (security-disabled OR anonymous owner). For a non-public encounter:
+     * submitterUserId is the resolved owner's UUID (absent if the owner is invalid/deleted ->
+     * admin-only/fail-closed), and viewUsers is computeViewUsers() (approved/edit collaborators +
+     * submitter-org orgAdmins). Anonymous-owned -> public; invalid/deleted non-anonymous owner -> closed.
+     */
+    public org.json.JSONObject opensearchAclFields(Shepherd myShepherd) {
+        org.json.JSONObject acl = new org.json.JSONObject();
+        boolean pub = this.isPubliclyReadable();
+        acl.put("publiclyReadable", pub);
+        org.json.JSONArray vu = new org.json.JSONArray();
+        if (!pub) {
+            User submitter = this.getSubmitterUser(myShepherd);
+            if ((submitter != null) && (submitter.getId() != null))
+                acl.put("submitterUserId", submitter.getId());
+            for (String id : this.computeViewUsers(myShepherd)) vu.put(id);
+        }
+        acl.put("viewUsers", vu);
+        return acl;
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `mvn test -Dtest=EncounterAclFieldsTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/java/org/ecocean/Encounter.java src/test/java/org/ecocean/EncounterAclFieldsTest.java | xargs -r sed -i 's/\r$//'
+git add src/main/java/org/ecocean/Encounter.java src/test/java/org/ecocean/EncounterAclFieldsTest.java
+git commit -m "feat(acl): single-source Encounter.opensearchAclFields for child-index denormalization"
+```
+(End every commit message with: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`)
+
+---
+
+### Task 2: Annotation index — ACL fields (union over parent encounter(s))
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/Encounter.java` (add `findAllByAnnotation`), `src/main/java/org/ecocean/Annotation.java`
+- Test: `src/test/java/org/ecocean/AnnotationAclSerializerTest.java` (create)
+
+- [ ] **Step 1: Add `Encounter.findAllByAnnotation` (return ALL parents, not just the first)**
+
+In `Encounter.java`, next to `findByAnnotation` (~`:3650`):
+
+```java
+    /** All encounters whose annotations contain this annotation (usually 0 or 1; >1 is anomalous). */
+    public static java.util.List<Encounter> findAllByAnnotation(Annotation annot, Shepherd myShepherd) {
+        String queryString =
+            "SELECT FROM org.ecocean.Encounter WHERE annotations.contains(ann) && ann.id == '"
+            + annot.getId() + "'";
+        javax.jdo.Query query = myShepherd.getPM().newQuery(queryString);
+        java.util.List<Encounter> out = new java.util.ArrayList<Encounter>();
+        try {
+            java.util.List results = (java.util.List) query.execute();
+            if (results != null) for (Object o : results) out.add((Encounter) o);
+        } finally {
+            query.closeAll();
+        }
+        return out;
+    }
+```
+
+- [ ] **Step 2: Write the failing serializer test**
+
+`src/test/java/org/ecocean/AnnotationAclSerializerTest.java`:
+
+```java
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.StringWriter;
+import java.util.Arrays;
+import org.json.JSONObject;
+import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.Test;
+
+class AnnotationAclSerializerTest {
+
+    private JSONObject serialize(Annotation ann, Shepherd sh) throws Exception {
+        StringWriter sw = new StringWriter();
+        JsonGenerator jg = new JsonFactory().createGenerator(sw);
+        jg.writeStartObject();
+        ann.writeAclFields(jg, sh); // the new helper under test (writes only the ACL fields)
+        jg.writeEndObject();
+        jg.close();
+        return new JSONObject(sw.toString());
+    }
+
+    @Test void unionOverParents_privatePlusPublic() throws Exception {
+        Annotation ann = spy(new Annotation());
+        Shepherd sh = mock(Shepherd.class);
+        Encounter encPrivate = mock(Encounter.class);
+        Encounter encPublic = mock(Encounter.class);
+        when(encPrivate.opensearchAclFields(sh)).thenReturn(new JSONObject(
+            "{\"publiclyReadable\":false,\"submitterUserId\":\"u1\",\"viewUsers\":[\"v1\"]}"));
+        when(encPublic.opensearchAclFields(sh)).thenReturn(new JSONObject(
+            "{\"publiclyReadable\":true,\"viewUsers\":[]}"));
+        doReturn(Arrays.asList(encPrivate, encPublic)).when(ann).parentEncounters(sh);
+
+        JSONObject out = serialize(ann, sh);
+        assertTrue(out.getBoolean("publiclyReadable"), "any public parent -> public");
+        assertTrue(out.getJSONArray("submitterUserIds").toList().contains("u1"));
+        assertTrue(out.getJSONArray("viewUsers").toList().contains("v1"));
+    }
+
+    @Test void zeroParents_failsClosed() throws Exception {
+        Annotation ann = spy(new Annotation());
+        Shepherd sh = mock(Shepherd.class);
+        doReturn(java.util.Collections.emptyList()).when(ann).parentEncounters(sh);
+        JSONObject out = serialize(ann, sh);
+        assertFalse(out.getBoolean("publiclyReadable"), "no parent -> not public");
+        assertEquals(0, out.getJSONArray("submitterUserIds").length(), "no parent -> admin-only");
+        assertEquals(0, out.getJSONArray("viewUsers").length(), "no parent -> admin-only");
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `mvn test -Dtest=AnnotationAclSerializerTest`
+Expected: FAIL — `parentEncounters`/`writeAclFields` not defined.
+
+- [ ] **Step 4: Implement the helpers + wire into the serializer + mapping**
+
+In `Annotation.java`, add:
+
+```java
+    /** All parent encounters of this annotation (0 = orphan; >1 = anomalous). */
+    public java.util.List<Encounter> parentEncounters(Shepherd myShepherd) {
+        return Encounter.findAllByAnnotation(this, myShepherd);
+    }
+
+    /** Write the denormalized ACL union over parent encounter(s); 0 parents -> fail closed (admin-only). */
+    public void writeAclFields(com.fasterxml.jackson.core.JsonGenerator jgen, Shepherd myShepherd)
+    throws java.io.IOException {
+        boolean pub = false;
+        java.util.Set<String> submitters = new java.util.LinkedHashSet<String>();
+        java.util.Set<String> viewers = new java.util.LinkedHashSet<String>();
+        for (Encounter enc : this.parentEncounters(myShepherd)) {
+            org.json.JSONObject acl = enc.opensearchAclFields(myShepherd);
+            if (acl.optBoolean("publiclyReadable", false)) pub = true;
+            String sid = acl.optString("submitterUserId", null);
+            if (sid != null) submitters.add(sid);
+            org.json.JSONArray vu = acl.optJSONArray("viewUsers");
+            if (vu != null) for (int i = 0; i < vu.length(); i++) viewers.add(vu.optString(i));
+        }
+        jgen.writeBooleanField("publiclyReadable", pub);
+        jgen.writeArrayFieldStart("submitterUserIds");
+        for (String s : submitters) jgen.writeString(s);
+        jgen.writeEndArray();
+        jgen.writeArrayFieldStart("viewUsers");
+        for (String v : viewers) jgen.writeString(v);
+        jgen.writeEndArray();
+    }
+```
+
+Then call it inside `opensearchDocumentSerializer` (after the `encounter*` fields, before the `embeddings` array at `:241`):
+
+```java
+        this.writeAclFields(jgen, myShepherd);
+```
+
+And add the mapping fields in `opensearchMapping()` (before the `embeddings` block, ~`:182`):
+
+```java
+        map.put("publiclyReadable", new JSONObject("{\"type\": \"boolean\"}"));
+        map.put("submitterUserIds", keywordType);
+        map.put("viewUsers", keywordType);
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `mvn test -Dtest=AnnotationAclSerializerTest`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Normalize + commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/java/org/ecocean/Encounter.java src/main/java/org/ecocean/Annotation.java src/test/java/org/ecocean/AnnotationAclSerializerTest.java | xargs -r sed -i 's/\r$//'
+git add src/main/java/org/ecocean/Encounter.java src/main/java/org/ecocean/Annotation.java src/test/java/org/ecocean/AnnotationAclSerializerTest.java
+git commit -m "feat(acl): denormalize encounter ACL union onto annotation index"
+```
+
+---
+
+### Task 3: Individual index — ACL fields (union over member encounters)
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/MarkedIndividual.java`
+- Test: `src/test/java/org/ecocean/MarkedIndividualAclSerializerTest.java` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.StringWriter;
+import org.json.JSONObject;
+import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.Test;
+
+class MarkedIndividualAclSerializerTest {
+
+    private JSONObject serialize(MarkedIndividual mi, Shepherd sh) throws Exception {
+        StringWriter sw = new StringWriter();
+        JsonGenerator jg = new JsonFactory().createGenerator(sw);
+        jg.writeStartObject();
+        mi.writeAclFields(jg, sh);
+        jg.writeEndObject();
+        jg.close();
+        return new JSONObject(sw.toString());
+    }
+
+    @Test void unionOverMembers() throws Exception {
+        MarkedIndividual mi = spy(new MarkedIndividual());
+        Shepherd sh = mock(Shepherd.class);
+        Encounter e1 = mock(Encounter.class);
+        Encounter e2 = mock(Encounter.class);
+        when(e1.opensearchAclFields(sh)).thenReturn(new JSONObject(
+            "{\"publiclyReadable\":false,\"submitterUserId\":\"u1\",\"viewUsers\":[\"v1\"]}"));
+        when(e2.opensearchAclFields(sh)).thenReturn(new JSONObject(
+            "{\"publiclyReadable\":false,\"submitterUserId\":\"u2\",\"viewUsers\":[\"v2\"]}"));
+        doReturn(java.util.Arrays.asList(e1, e2)).when(mi).getEncounters();
+
+        JSONObject out = serialize(mi, sh);
+        assertFalse(out.getBoolean("publiclyReadable"));
+        assertTrue(out.getJSONArray("submitterUserIds").toList().containsAll(java.util.Arrays.asList("u1","u2")));
+        assertTrue(out.getJSONArray("viewUsers").toList().containsAll(java.util.Arrays.asList("v1","v2")));
+    }
+
+    @Test void zeroEncounters_worldReadable() throws Exception {
+        MarkedIndividual mi = spy(new MarkedIndividual());
+        Shepherd sh = mock(Shepherd.class);
+        doReturn(java.util.Collections.emptyList()).when(mi).getEncounters();
+        JSONObject out = serialize(mi, sh);
+        assertTrue(out.getBoolean("publiclyReadable"),
+            "encounterless individual -> visible to anyone (matches canUserAccessMarkedIndividual)");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn test -Dtest=MarkedIndividualAclSerializerTest`
+Expected: FAIL — `writeAclFields` not defined.
+
+- [ ] **Step 3: Implement `writeAclFields` + wire into serializer + mapping**
+
+In `MarkedIndividual.java`, add:
+
+```java
+    /** Denormalized ACL union over member encounters; 0 encounters -> world-readable (matches the live gate). */
+    public void writeAclFields(com.fasterxml.jackson.core.JsonGenerator jgen, Shepherd myShepherd)
+    throws java.io.IOException {
+        java.util.List<Encounter> encs = this.getEncounters();
+        boolean pub = (encs == null) || encs.isEmpty(); // encounterless -> visible to anyone
+        java.util.Set<String> submitters = new java.util.LinkedHashSet<String>();
+        java.util.Set<String> viewers = new java.util.LinkedHashSet<String>();
+        if (encs != null) {
+            for (Encounter enc : encs) {
+                org.json.JSONObject acl = enc.opensearchAclFields(myShepherd);
+                if (acl.optBoolean("publiclyReadable", false)) pub = true;
+                String sid = acl.optString("submitterUserId", null);
+                if (sid != null) submitters.add(sid);
+                org.json.JSONArray vu = acl.optJSONArray("viewUsers");
+                if (vu != null) for (int i = 0; i < vu.length(); i++) viewers.add(vu.optString(i));
+            }
+        }
+        jgen.writeBooleanField("publiclyReadable", pub);
+        jgen.writeArrayFieldStart("submitterUserIds");
+        for (String s : submitters) jgen.writeString(s);
+        jgen.writeEndArray();
+        jgen.writeArrayFieldStart("viewUsers");
+        for (String v : viewers) jgen.writeString(v);
+        jgen.writeEndArray();
+    }
+```
+
+Call it at the top of `opensearchDocumentSerializer` (right after `super.opensearchDocumentSerializer(...)`, ~`:2725`):
+
+```java
+        this.writeAclFields(jgen, myShepherd);
+```
+
+> Note: `getEncounters()` returns the live member list (already loaded as `this.encounters`); `enc.opensearchAclFields` calls `computeViewUsers` per member. This is the per-doc cost A's bulk pass avoids; see Task 8's reindex-cost note. Acceptable for a one-time reindex + incremental updates; an optional bulk optimization is a documented follow-up.
+
+Add to `opensearchMapping()` (~`:2719`, before `return map;`):
+
+```java
+        map.put("publiclyReadable", new org.json.JSONObject("{\"type\": \"boolean\"}"));
+        map.put("submitterUserIds", keywordType);
+        // viewUsers is already mapped as keyword in Base.opensearchMapping()
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `mvn test -Dtest=MarkedIndividualAclSerializerTest`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/java/org/ecocean/MarkedIndividual.java src/test/java/org/ecocean/MarkedIndividualAclSerializerTest.java | xargs -r sed -i 's/\r$//'
+git add src/main/java/org/ecocean/MarkedIndividual.java src/test/java/org/ecocean/MarkedIndividualAclSerializerTest.java
+git commit -m "feat(acl): denormalize encounter ACL union onto individual index (0 encs -> world-readable)"
+```
+
+---
+
+### Task 4: Index-aware ACL pre-filter (`applyAclFilter`)
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/OpenSearch.java`
+- Test: `src/test/java/org/ecocean/OpenSearchAclFilterIndexAwareTest.java` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchAclFilterIndexAwareTest {
+
+    private JSONArray shoulds(JSONObject out) {
+        return out.getJSONObject("query").getJSONObject("bool")
+            .getJSONArray("filter").getJSONObject(0).getJSONObject("bool").getJSONArray("should");
+    }
+
+    @Test void encounterUsesSubmitterUserId() throws Exception {
+        JSONObject out = OpenSearch.applyAclFilter(
+            new JSONObject("{\"query\":{\"match_all\":{}}}"), "u1", "encounter");
+        assertEquals("u1", shoulds(out).getJSONObject(1).getJSONObject("term").getString("submitterUserId"));
+    }
+
+    @Test void individualUsesSubmitterUserIds() throws Exception {
+        JSONObject out = OpenSearch.applyAclFilter(
+            new JSONObject("{\"query\":{\"match_all\":{}}}"), "u1", "individual");
+        assertEquals("u1", shoulds(out).getJSONObject(1).getJSONObject("term").getString("submitterUserIds"));
+    }
+
+    @Test void annotationUsesSubmitterUserIds() throws Exception {
+        JSONObject out = OpenSearch.applyAclFilter(
+            new JSONObject("{\"query\":{\"match_all\":{}}}"), "u1", "annotation");
+        assertEquals("u1", shoulds(out).getJSONObject(1).getJSONObject("term").getString("submitterUserIds"));
+    }
+
+    @Test void rejectsNullUser() {
+        assertThrows(java.io.IOException.class,
+            () -> OpenSearch.applyAclFilter(new JSONObject("{\"query\":{\"match_all\":{}}}"), null, "encounter"));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn test -Dtest=OpenSearchAclFilterIndexAwareTest`
+Expected: FAIL — `applyAclFilter` not defined.
+
+- [ ] **Step 3: Generalize the filter**
+
+In `OpenSearch.java`, replace `applyEncounterAclFilter` with a delegator and add `applyAclFilter`:
+
+```java
+    public static JSONObject applyEncounterAclFilter(JSONObject query, String userId)
+    throws IOException {
+        return applyAclFilter(query, userId, "encounter");
+    }
+
+    public static JSONObject applyAclFilter(JSONObject query, String userId, String indexName)
+    throws IOException {
+        if ((query == null) || !Util.stringExists(userId))
+            throw new IOException("applyAclFilter: null query or userId");
+        // encounter docs carry a single submitterUserId; annotation/individual carry the union set submitterUserIds
+        String submitterField = "encounter".equals(indexName) ? "submitterUserId" : "submitterUserIds";
+        JSONArray should = new JSONArray();
+        should.put(new JSONObject().put("term", new JSONObject().put("publiclyReadable", true)));
+        should.put(new JSONObject().put("term", new JSONObject().put(submitterField, userId)));
+        should.put(new JSONObject().put("term", new JSONObject().put("viewUsers", userId)));
+        JSONObject aclBool = new JSONObject();
+        aclBool.put("should", should);
+        aclBool.put("minimum_should_match", 1);
+        JSONObject acl = new JSONObject().put("bool", aclBool);
+
+        JSONObject wrapBool = new JSONObject();
+        JSONObject inner = query.optJSONObject("query");
+        if (inner != null) {
+            JSONArray must = new JSONArray();
+            must.put(inner);
+            wrapBool.put("must", must);
+        }
+        wrapBool.put("filter", new JSONArray().put(acl));
+
+        JSONObject out = new JSONObject(query.toString());
+        out.put("query", new JSONObject().put("bool", wrapBool));
+        return out;
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `mvn test -Dtest=OpenSearchAclFilterIndexAwareTest,OpenSearchAclFilterTest`
+Expected: PASS (the new 4 + D's original 3 still green via the delegator).
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/java/org/ecocean/OpenSearch.java src/test/java/org/ecocean/OpenSearchAclFilterIndexAwareTest.java | xargs -r sed -i 's/\r$//'
+git add src/main/java/org/ecocean/OpenSearch.java src/test/java/org/ecocean/OpenSearchAclFilterIndexAwareTest.java
+git commit -m "feat(search): index-aware applyAclFilter (submitterUserId vs submitterUserIds)"
+```
+
+---
+
+### Task 5: `sanitizeDoc` — universal ACL scrub + token-aware individual allowlist
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/OpenSearch.java`
+- Test: `src/test/java/org/ecocean/OpenSearchSanitizeDocTest.java` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.json.JSONObject;
+import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchSanitizeDocTest {
+
+    private User user(boolean admin) {
+        User u = mock(User.class);
+        when(u.getId()).thenReturn("u1");
+        return u;
+    }
+
+    @Test void annotation_stripsAclFields_keepsContent() throws Exception {
+        JSONObject doc = new JSONObject("{\"id\":\"a1\",\"viewpoint\":\"left\",\"embeddings\":[{}],"
+            + "\"publiclyReadable\":true,\"submitterUserIds\":[\"x\"],\"viewUsers\":[\"y\"]}");
+        Shepherd sh = mock(Shepherd.class);
+        JSONObject out = OpenSearch.sanitizeDoc(doc, "annotation", sh, user(false), true);
+        assertEquals("left", out.getString("viewpoint"), "content kept");
+        assertTrue(out.has("embeddings"), "embeddings kept (not precious)");
+        assertFalse(out.has("viewUsers"), "ACL fields scrubbed");
+        assertFalse(out.has("submitterUserIds"), "ACL fields scrubbed");
+        assertFalse(out.has("publiclyReadable"), "ACL fields scrubbed");
+    }
+
+    @Test void individualToken_allowlistOnly() throws Exception {
+        JSONObject doc = new JSONObject("{\"id\":\"i1\",\"displayName\":\"Fluke\",\"sex\":\"female\","
+            + "\"taxonomy\":\"x\",\"numberEncounters\":42,\"users\":[\"owner\"],"
+            + "\"encounterIds\":[\"e1\"],\"locationGeoPoints\":[{}],\"viewUsers\":[\"y\"]}");
+        Shepherd sh = mock(Shepherd.class);
+        User u = user(false);
+        when(u.isAdmin(sh)).thenReturn(false);
+        JSONObject out = OpenSearch.sanitizeDoc(doc, "individual", sh, u, true);
+        assertEquals("Fluke", out.getString("displayName"), "identity kept");
+        assertEquals("female", out.getString("sex"), "identity kept");
+        assertFalse(out.has("numberEncounters"), "aggregate dropped");
+        assertFalse(out.has("users"), "aggregate dropped (would leak hidden submitters)");
+        assertFalse(out.has("encounterIds"), "aggregate dropped");
+        assertFalse(out.has("locationGeoPoints"), "aggregate dropped");
+        assertFalse(out.has("viewUsers"), "ACL field scrubbed");
+    }
+
+    @Test void individualAdminToken_fullDocMinusAcl() throws Exception {
+        JSONObject doc = new JSONObject("{\"id\":\"i1\",\"numberEncounters\":42,\"viewUsers\":[\"y\"]}");
+        Shepherd sh = mock(Shepherd.class);
+        User u = user(true);
+        when(u.isAdmin(sh)).thenReturn(true);
+        JSONObject out = OpenSearch.sanitizeDoc(doc, "individual", sh, u, true);
+        assertEquals(42, out.getInt("numberEncounters"), "admin keeps aggregates");
+        assertFalse(out.has("viewUsers"), "ACL still scrubbed even for admin");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn test -Dtest=OpenSearchSanitizeDocTest`
+Expected: FAIL — `sanitizeDoc` has no 5-arg (tokenAuth) overload.
+
+- [ ] **Step 3: Implement**
+
+In `OpenSearch.java`, add the constants + a universal scrub + the allowlist, and a new 5-arg `sanitizeDoc`; keep the 4-arg as a delegator:
+
+```java
+    private static final String[] ACL_FIELDS = {
+        "publiclyReadable", "submitterUserId", "submitterUserIds", "viewUsers", "editUsers"
+    };
+    // identity fields kept for a non-admin token individual hit; everything else dropped (allowlist)
+    private static final String[] INDIVIDUAL_TOKEN_KEEP = {
+        "id", "version", "indexTimestamp", "displayName", "names", "nameMap",
+        "sex", "taxonomy", "timeOfBirth", "timeOfDeath"
+    };
+
+    private static void scrubAclFields(JSONObject doc) {
+        for (String f : ACL_FIELDS) doc.remove(f);
+    }
+
+    // 4-arg overload preserved for existing callers (non-token path)
+    public static JSONObject sanitizeDoc(final JSONObject sourceDoc, String indexName,
+        Shepherd myShepherd, User user)
+    throws IOException {
+        return sanitizeDoc(sourceDoc, indexName, myShepherd, user, false);
+    }
+
+    public static JSONObject sanitizeDoc(final JSONObject sourceDoc, String indexName,
+        Shepherd myShepherd, User user, boolean tokenAuth)
+    throws IOException {
+        if ((user == null) || (sourceDoc == null)) throw new IOException("null user or sourceDoc");
+        if ("annotation".equals(indexName)) {
+            JSONObject clean = new JSONObject(sourceDoc.toString());
+            scrubAclFields(clean);             // never leak the internal ACL fields
+            return clean;                      // content (incl. embeddings) returned as-is
+        }
+        if ("individual".equals(indexName)) {
+            boolean admin = user.isAdmin(myShepherd);
+            if (tokenAuth && !admin) {
+                JSONObject clean = new JSONObject();
+                for (String f : INDIVIDUAL_TOKEN_KEEP) {
+                    if (sourceDoc.has(f)) clean.put(f, sourceDoc.get(f));
+                }
+                return clean;                  // allowlist: identity only, aggregates dropped
+            }
+            JSONObject clean = new JSONObject(sourceDoc.toString());
+            scrubAclFields(clean);
+            return clean;
+        }
+        // these we return some kinda cleaned value
+        JSONObject clean = new JSONObject();
+        if ("encounter".equals(indexName)) {
+            boolean hasAccess = Encounter.opensearchAccess(sourceDoc, user, myShepherd);
+            if (hasAccess) {
+                clean = new JSONObject(sourceDoc.toString());
+                scrubAclFields(clean);
+                clean.put("access", "full");
+                return clean;
+            }
+            clean.put("access", "none");
+            String[] okFields = new String[] {
+                "id", "version", "indexTimestamp", "version", "individualId",
+                    "individualDisplayName", "occurrenceId", "otherCatalogNumbers", "dateSubmitted",
+                    "date", "locationId", "locationName", "taxonomy", "assignedUsername",
+                    "numberAnnotations"
+            };
+            for (String fieldName : okFields) {
+                if (sourceDoc.has(fieldName)) clean.put(fieldName, sourceDoc.get(fieldName));
+            }
+        } else if ("occurrence".equals(indexName)) {
+            boolean hasAccess = user.isAdmin(myShepherd) || hasAccessOccurrence(user, sourceDoc);
+            if (hasAccess) {
+                clean = new JSONObject(sourceDoc.toString());
+                scrubAclFields(clean);
+                clean.put("access", "full");
+            } else {
+                clean = new JSONObject();
+                clean.put("id", sourceDoc.optString("id", "unknown"));
+                clean.put("access", "none");
+            }
+        }
+        return clean;
+    }
+```
+
+(This replaces the old `:964-1008` body; the encounter branch now uses `scrubAclFields` instead of only `clean.remove("viewUsers")` — equivalent + safer. The early `annotation/individual return sourceDoc` at `:969` is gone.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `mvn test -Dtest=OpenSearchSanitizeDocTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/java/org/ecocean/OpenSearch.java src/test/java/org/ecocean/OpenSearchSanitizeDocTest.java | xargs -r sed -i 's/\r$//'
+git add src/main/java/org/ecocean/OpenSearch.java src/test/java/org/ecocean/OpenSearchSanitizeDocTest.java
+git commit -m "feat(search): universal ACL-field scrub + token individual allowlist in sanitizeDoc"
+```
+
+---
+
+### Task 6: `SearchApi` — widen token indices, effective-index ordering, index-aware filter, token-aware sanitize
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/api/SearchApi.java`
+- Test: `src/test/java/org/ecocean/api/SearchApiChildIndexTest.java` (create)
+
+- [ ] **Step 1: Read the current ladder** (`SearchApi.java:60-130`) to confirm the anchors from the File Structure facts (annotation-admin gate `:85`, encounter-only token gate `:97`, ACL call `:129`, sanitizeDoc `:155`).
+
+- [ ] **Step 2: Edit A — widen the token index gate.** Replace the encounter-only token gate (`:97`):
+
+```java
+                } else if (tokenAuth && !"encounter".equals(EFFECTIVE_INDEX)
+                    && !"annotation".equals(EFFECTIVE_INDEX)
+                    && !"individual".equals(EFFECTIVE_INDEX)) {
+                    response.setStatus(403);
+                    res.put("error", "token search is limited to encounter, annotation, individual");
+```
+
+where `EFFECTIVE_INDEX` is the resolved index expression already used there: `(searchQueryId != null) ? query.optString("indexName", null) : indexName`. Introduce a local `String effectiveIndex = (searchQueryId != null) ? query.optString("indexName", null) : indexName;` right after the stored query is loaded (before the guard ladder) and use it in BOTH this gate and the annotation-admin gate (Edit B).
+
+- [ ] **Step 3: Edit B — resolve effective index before the annotation-admin gate (Codex Medium).** Change the existing annotation-admin gate (`:85`) so it (a) uses `effectiveIndex` not the raw `indexName`, and (b) applies only on the **non-token** path (token path is governed by the ACL filter):
+
+```java
+                } else if (!tokenAuth && "annotation".equals(effectiveIndex) && !isAdmin) {
+                    // session path: annotation API remains admin-only (token path uses the ACL filter)
+                    response.setStatus(403);
+                    res.put("error", 403);
+```
+
+- [ ] **Step 4: Edit C — index-aware ACL injection.** Replace the ACL call (`:129`):
+
+```java
+                    if (tokenAuth && !isAdmin) {
+                        query = OpenSearch.applyAclFilter(query, currentUser.getId(), indexName);
+                    }
+```
+
+- [ ] **Step 5: Edit D — pass tokenAuth to sanitizeDoc.** Replace the sanitize call (`:155`):
+
+```java
+                            hitsArr.put(OpenSearch.sanitizeDoc(doc, indexName, myShepherd,
+                                currentUser, tokenAuth));
+```
+
+- [ ] **Step 6: Write the test**
+
+`src/test/java/org/ecocean/api/SearchApiChildIndexTest.java` — mirror `SearchApiTokenAuthTest`'s Mockito pattern (mock request/response, `mockStatic(ServletUtilities)` for `getContext`/`jsonFromHttpServletRequest`, `mockConstruction(Shepherd)` returning the user, `mockConstruction(OpenSearch)` capturing `queryPit`'s query arg). Tests:
+
+```java
+    // token POST /individual (non-admin) -> allowed, ACL filter uses submitterUserIds, results allowlisted
+    @Test void tokenIndividualSearch_injectsSubmitterUserIdsFilter() throws Exception { /* assert
+        the query passed to queryPit has filter.should containing term submitterUserIds; status 200 */ }
+
+    // token POST /annotation (non-admin) -> allowed, ACL filter applied
+    @Test void tokenAnnotationSearch_allowedAndFiltered() throws Exception { /* status 200, filter present */ }
+
+    // token POST /occurrence -> still 403
+    @Test void tokenOccurrenceSearch_returns403() throws Exception { /* status 403 */ }
+
+    // session (non-token) GET annotation by stored-query whose indexName=annotation, non-admin -> 403
+    // (effective-index resolved before the admin gate)
+    @Test void sessionStoredAnnotationQuery_nonAdmin_403() throws Exception { /* status 403 */ }
+
+    // session (non-token) POST /individual, non-admin -> NOT blocked by token gate (proceeds)
+    @Test void sessionIndividualSearch_notBlocked() throws Exception { /* status 200 */ }
+```
+
+(Use the `EMPTY_HITS` + `mockConstruction<OpenSearch>` capture pattern from `SearchApiTokenAuthTest`; for the individual ACL-filter assertion, check `q.getJSONObject("query").getJSONObject("bool").getJSONArray("filter")...` contains a `submitterUserIds` term.)
+
+- [ ] **Step 7: Run**
+
+Run: `mvn test -Dtest=SearchApiChildIndexTest,SearchApiTokenAuthTest`
+Expected: PASS (new cases + D's existing token tests unchanged). Iterate on SearchApi (not tests) until green.
+
+- [ ] **Step 8: Normalize + commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/java/org/ecocean/api/SearchApi.java src/test/java/org/ecocean/api/SearchApiChildIndexTest.java | xargs -r sed -i 's/\r$//'
+git add src/main/java/org/ecocean/api/SearchApi.java src/test/java/org/ecocean/api/SearchApiChildIndexTest.java
+git commit -m "feat(search): token-expose annotation+individual (effective-index gate, index-aware filter, token sanitize)"
+```
+
+---
+
+### Task 7: Reindex triggers — ACL-change and membership-change propagation to children
+
+When an encounter's ACL changes, its annotations + individual must reindex. When encounter↔individual membership changes (reassign/remove/merge/split), **both** old and new individuals (and the moved encounter's annotations) must reindex.
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/Encounter.java` (`setIndividual`), `src/main/java/org/ecocean/MarkedIndividual.java` (`addEncounter`/`removeEncounter`/`mergeIndividual`), `src/main/java/org/ecocean/servlet/IndividualRemoveEncounter.java`, and the ACL-change path (`Encounter.opensearchIndexPermissions` or its enqueue points).
+- Test: `src/test/java/org/ecocean/ChildReindexTriggerTest.java` (create)
+
+- [ ] **Step 1: Add a reindex-fanout helper on `Encounter`.** In `Encounter.java`:
+
+```java
+    /** Enqueue reindex of this encounter's individual + annotations (children whose denormalized ACL derives from it). */
+    public void enqueueChildAclReindex(Shepherd myShepherd) {
+        try {
+            IndexingManager im = IndexingManagerFactory.getIndexingManager();
+            MarkedIndividual ind = this.getIndividual();
+            if (ind != null) im.addIndexingQueueEntry(ind, false);
+            if (this.getAnnotations() != null)
+                for (Annotation ann : this.getAnnotations()) im.addIndexingQueueEntry(ann, false);
+        } catch (Exception ex) {
+            System.out.println("enqueueChildAclReindex failed for enc " + this.getId() + ": " + ex);
+        }
+    }
+```
+
+- [ ] **Step 2: ACL-change propagation.** In `Encounter.opensearchIndexPermissions` (the bulk pass that updates encounter `viewUsers`, `Encounter.java:~4281`), after a successful `os.indexUpdate("encounter", id, updateData)` for an encounter whose `viewUsers` changed, also enqueue child reindex for that encounter (resolve the `Encounter` object as the invalid-owner branch already does at `:4231`). Because the permissions pass is bulk and may touch many encounters, enqueue child reindex only when the computed `viewUsers`/public actually changed for that doc (compare against the prior indexed value if available, else enqueue). Document this as best-effort, consistent with A.
+
+> Implementation note for the engineer: verify whether `IndexingManager.scheduleIndexingJob` reindexes shallowly (`opensearchIndex()`) or deeply. If shallow, enqueuing the `MarkedIndividual` + each `Annotation` (as above) is correct (each re-serializes itself, recomputing its own ACL union). If it deep-indexes, guard against redundant fan-out. Confirm against `IndexingManager.java` before finalizing.
+
+- [ ] **Step 3: Membership-change hooks (capture OLD + NEW).** At each mutation site, enqueue reindex of the old and new individual (+ the encounter's annotations):
+  - `Encounter.setIndividual(MarkedIndividual indiv)` (`:1245`): capture `MarkedIndividual old = this.individual;` before reassigning; after, enqueue reindex for both `old` and `indiv` (if non-null) and this encounter's annotations.
+  - `MarkedIndividual.removeEncounter` (`:513`) and `addEncounter` (`:468`): enqueue reindex of `this` individual + the encounter's annotations.
+  - `MarkedIndividual.mergeIndividual` (`:2608`): after the merge loop, enqueue reindex of `this` (primary) and `other` (secondary, now empty) + all moved encounters' annotations.
+  - `IndividualRemoveEncounter.java` (`:60`,`:74`): the servlet already mutates via `setIndividual(null)`/`removeEncounter`; ensure the enqueue fires (it will, if the hooks are in the model methods — prefer hooking the model methods over the servlet so all callers are covered).
+
+  Each hook calls a small helper, e.g. on `MarkedIndividual`:
+
+```java
+    void enqueueAclReindex() {
+        try { IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false); }
+        catch (Exception ex) { System.out.println("MarkedIndividual.enqueueAclReindex failed " + this.getId() + ": " + ex); }
+    }
+```
+
+  Prefer placing enqueues in the **model** methods (`setIndividual`/`add`/`removeEncounter`/`mergeIndividual`) so every caller (servlets, bulk import, merge tools) is covered, not just `IndividualRemoveEncounter`.
+
+- [ ] **Step 4: Test (model-level, Mockito).** `ChildReindexTriggerTest` — use `mockStatic(IndexingManagerFactory)` returning a mock `IndexingManager`; call `Encounter.setIndividual(newInd)` on an encounter whose old individual is `oldInd`; verify `addIndexingQueueEntry(oldInd,false)` AND `addIndexingQueueEntry(newInd,false)` were called. Similar for `removeEncounter`/`mergeIndividual`. (Where a method's internals make pure unit testing hard, assert the helper is invoked and cover the end-to-end propagation in Task 9's integration test.)
+
+- [ ] **Step 5: Run + commit**
+
+Run: `mvn test -Dtest=ChildReindexTriggerTest`
+Expected: PASS.
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/main/java/org/ecocean/Encounter.java src/main/java/org/ecocean/MarkedIndividual.java src/main/java/org/ecocean/servlet/IndividualRemoveEncounter.java src/test/java/org/ecocean/ChildReindexTriggerTest.java | xargs -r sed -i 's/\r$//'
+git add -A
+git commit -m "feat(acl): reindex child indices on encounter ACL + individual-membership changes"
+```
+
+---
+
+### Task 8: Mapping migration + corrective reindex runbook
+
+**Files:**
+- Create: `docs/superpowers/runbooks/childindex-acl-reindex.md`
+
+- [ ] **Step 1: Write the runbook** with these operator steps (no code change — the mappings in Tasks 2/3 apply to fresh indices; existing installs need the additive mapping PUT + a reindex):
+  1. **Add the new fields to the live mappings** (additive; OpenSearch allows new fields on an existing mapping). For each of `annotation`, `individual`: `PUT /<index>/_mapping {"properties":{"publiclyReadable":{"type":"boolean"},"submitterUserIds":{"type":"keyword"},"viewUsers":{"type":"keyword"}}}` (individual `viewUsers` already exists via Base).
+  2. **Corrective reindex, in order** (analogue of A's `viewUsers` corrective pass): (a) encounter anonymous-owner correction / full encounter pass; (b) **full annotation reindex** — the long pole (multiple annotations per encounter; can be 100K+ on large installs); (c) full individual reindex. Use the existing full-reindex tooling.
+  3. **Fail-closed note:** until step 2 completes for an index, the new ACL fields are absent → non-admin token reads on that index return nothing (never leaky). Order doesn't risk exposure.
+  4. **Reindex cost note (engineering):** the child serializers compute `computeViewUsers` per parent encounter synchronously (the path A's bulk pass avoids for scale). On large installs this makes the one-time annotation/individual reindex expensive. If measured prohibitive, a follow-up optimization is to extend A's bulk `opensearchIndexPermissions` map-building pass to also write child `viewUsers` via `indexUpdate` (deferred; not required for correctness).
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+git add docs/superpowers/runbooks/childindex-acl-reindex.md
+git commit -m "docs(runbook): child-index ACL mapping migration + corrective reindex"
+```
+
+---
+
+### Task 9: End-to-end integration test (real OpenSearch)
+
+**Files:**
+- Create: `src/test/java/org/ecocean/api/SearchTokenScopeChildIndexTest.java` (sibling of `SearchTokenScopeTest`)
+- Modify: `src/test/resources/shiro.ini` (the token filter is already wired from D; no change needed — the same `/api/v3/search/**` rule covers annotation/individual)
+
+- [ ] **Step 1: Write the integration test** modeled on `SearchTokenScopeTest`'s `@BeforeAll` (Testcontainers OpenSearch+Postgres, embedded Jetty + `SearchApi`, JWT keypair in `CommonConfiguration`, REST Assured). Seeding: index, with the **real** mappings, encounters with mixed ACLs + their annotations (with `publiclyReadable`/`submitterUserIds`/`viewUsers`) + a shared individual spanning multiple owners (with the union fields). Then with a non-admin token (`testy`-style):
+
+```java
+    @Test void tokenAnnotationSearch_scopedToVisibleEncounters() throws Exception {
+        // match_all on /api/v3/search/annotation -> only annotations whose parent encounter is visible;
+        // X-Wildbook-Total-Hits scoped; no publiclyReadable/submitterUserIds/viewUsers in any hit _source;
+        // embeddings present in returned hits.
+    }
+
+    @Test void tokenIndividualSearch_gatedAndAllowlisted() throws Exception {
+        // /api/v3/search/individual -> only individuals with >=1 visible encounter;
+        // returned hits contain ONLY identity fields (id/displayName/names/sex/taxonomy/timeOf*),
+        // NO numberEncounters/users/encounterIds/locationGeoPoints, NO ACL fields.
+    }
+
+    @Test void adminTokenIndividualSearch_full() throws Exception {
+        // admin token -> unscoped, aggregates present, ACL fields still scrubbed.
+    }
+
+    @Test void tokenOccurrenceSearch_403() throws Exception {
+        // /api/v3/search/occurrence with token -> 403 (still deferred).
+    }
+```
+
+- [ ] **Step 2: Run**
+
+Run: `mvn test -Dtest=SearchTokenScopeChildIndexTest` (pulls OpenSearch container; allow minutes). Also re-run `SearchTokenScopeTest` + `EncounterExportImagesTest` to confirm no regression.
+Expected: PASS. If Docker unavailable, `@Disabled("requires Docker/Testcontainers")` with a comment (do not delete), per D's precedent.
+
+- [ ] **Step 3: Normalize + commit**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+grep -lU $'\r' src/test/java/org/ecocean/api/SearchTokenScopeChildIndexTest.java | xargs -r sed -i 's/\r$//'
+git add src/test/java/org/ecocean/api/SearchTokenScopeChildIndexTest.java
+git commit -m "test(search): e2e token-scoped annotation+individual enforcement (real OpenSearch)"
+```
+
+---
+
+### Task 10: Full build, self-review, Codex code review
+
+- [ ] **Step 1: Compile + run the affected unit set**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+mvn -q -DskipTests compile
+mvn test -Dtest=EncounterAclFieldsTest,AnnotationAclSerializerTest,MarkedIndividualAclSerializerTest,OpenSearchAclFilterTest,OpenSearchAclFilterIndexAwareTest,OpenSearchSanitizeDocTest,SearchApiTokenAuthTest,SearchApiChildIndexTest,ChildReindexTriggerTest,EndpointAuthWiringTest,JwtServiceTest,WildbookTokenAuthenticationFilterTest
+```
+Expected: BUILD SUCCESS; all green. (Run the two Testcontainers ITs separately.)
+
+- [ ] **Step 2: LF check**
+
+```bash
+cd /mnt/c/Wildbook-token-auth
+git diff --name-only origin/token-auth-scoped-search..HEAD | xargs -r grep -lU $'\r' || echo "LF-clean"
+```
+
+- [ ] **Step 3: Self-review vs spec** — confirm each spec section maps to a task: ACL fields (T1-3), index-aware filter (T4), universal scrub + allowlist (T5), SearchApi widen + effective-index + token sanitize (T6), triggers incl. membership (T7), mapping/reindex runbook (T8), e2e proof (T9). Confirm parity edges: annotation union/0-parent (T2), individual 0-encounter world-readable (T3), anonymous-vs-invalid owner in the single source (T1).
+
+- [ ] **Step 4: Codex code review** on the full Spec-A diff (`git diff <task-1-parent>..HEAD`), per project convention. Prompt Codex (read-only, may read files) to specifically check: no fail-open for non-admin token on the new indices; allowlist completeness vs the live individual serializer; universal ACL scrub covers session AND token on all three indices; membership-trigger coverage (old+new individual); annotation union over all parents (not just first); anonymous-vs-invalid-owner correctness. Fold findings, re-review until SAFE TO MERGE.
+
+- [ ] **Step 5: Report** to the user: diff summary, test counts, Codex verdict, the carried-forward follow-ups (global session metadata leak; orgAdmin viewUsers verification — now also covers the individual unions), and the reindex-cost note. Await push/PR decision.
+
+---
+
+## Self-Review (plan author)
+
+**Spec coverage:** every spec section maps to a task (see Task 10 Step 3). The four Codex-High spec items are implemented: annotation union (T2), universal ACL scrub (T5), allowlist sanitizer (T5), membership-change triggers (T7).
+
+**Placeholder scan:** Task 6's test bodies and Task 9's integration test are described as method stubs with explicit assertions to fill — they reference concrete patterns (`SearchApiTokenAuthTest`/`SearchTokenScopeTest`) and exact fields to assert. Task 7 Step 2 carries an explicit engineer verification (shallow-vs-deep indexing) rather than a guess — this is a flagged real uncertainty, not a placeholder; the implementer must confirm against `IndexingManager`.
+
+**Type/name consistency:** `opensearchAclFields` (T1) returns `{publiclyReadable, submitterUserId?, viewUsers[]}` and is consumed by `writeAclFields` in T2/T3 (which emit `submitterUserIds` plural unions). `applyAclFilter(query,uuid,indexName)` (T4) uses `submitterUserId` for encounter, `submitterUserIds` for annotation/individual — matching the serializers. `sanitizeDoc(...,tokenAuth)` (T5) is called with `tokenAuth` in T6. `INDIVIDUAL_TOKEN_KEEP` allowlist matches the identity fields the individual serializer emits.

--- a/docs/superpowers/plans/2026-06-07-token-scoped-individual-annotation-plan.md
+++ b/docs/superpowers/plans/2026-06-07-token-scoped-individual-annotation-plan.md
@@ -133,6 +133,9 @@ Add to `Encounter.java` (near `computeViewUsers`, ~`:3389`):
      * submitterUserId is the resolved owner's UUID (absent if the owner is invalid/deleted ->
      * admin-only/fail-closed), and viewUsers is computeViewUsers() (approved/edit collaborators +
      * submitter-org orgAdmins). Anonymous-owned -> public; invalid/deleted non-anonymous owner -> closed.
+     * Semantically equivalent to (not byte-identical with) the encounter index's own serialization
+     * (e.g. for a public encounter we omit submitterUserId since publiclyReadable=true already grants);
+     * the ACCESS DECISION is identical, only the stored field set differs harmlessly.
      */
     public org.json.JSONObject opensearchAclFields(Shepherd myShepherd) {
         org.json.JSONObject acl = new org.json.JSONObject();
@@ -167,7 +170,9 @@ git commit -m "feat(acl): single-source Encounter.opensearchAclFields for child-
 
 ---
 
-### Task 2: Annotation index — ACL fields (union over parent encounter(s))
+### Task 2: Annotation index — ACL fields (single parent's ACL; 0 or >1 parents → fail-closed)
+
+> **Codex High — do NOT union over parents.** The annotation doc carries parent-encounter *metadata* (`encounterId`, `encounterSubmitterId`, `encounterLocationId`, `encounterTaxonomy`, `encounterUserUuid`, `encounterProjectIds`, `encounterIndividualTimeOfDeath`) from `findEncounter()` = the **first** parent. If we granted access by union over all parents, a user authorized via parent B would receive parent A's metadata. So: an annotation gets **its single parent encounter's ACL**; if it has **0 or >1 parents**, fail closed (admin-only) and log. Normal single-parent annotations work; anomalous multi-parent ones are admin-only (admins bypass anyway, and the first-parent metadata is then only ever shown to admins).
 
 **Files:**
 - Modify: `src/main/java/org/ecocean/Encounter.java` (add `findAllByAnnotation`), `src/main/java/org/ecocean/Annotation.java`
@@ -225,19 +230,16 @@ class AnnotationAclSerializerTest {
         return new JSONObject(sw.toString());
     }
 
-    @Test void unionOverParents_privatePlusPublic() throws Exception {
+    @Test void singleParent_usesItsAcl() throws Exception {
         Annotation ann = spy(new Annotation());
         Shepherd sh = mock(Shepherd.class);
-        Encounter encPrivate = mock(Encounter.class);
-        Encounter encPublic = mock(Encounter.class);
-        when(encPrivate.opensearchAclFields(sh)).thenReturn(new JSONObject(
+        Encounter parent = mock(Encounter.class);
+        when(parent.opensearchAclFields(sh)).thenReturn(new JSONObject(
             "{\"publiclyReadable\":false,\"submitterUserId\":\"u1\",\"viewUsers\":[\"v1\"]}"));
-        when(encPublic.opensearchAclFields(sh)).thenReturn(new JSONObject(
-            "{\"publiclyReadable\":true,\"viewUsers\":[]}"));
-        doReturn(Arrays.asList(encPrivate, encPublic)).when(ann).parentEncounters(sh);
+        doReturn(Arrays.asList(parent)).when(ann).parentEncounters(sh);
 
         JSONObject out = serialize(ann, sh);
-        assertTrue(out.getBoolean("publiclyReadable"), "any public parent -> public");
+        assertFalse(out.getBoolean("publiclyReadable"));
         assertTrue(out.getJSONArray("submitterUserIds").toList().contains("u1"));
         assertTrue(out.getJSONArray("viewUsers").toList().contains("v1"));
     }
@@ -250,6 +252,19 @@ class AnnotationAclSerializerTest {
         assertFalse(out.getBoolean("publiclyReadable"), "no parent -> not public");
         assertEquals(0, out.getJSONArray("submitterUserIds").length(), "no parent -> admin-only");
         assertEquals(0, out.getJSONArray("viewUsers").length(), "no parent -> admin-only");
+    }
+
+    @Test void multipleParents_failsClosed() throws Exception {
+        // anomalous: >1 parent -> admin-only (avoids leaking first-parent metadata to a B-authorized user)
+        Annotation ann = spy(new Annotation());
+        Shepherd sh = mock(Shepherd.class);
+        Encounter a = mock(Encounter.class);
+        Encounter b = mock(Encounter.class);
+        doReturn(Arrays.asList(a, b)).when(ann).parentEncounters(sh);
+        JSONObject out = serialize(ann, sh);
+        assertFalse(out.getBoolean("publiclyReadable"), ">1 parent -> not public");
+        assertEquals(0, out.getJSONArray("submitterUserIds").length(), ">1 parent -> admin-only");
+        assertEquals(0, out.getJSONArray("viewUsers").length(), ">1 parent -> admin-only");
     }
 }
 ```
@@ -269,21 +284,30 @@ In `Annotation.java`, add:
         return Encounter.findAllByAnnotation(this, myShepherd);
     }
 
-    /** Write the denormalized ACL union over parent encounter(s); 0 parents -> fail closed (admin-only). */
+    /**
+     * Write the denormalized ACL from this annotation's SINGLE parent encounter.
+     * 0 parents (orphan) or >1 parents (anomalous) -> fail closed (admin-only), because the doc's
+     * encounter* metadata fields come from only the first parent and must not be exposed to a user
+     * authorized via a different parent.
+     */
     public void writeAclFields(com.fasterxml.jackson.core.JsonGenerator jgen, Shepherd myShepherd)
     throws java.io.IOException {
         boolean pub = false;
         java.util.Set<String> submitters = new java.util.LinkedHashSet<String>();
         java.util.Set<String> viewers = new java.util.LinkedHashSet<String>();
-        for (Encounter enc : this.parentEncounters(myShepherd)) {
-            org.json.JSONObject acl = enc.opensearchAclFields(myShepherd);
+        java.util.List<Encounter> parents = this.parentEncounters(myShepherd);
+        if (parents.size() == 1) { // exactly one parent: use its ACL
+            org.json.JSONObject acl = parents.get(0).opensearchAclFields(myShepherd);
             if (acl.optBoolean("publiclyReadable", false)) pub = true;
             String sid = acl.optString("submitterUserId", null);
             if (sid != null) submitters.add(sid);
             org.json.JSONArray vu = acl.optJSONArray("viewUsers");
             if (vu != null) for (int i = 0; i < vu.length(); i++) viewers.add(vu.optString(i));
+        } else if (parents.size() > 1) {
+            System.out.println("Annotation.writeAclFields: " + this.getId() + " has " + parents.size()
+                + " parent encounters -> indexing admin-only (fail closed)");
         }
-        jgen.writeBooleanField("publiclyReadable", pub);
+        jgen.writeBooleanField("publiclyReadable", pub); // false for 0/many parents
         jgen.writeArrayFieldStart("submitterUserIds");
         for (String s : submitters) jgen.writeString(s);
         jgen.writeEndArray();
@@ -299,12 +323,11 @@ Then call it inside `opensearchDocumentSerializer` (after the `encounter*` field
         this.writeAclFields(jgen, myShepherd);
 ```
 
-And add the mapping fields in `opensearchMapping()` (before the `embeddings` block, ~`:182`):
+And add the mapping fields in `opensearchMapping()` (before the `embeddings` block, ~`:182`). `viewUsers` is **already** mapped (keyword) by `Base.opensearchMapping()`, so add only:
 
 ```java
         map.put("publiclyReadable", new JSONObject("{\"type\": \"boolean\"}"));
         map.put("submitterUserIds", keywordType);
-        map.put("viewUsers", keywordType);
 ```
 
 - [ ] **Step 5: Run to verify it passes**
@@ -365,7 +388,8 @@ class MarkedIndividualAclSerializerTest {
             "{\"publiclyReadable\":false,\"submitterUserId\":\"u1\",\"viewUsers\":[\"v1\"]}"));
         when(e2.opensearchAclFields(sh)).thenReturn(new JSONObject(
             "{\"publiclyReadable\":false,\"submitterUserId\":\"u2\",\"viewUsers\":[\"v2\"]}"));
-        doReturn(java.util.Arrays.asList(e1, e2)).when(mi).getEncounters();
+        // getEncounters() returns Vector<Encounter>, not List — stub with a Vector
+        doReturn(new java.util.Vector<Encounter>(java.util.Arrays.asList(e1, e2))).when(mi).getEncounters();
 
         JSONObject out = serialize(mi, sh);
         assertFalse(out.getBoolean("publiclyReadable"));
@@ -376,7 +400,7 @@ class MarkedIndividualAclSerializerTest {
     @Test void zeroEncounters_worldReadable() throws Exception {
         MarkedIndividual mi = spy(new MarkedIndividual());
         Shepherd sh = mock(Shepherd.class);
-        doReturn(java.util.Collections.emptyList()).when(mi).getEncounters();
+        doReturn(new java.util.Vector<Encounter>()).when(mi).getEncounters();
         JSONObject out = serialize(mi, sh);
         assertTrue(out.getBoolean("publiclyReadable"),
             "encounterless individual -> visible to anyone (matches canUserAccessMarkedIndividual)");
@@ -627,6 +651,32 @@ class OpenSearchSanitizeDocTest {
         assertEquals(42, out.getInt("numberEncounters"), "admin keeps aggregates");
         assertFalse(out.has("viewUsers"), "ACL still scrubbed even for admin");
     }
+
+    // Allowlist completeness (Codex High): a doc carrying EVERY field the real individual serializer
+    // emits must, for a non-admin token, retain ONLY the keep-list and drop all aggregates/relations.
+    @Test void individualToken_allowlistDropsAllSerializerAggregates() throws Exception {
+        // every field MarkedIndividual.opensearchDocumentSerializer can emit (pin against current source)
+        JSONObject doc = new JSONObject("{"
+            + "\"id\":\"i1\",\"version\":1,\"indexTimestamp\":1,\"displayName\":\"F\",\"names\":[\"F\"],"
+            + "\"nameMap\":{},\"sex\":\"female\",\"taxonomy\":\"t\",\"timeOfBirth\":\"x\",\"timeOfDeath\":\"y\","
+            + "\"numberEncounters\":5,\"encounterIds\":[\"e\"],\"users\":[\"u\"],\"numberOccurrences\":2,"
+            + "\"cooccurrenceIndividualIds\":[\"c\"],\"cooccurrenceIndividualMap\":{},\"locationGeoPoints\":[{}],"
+            + "\"numberMediaAssets\":3,\"socialUnits\":[{}],\"relationships\":[{}],"
+            + "\"publiclyReadable\":false,\"submitterUserIds\":[\"s\"],\"viewUsers\":[\"v\"]}");
+        Shepherd sh = mock(Shepherd.class);
+        User u = user(false);
+        when(u.isAdmin(sh)).thenReturn(false);
+        JSONObject out = OpenSearch.sanitizeDoc(doc, "individual", sh, u, true);
+        java.util.Set<String> keep = new java.util.HashSet<>(java.util.Arrays.asList(
+            "id","version","indexTimestamp","displayName","names","nameMap","sex","taxonomy",
+            "timeOfBirth","timeOfDeath"));
+        for (String k : out.keySet()) assertTrue(keep.contains(k), "leaked non-allowlisted field: " + k);
+        for (String dropped : new String[]{"numberEncounters","encounterIds","users","numberOccurrences",
+            "cooccurrenceIndividualIds","cooccurrenceIndividualMap","locationGeoPoints","numberMediaAssets",
+            "socialUnits","relationships","publiclyReadable","submitterUserIds","viewUsers"}) {
+            assertFalse(out.has(dropped), "must drop " + dropped);
+        }
+    }
 }
 ```
 
@@ -648,6 +698,13 @@ In `OpenSearch.java`, add the constants + a universal scrub + the allowlist, and
         "id", "version", "indexTimestamp", "displayName", "names", "nameMap",
         "sex", "taxonomy", "timeOfBirth", "timeOfDeath"
     };
+    // NOTE (Codex Medium): the individual serializer also emits socialUnits, relationships,
+    // cooccurrenceIndividualIds/Map, users, encounterIds, numberEncounters/Occurrences/MediaAssets,
+    // locationGeoPoints. These are DELIBERATELY excluded from the keep-list: they are cross-encounter
+    // aggregates and/or reveal connections to OTHER individuals (social/relationship/cooccurrence) that
+    // may be derived from encounters the viewer can't see. They are out of scope for the v1 token
+    // individual view (the agent gets per-viewer detail via the scoped encounter index). If a future
+    // need arises, expose them only with per-viewer filtering — a separate design decision.
 
     private static void scrubAclFields(JSONObject doc) {
         for (String f : ACL_FIELDS) doc.remove(f);
@@ -756,6 +813,16 @@ git commit -m "feat(search): universal ACL-field scrub + token individual allowl
 
 where `EFFECTIVE_INDEX` is the resolved index expression already used there: `(searchQueryId != null) ? query.optString("indexName", null) : indexName`. Introduce a local `String effectiveIndex = (searchQueryId != null) ? query.optString("indexName", null) : indexName;` right after the stored query is loaded (before the guard ladder) and use it in BOTH this gate and the annotation-admin gate (Edit B).
 
+**Edit A.1 — guard a missing/invalid effective index (Codex Medium).** A stored query whose saved `indexName` is null or not a valid index currently slips past the validity checks and 500s at `queryPit`. Add, as an early branch in the ladder (after the token method gates, before the annotation/token gates):
+
+```java
+                } else if (!OpenSearch.isValidIndexName(effectiveIndex)) {
+                    response.setStatus(404);
+                    res.put("error", "unknown index");
+```
+
+(For a direct request `effectiveIndex == indexName`, so this also subsumes the existing `(searchQueryId == null) && !isValidIndexName(indexName)` check — keep one, not both.)
+
 - [ ] **Step 3: Edit B — resolve effective index before the annotation-admin gate (Codex Medium).** Change the existing annotation-admin gate (`:85`) so it (a) uses `effectiveIndex` not the raw `indexName`, and (b) applies only on the **non-token** path (token path is governed by the ACL filter):
 
 ```java
@@ -829,45 +896,51 @@ When an encounter's ACL changes, its annotations + individual must reindex. When
 - Modify: `src/main/java/org/ecocean/Encounter.java` (`setIndividual`), `src/main/java/org/ecocean/MarkedIndividual.java` (`addEncounter`/`removeEncounter`/`mergeIndividual`), `src/main/java/org/ecocean/servlet/IndividualRemoveEncounter.java`, and the ACL-change path (`Encounter.opensearchIndexPermissions` or its enqueue points).
 - Test: `src/test/java/org/ecocean/ChildReindexTriggerTest.java` (create)
 
-- [ ] **Step 1: Add a reindex-fanout helper on `Encounter`.** In `Encounter.java`:
+**Key facts (verified):** `IndexingManager.addIndexingQueueEntry(base,false)` schedules `base.opensearchIndexDeep()` (DEEP). `Encounter.opensearchIndexDeep()` reindexes the encounter **plus its individual and all its annotations** (shallow re-serialize of each — recomputing their ACL). `MarkedIndividual.opensearchIndexDeep()` reindexes the individual + all its member encounters. Deep-index does NOT re-enqueue, so there is no recursion — but enqueuing an individual fans out to all its encounters, so prefer enqueuing the **encounter** (smaller fan-out: encounter → its individual + its annotations) and only enqueue an individual directly for the old-individual-after-reassignment case. `Base.getSkipAutoIndexing()` (and the global auto-index-disabled flag the `WildbookLifecycleListener` already checks) must be honored so bulk import doesn't storm.
+
+- [ ] **Step 1: Add guarded enqueue helpers.** In `Encounter.java`:
 
 ```java
-    /** Enqueue reindex of this encounter's individual + annotations (children whose denormalized ACL derives from it). */
-    public void enqueueChildAclReindex(Shepherd myShepherd) {
+    /** Enqueue a (deep) reindex of this encounter — which re-serializes its individual + annotations
+     *  with fresh ACL. Honors skipAutoIndexing so bulk import / deserialization don't storm. */
+    public void enqueueAclReindex() {
+        if (this.getSkipAutoIndexing()) return;
         try {
-            IndexingManager im = IndexingManagerFactory.getIndexingManager();
-            MarkedIndividual ind = this.getIndividual();
-            if (ind != null) im.addIndexingQueueEntry(ind, false);
-            if (this.getAnnotations() != null)
-                for (Annotation ann : this.getAnnotations()) im.addIndexingQueueEntry(ann, false);
+            IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false);
         } catch (Exception ex) {
-            System.out.println("enqueueChildAclReindex failed for enc " + this.getId() + ": " + ex);
+            System.out.println("Encounter.enqueueAclReindex failed for " + this.getId() + ": " + ex);
         }
     }
 ```
 
-- [ ] **Step 2: ACL-change propagation.** In `Encounter.opensearchIndexPermissions` (the bulk pass that updates encounter `viewUsers`, `Encounter.java:~4281`), after a successful `os.indexUpdate("encounter", id, updateData)` for an encounter whose `viewUsers` changed, also enqueue child reindex for that encounter (resolve the `Encounter` object as the invalid-owner branch already does at `:4231`). Because the permissions pass is bulk and may touch many encounters, enqueue child reindex only when the computed `viewUsers`/public actually changed for that doc (compare against the prior indexed value if available, else enqueue). Document this as best-effort, consistent with A.
-
-> Implementation note for the engineer: verify whether `IndexingManager.scheduleIndexingJob` reindexes shallowly (`opensearchIndex()`) or deeply. If shallow, enqueuing the `MarkedIndividual` + each `Annotation` (as above) is correct (each re-serializes itself, recomputing its own ACL union). If it deep-indexes, guard against redundant fan-out. Confirm against `IndexingManager.java` before finalizing.
-
-- [ ] **Step 3: Membership-change hooks (capture OLD + NEW).** At each mutation site, enqueue reindex of the old and new individual (+ the encounter's annotations):
-  - `Encounter.setIndividual(MarkedIndividual indiv)` (`:1245`): capture `MarkedIndividual old = this.individual;` before reassigning; after, enqueue reindex for both `old` and `indiv` (if non-null) and this encounter's annotations.
-  - `MarkedIndividual.removeEncounter` (`:513`) and `addEncounter` (`:468`): enqueue reindex of `this` individual + the encounter's annotations.
-  - `MarkedIndividual.mergeIndividual` (`:2608`): after the merge loop, enqueue reindex of `this` (primary) and `other` (secondary, now empty) + all moved encounters' annotations.
-  - `IndividualRemoveEncounter.java` (`:60`,`:74`): the servlet already mutates via `setIndividual(null)`/`removeEncounter`; ensure the enqueue fires (it will, if the hooks are in the model methods — prefer hooking the model methods over the servlet so all callers are covered).
-
-  Each hook calls a small helper, e.g. on `MarkedIndividual`:
+  In `MarkedIndividual.java` (used only for the OLD individual after an encounter leaves it):
 
 ```java
-    void enqueueAclReindex() {
-        try { IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false); }
-        catch (Exception ex) { System.out.println("MarkedIndividual.enqueueAclReindex failed " + this.getId() + ": " + ex); }
+    public void enqueueAclReindex() {
+        if (this.getSkipAutoIndexing()) return;
+        try {
+            IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false);
+        } catch (Exception ex) {
+            System.out.println("MarkedIndividual.enqueueAclReindex failed for " + this.getId() + ": " + ex);
+        }
     }
 ```
 
-  Prefer placing enqueues in the **model** methods (`setIndividual`/`add`/`removeEncounter`/`mergeIndividual`) so every caller (servlets, bulk import, merge tools) is covered, not just `IndividualRemoveEncounter`.
+- [ ] **Step 2: ACL-change propagation (collaboration/role/org changes).** These flow through `setPermissionsNeeded(true)` → the bulk `Encounter.opensearchIndexPermissions` pass, which `indexUpdate`s the encounter's `viewUsers` but leaves children stale. Extend that pass so that, for each encounter whose `viewUsers` (or publiclyReadable) it computes, it **detects a change vs the currently-indexed value and, on a diff, enqueues that encounter for deep reindex** (which refreshes its individual + annotations):
+  - The pass already fetches the `Encounter` in the invalid-owner branch (`:4231`); do the same on the change path: `Encounter changed = myShepherd.getEncounter(id); if (changed != null) changed.enqueueAclReindex();`.
+  - Change detection: before `os.indexUpdate(...)`, read the doc's current `viewUsers` (the pass holds an `OpenSearch os`; add a small `os.getViewUsers("encounter", id)` helper, or read via the existing client) and compare to the freshly computed list. Enqueue only on diff to avoid a full child reindex every pass.
+  - This is the highest-risk step; document it as best-effort (a missed propagation is recovered by the periodic reconciler + the corrective reindex), consistent with A.
 
-- [ ] **Step 4: Test (model-level, Mockito).** `ChildReindexTriggerTest` — use `mockStatic(IndexingManagerFactory)` returning a mock `IndexingManager`; call `Encounter.setIndividual(newInd)` on an encounter whose old individual is `oldInd`; verify `addIndexingQueueEntry(oldInd,false)` AND `addIndexingQueueEntry(newInd,false)` were called. Similar for `removeEncounter`/`mergeIndividual`. (Where a method's internals make pure unit testing hard, assert the helper is invoked and cover the end-to-end propagation in Task 9's integration test.)
+- [ ] **Step 3: Membership-change hooks (capture OLD + NEW), in the MODEL methods so all callers are covered.** Enqueue at:
+  - `Encounter.setIndividual(MarkedIndividual indiv)` (`:1245`): `MarkedIndividual old = this.individual;` BEFORE reassigning; after, `this.enqueueAclReindex();` (covers the encounter + its NEW individual + its annotations) and `if (old != null && old != indiv) old.enqueueAclReindex();` (old individual's union shrinks).
+  - `MarkedIndividual.removeEncounter` (`:513`): after removal, `this.enqueueAclReindex();` and `getRidOfMe.enqueueAclReindex();` (the encounter, now individual-less, refreshes its own + annotation ACL).
+  - `MarkedIndividual.addEncounter` (`:468`): after add, `newEncounter.enqueueAclReindex();` (covers the encounter + this individual + annotations).
+  - `MarkedIndividual.mergeIndividual` (`:2608`): after the loop, `this.enqueueAclReindex();` (primary) and `other.enqueueAclReindex();` (secondary, now empty).
+  - `IndividualRemoveEncounter.java` (`:60`,`:74`): no change needed — it calls `setIndividual(null)` + `removeEncounter`, both now hooked.
+
+  Hooking the model methods (not the servlets) ensures bulk import, merge tools, and API paths are all covered. The `skipAutoIndexing` guard in the helpers prevents bulk-import storms; confirm bulk import sets skip on the encounters/individuals it mutates (`BulkImporter` does — verify the flag is set on the objects these methods see).
+
+- [ ] **Step 4: Test (model-level, Mockito).** `ChildReindexTriggerTest` — `mockStatic(IndexingManagerFactory)` returning a mock `IndexingManager`; build an `Encounter enc` (spy) whose current individual is `oldInd` (spy) with `skipAutoIndexing=false`; call `enc.setIndividual(newInd)`. Verify `im.addIndexingQueueEntry(enc, false)` AND `im.addIndexingQueueEntry(oldInd, false)` were called (the encounter covers `newInd` + annotations via deep index; `oldInd` is enqueued directly). Add a `skipAutoIndexing=true` case asserting **no** enqueue. Similar coverage for `removeEncounter`/`mergeIndividual`. (Where a method's internals resist pure unit testing, assert the helper is invoked and rely on Task 9's integration test for end-to-end propagation.)
 
 - [ ] **Step 5: Run + commit**
 

--- a/docs/superpowers/plans/2026-06-08-token-scoped-media-resolve-plan.md
+++ b/docs/superpowers/plans/2026-06-08-token-scoped-media-resolve-plan.md
@@ -1,0 +1,1097 @@
+# Token-Scoped Media Resolve Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a token-gated `POST /api/v3/media/resolve` that turns a batch of annotation IDs the caller may already see into `{imageUrl, imageWidth, imageHeight, bbox (in the returned image's pixel space), theta, viewpoint, encounterId, individualId, methodVersion}`, so a token-only agent can render side-by-side annotation crops for missed-match verification.
+
+**Architecture:** A new `MediaResolveApi extends ApiBase` servlet. Visibility reuses Spec A's exact ACL gate (`OpenSearch.applyAclFilter` over an `ids` query) as the single source of truth — admins bypass it. For each visible annotation it selects a safe derivative (`_master`→`_mid`, rejecting `_original`/`URLAssetStore`/unknown), reads the source-asset and derivative dimensions, and scales+clamps the bbox into the derivative's pixel space. Non-visible/unresolvable IDs are silently absent (no existence oracle). No new index fields, no image proxy, no UI.
+
+**Tech Stack:** Java 17, servlet (`javax.servlet`), DataNucleus JDO (`Shepherd`), OpenSearch, org.json, JUnit 5 + Mockito (`MockedConstruction`/`MockedStatic`), Maven/surefire.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-token-scoped-media-resolve-design.md` (Codex-reviewed).
+
+**Branch:** this Spec A worktree branch (`token-auth-scoped-search`). Do NOT push or open a PR — the user merges/pushes explicitly.
+
+**Repo conventions (read before starting):**
+- JUnit 5 assertions put the message LAST: `assertEquals(expected, actual, "msg")`, `assertTrue(cond, "msg")`.
+- Normalize line endings before every commit: `grep -c $'\r' <file>` must be 0; if not, `sed -i 's/\r$//' <file>`.
+- Run one test class:
+  ```
+  mvn test -Dtest=MediaResolveApiTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xmx2g"
+  ```
+- Commit each task; end every commit message with the trailer:
+  ```
+  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+  ```
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/main/java/org/ecocean/api/MediaResolveApi.java` (**create**) | The endpoint + two static helpers (`scaleBbox`, `selectSafeDerivative`) + per-ID `resolveOne` + the visibility gate. |
+| `src/main/java/org/ecocean/OpenSearch.java` (**modify**) | Widen `buildIdEligibilityQuery` from package-private to `public` so the `api` package can reuse it. |
+| `src/main/webapp/WEB-INF/web.xml` (**modify**) | Register the servlet + url mapping; add the Shiro token-filter rule for `/api/v3/media/**`. |
+| `src/test/java/org/ecocean/api/MediaResolveApiTest.java` (**create**) | Unit + servlet-level tests (helpers, gate, payload, omission, no-oracle, dedup, size guard, validation). |
+| `src/test/java/org/ecocean/api/EndpointAuthWiringTest.java` (**modify**) | Add assertions that the media endpoint is registered + token-gated in web.xml. |
+| `docs/superpowers/runbooks/childindex-acl-reindex.md` (**modify**) | Append the live smoke-test for resolve. |
+
+Reused as-is (do not modify): `OpenSearch.applyAclFilter`, `OpenSearch.queryPit`/`deletePit`, `WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR`/`TOKEN_CONTEXT_ATTR`, `Annotation.getBbox`/`getTheta`/`getViewpoint`/`findEncounter`/`findIndividualId`/`getMediaAsset`/`getEmbeddings`/`getId`, `MediaAsset.findChildrenByLabel`/`getWidth`/`getHeight`/`getStore`/`hasLabel`/`webURL`, `Shepherd.getAnnotation`/`getUser`, `ServletUtilities.jsonFromHttpServletRequest`/`getContext`.
+
+---
+
+## Task 1: `scaleBbox` — pure bbox→derivative-space scaling helper
+
+This is the High-severity Codex fix: `getBbox()` is in the source asset's pixel space, but the served derivative is resized. Pure function → test it directly, no mocks.
+
+**Files:**
+- Create: `src/main/java/org/ecocean/api/MediaResolveApi.java`
+- Test: `src/test/java/org/ecocean/api/MediaResolveApiTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/java/org/ecocean/api/MediaResolveApiTest.java`:
+
+```java
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class MediaResolveApiTest {
+
+    @Test void scaleBbox_identityWhenSameDims() {
+        int[] out = MediaResolveApi.scaleBbox(new int[] {10, 20, 30, 40}, 100, 200, 100, 200);
+        assertArrayEquals(new int[] {10, 20, 30, 40}, out, "same src/dst dims must be identity");
+    }
+
+    @Test void scaleBbox_halfScaleDownscales() {
+        int[] out = MediaResolveApi.scaleBbox(new int[] {100, 200, 300, 400}, 1000, 1000, 500, 500);
+        assertArrayEquals(new int[] {50, 100, 150, 200}, out, "0.5x scale halves every component");
+    }
+
+    @Test void scaleBbox_clampsOverflowToDerivative() {
+        // box runs to x+w=1000 in src; at 0.5x that's 500 == dst width, fine; push past:
+        int[] out = MediaResolveApi.scaleBbox(new int[] {900, 0, 400, 100}, 1000, 1000, 500, 500);
+        // x=450, w would be 200 -> 450+200=650 > 500, clamp w to 50
+        assertArrayEquals(new int[] {450, 0, 50, 50}, out, "overflow width/height clamped to derivative bounds");
+    }
+
+    @Test void scaleBbox_nullOnBadInput() {
+        assertNull(MediaResolveApi.scaleBbox(null, 100, 100, 50, 50), "null src -> null");
+        assertNull(MediaResolveApi.scaleBbox(new int[] {1, 2, 3}, 100, 100, 50, 50), "short src -> null");
+        assertNull(MediaResolveApi.scaleBbox(new int[] {0, 0, 10, 10}, 0, 100, 50, 50), "zero src dim -> null");
+        assertNull(MediaResolveApi.scaleBbox(new int[] {0, 0, 10, 10}, 100, 100, 0, 50), "zero dst dim -> null");
+    }
+
+    @Test void scaleBbox_nullWhenScaledRegionVanishes() {
+        int[] out = MediaResolveApi.scaleBbox(new int[] {0, 0, 1, 1}, 10000, 10000, 5, 5);
+        assertNull(out, "a region that rounds to <1px in the derivative -> null (omit)");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -Dtest=MediaResolveApiTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xmx2g"`
+Expected: FAIL — `MediaResolveApi` does not exist / `scaleBbox` not found (compilation error).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/main/java/org/ecocean/api/MediaResolveApi.java`:
+
+```java
+package org.ecocean.api;
+
+public class MediaResolveApi extends ApiBase {
+
+    /** Max annotation IDs accepted per request. */
+    static final int MAX_IDS = 100;
+
+    /**
+     * Scale an axis-aligned bbox from the source asset's pixel space into the returned
+     * derivative's pixel space, then clamp to the derivative bounds.
+     * Returns null if inputs are invalid or the scaled region is empty (<1px) — caller omits the entry.
+     *
+     * @param src  [x, y, width, height] in source-asset pixels
+     */
+    static int[] scaleBbox(int[] src, double srcW, double srcH, double dstW, double dstH) {
+        if ((src == null) || (src.length < 4)) return null;
+        if ((srcW <= 0) || (srcH <= 0) || (dstW <= 0) || (dstH <= 0)) return null;
+        double sx = dstW / srcW;
+        double sy = dstH / srcH;
+        int x = (int) Math.round(src[0] * sx);
+        int y = (int) Math.round(src[1] * sy);
+        int w = (int) Math.round(src[2] * sx);
+        int h = (int) Math.round(src[3] * sy);
+        int maxW = (int) Math.floor(dstW);
+        int maxH = (int) Math.floor(dstH);
+        if (x < 0) x = 0;
+        if (y < 0) y = 0;
+        if (x > maxW) x = maxW;
+        if (y > maxH) y = maxH;
+        if (x + w > maxW) w = maxW - x;
+        if (y + h > maxH) h = maxH - y;
+        if ((w < 1) || (h < 1)) return null;
+        return new int[] {x, y, w, h};
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the same `mvn test -Dtest=MediaResolveApiTest ...` command.
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
+# if any nonzero: sed -i 's/\r$//' <that file>
+git add src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
+git commit -m "media-resolve: bbox scaling helper into derivative pixel space
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `selectSafeDerivative` — explicit `_master`→`_mid` selection
+
+Codex High/Medium fix: do NOT use `safeURL`/`bestSafeAsset` (returns originals for `URLAssetStore`, returns `this` when self-labeled, and does not fall back master→mid). Select explicitly.
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/api/MediaResolveApi.java`
+- Test: `src/test/java/org/ecocean/api/MediaResolveApiTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Add these imports to the test file (top, after the existing imports):
+
+```java
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import org.ecocean.Annotation;
+import org.ecocean.media.MediaAsset;
+import org.ecocean.media.URLAssetStore;
+import org.ecocean.media.LocalAssetStore;
+import org.ecocean.shepherd.core.Shepherd;
+```
+
+Add these tests to the class:
+
+```java
+    private MediaAsset child(String label, boolean urlStore) {
+        MediaAsset ma = mock(MediaAsset.class);
+        ArrayList<String> labels = new ArrayList<>();
+        labels.add(label);
+        when(ma.getLabels()).thenReturn(labels);
+        when(ma.hasLabel(label)).thenReturn(true);
+        when(ma.getStore()).thenReturn(urlStore ? mock(URLAssetStore.class) : mock(LocalAssetStore.class));
+        return ma;
+    }
+
+    private Annotation annWithSource(MediaAsset src) {
+        Annotation ann = mock(Annotation.class);
+        when(ann.getMediaAsset()).thenReturn(src);
+        return ann;
+    }
+
+    @Test void selectSafeDerivative_prefersMaster() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        MediaAsset master = child("_master", false);
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
+        MediaAsset out = MediaResolveApi.selectSafeDerivative(annWithSource(src), sh);
+        assertSame(master, out, "a _master child must be selected first");
+    }
+
+    @Test void selectSafeDerivative_fallsBackToMidWhenNoMaster() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(null);
+        MediaAsset mid = child("_mid", false);
+        ArrayList<MediaAsset> mids = new ArrayList<>(); mids.add(mid);
+        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(mids);
+        MediaAsset out = MediaResolveApi.selectSafeDerivative(annWithSource(src), sh);
+        assertSame(mid, out, "must fall back to _mid when _master is absent (bestSafeAsset bug bypassed)");
+    }
+
+    @Test void selectSafeDerivative_nullWhenNoSafeDerivative() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(null);
+        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(null);
+        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "no _master/_mid -> null (omit)");
+    }
+
+    @Test void selectSafeDerivative_rejectsUrlAssetStoreSource() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(URLAssetStore.class));
+        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "URLAssetStore source (external original) must be rejected");
+    }
+
+    @Test void selectSafeDerivative_skipsUrlStoreAndOriginalChildren() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        MediaAsset urlChild = child("_master", true); // _master label but URLAssetStore
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(urlChild);
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
+        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(null);
+        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "a URLAssetStore-backed child must be skipped");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
+Expected: FAIL — `selectSafeDerivative` not defined (compile error).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `MediaResolveApi.java` (inside the class). Add imports at the top of the file:
+
+```java
+import java.util.ArrayList;
+
+import org.ecocean.Annotation;
+import org.ecocean.media.MediaAsset;
+import org.ecocean.media.URLAssetStore;
+import org.ecocean.shepherd.core.Shepherd;
+```
+
+Method:
+
+```java
+    /**
+     * Select the safe derivative to serve for an annotation's region: a child of the source asset
+     * labeled _master (preferred) or _mid. Rejects URLAssetStore-backed assets (external/public
+     * originals) and any child also carrying _original. Returns null if none qualifies (caller omits).
+     * Deliberately does NOT use MediaAsset.safeURL/bestSafeAsset, which can return originals for
+     * URLAssetStore and does not fall back from a missing _master to _mid.
+     */
+    static MediaAsset selectSafeDerivative(Annotation ann, Shepherd myShepherd) {
+        if (ann == null) return null;
+        MediaAsset src = ann.getMediaAsset();
+        if (src == null) return null;
+        if (src.getStore() instanceof URLAssetStore) return null;
+        for (String label : new String[] {"_master", "_mid"}) {
+            ArrayList<MediaAsset> kids = src.findChildrenByLabel(myShepherd, label);
+            if (kids == null) continue;
+            for (MediaAsset kid : kids) {
+                if (kid == null) continue;
+                if (kid.getStore() instanceof URLAssetStore) continue;
+                if (kid.hasLabel("_original")) continue;
+                return kid;
+            }
+        }
+        return null;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
+Expected: PASS (10 tests total).
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
+git add src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
+git commit -m "media-resolve: explicit _master/_mid derivative selection
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Widen `buildIdEligibilityQuery` to public
+
+The visibility gate reuses `OpenSearch.buildIdEligibilityQuery(Set<String>)` (builds `{"query":{"ids":{"values":[...]}}}`). It is currently package-private in `org.ecocean`; `MediaResolveApi` is in `org.ecocean.api`, so it must be `public`.
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/OpenSearch.java` (the `static JSONObject buildIdEligibilityQuery` declaration)
+
+- [ ] **Step 1: Make the change**
+
+Find:
+
+```java
+    // Package-visible for testing. Returns the _count-shaped query body that
+    // filters on _id ∈ ids, using OpenSearch's idiomatic `ids` query.
+    static JSONObject buildIdEligibilityQuery(Set<String> ids) {
+```
+
+Replace the comment + signature with:
+
+```java
+    // Returns a query body that filters on _id ∈ ids, using OpenSearch's idiomatic `ids` query.
+    // Public so the media-resolve endpoint (org.ecocean.api) can reuse the exact id-eligibility shape.
+    public static JSONObject buildIdEligibilityQuery(Set<String> ids) {
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `mvn -q -o test-compile -DargLine="-Xmx2g" 2>&1 | tail -5` (offline compile; if `-o` fails due to missing deps, drop `-o`).
+Expected: BUILD SUCCESS (no compile errors).
+
+- [ ] **Step 3: Normalize + commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/OpenSearch.java
+git add src/main/java/org/ecocean/OpenSearch.java
+git commit -m "OpenSearch: make buildIdEligibilityQuery public for media-resolve reuse
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Endpoint skeleton — token-path enforcement + body validation + JSON writer
+
+Codex Low fix: require `TOKEN_AUTH_ATTR`, use the filter-verified context, never fall back to a session. Validate the body before any DB/OpenSearch work.
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/api/MediaResolveApi.java`
+- Test: `src/test/java/org/ecocean/api/MediaResolveApiTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Add imports to the test file:
+
+```java
+import static org.mockito.ArgumentMatchers.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.ecocean.User;
+import org.ecocean.security.WildbookTokenAuthenticationFilter;
+import org.ecocean.servlet.ServletUtilities;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+```
+
+Add a nested helper + tests (these exercise `doPost`):
+
+```java
+    /** Build a token-auth request mock; body comes from the ServletUtilities static mock. */
+    private HttpServletRequest tokenRequest() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getMethod()).thenReturn("POST");
+        when(req.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR)).thenReturn(Boolean.TRUE);
+        when(req.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_CONTEXT_ATTR)).thenReturn("context0");
+        return req;
+    }
+
+    private User mockUser(String id, boolean admin) {
+        User u = mock(User.class);
+        when(u.getId()).thenReturn(id);
+        return u;
+    }
+
+    private MockedConstruction<Shepherd> shepherd(User user, boolean admin) {
+        return mockConstruction(Shepherd.class, (m, c) -> {
+            doNothing().when(m).beginDBTransaction();
+            doNothing().when(m).setAction(anyString());
+            doNothing().when(m).rollbackAndClose();
+            when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
+            when(user.isAdmin(m)).thenReturn(admin);
+        });
+    }
+
+    @Test void doPost_non_token_request_401() throws Exception {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getMethod()).thenReturn("POST");
+        when(req.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR)).thenReturn(Boolean.FALSE);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        new MediaResolveApi().doPostForTest(req, resp);
+        verify(resp).setStatus(401);
+    }
+
+    @Test void doPost_empty_ids_400() throws Exception {
+        HttpServletRequest req = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = shepherd(mockUser("u1", false), false)) {
+            su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject("{\"annotationIds\":[]}"));
+            new MediaResolveApi().doPostForTest(req, resp);
+        }
+        verify(resp).setStatus(400);
+    }
+
+    @Test void doPost_over_max_ids_400() throws Exception {
+        HttpServletRequest req = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        JSONArray big = new JSONArray();
+        for (int i = 0; i < MediaResolveApi.MAX_IDS + 1; i++) big.put("id-" + i);
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = shepherd(mockUser("u1", false), false)) {
+            su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", big));
+            new MediaResolveApi().doPostForTest(req, resp);
+        }
+        verify(resp).setStatus(400);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
+Expected: FAIL — `doPostForTest` not defined / `doPost` logic absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add imports to `MediaResolveApi.java`:
+
+```java
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.User;
+import org.ecocean.Util;
+import org.ecocean.security.WildbookTokenAuthenticationFilter;
+import org.ecocean.servlet.ServletUtilities;
+import org.json.JSONArray;
+import org.json.JSONObject;
+```
+
+Add the servlet methods. `doPostForTest` is a thin package-visible delegate so tests can invoke the logic directly (mirrors how the servlet container would call `doPost`):
+
+```java
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+    throws ServletException, IOException {
+        handle(request, response);
+    }
+
+    // package-visible entry point for unit tests
+    void doPostForTest(HttpServletRequest request, HttpServletResponse response)
+    throws IOException {
+        handle(request, response);
+    }
+
+    private void handle(HttpServletRequest request, HttpServletResponse response)
+    throws IOException {
+        boolean tokenAuth = Boolean.TRUE.equals(
+            request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR));
+        if (!tokenAuth) {
+            writeError(response, 401, "token auth required");
+            return;
+        }
+        String tokenContext = (String) request.getAttribute(
+            WildbookTokenAuthenticationFilter.TOKEN_CONTEXT_ATTR);
+        String context = (tokenContext != null) ? tokenContext : ServletUtilities.getContext(request);
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("api.MediaResolveApi.POST");
+        myShepherd.beginDBTransaction();
+        try {
+            User currentUser = myShepherd.getUser(request);
+            if ((currentUser == null) || (currentUser.getId() == null)) {
+                writeError(response, 401, "unauthorized");
+                return;
+            }
+            JSONObject body = ServletUtilities.jsonFromHttpServletRequest(request);
+            JSONArray idArr = (body != null) ? body.optJSONArray("annotationIds") : null;
+            if ((idArr == null) || (idArr.length() == 0) || (idArr.length() > MAX_IDS)) {
+                writeError(response, 400, "annotationIds must be a non-empty array of <= " + MAX_IDS);
+                return;
+            }
+            Set<String> ids = new LinkedHashSet<>();
+            for (int i = 0; i < idArr.length(); i++) {
+                String s = idArr.optString(i, null);
+                if (Util.stringExists(s)) ids.add(s);
+            }
+            if (ids.isEmpty()) {
+                writeError(response, 400, "annotationIds must contain at least one valid id");
+                return;
+            }
+            boolean isAdmin = currentUser.isAdmin(myShepherd);
+            Set<String> visible = isAdmin ? ids : gatedVisibleIds(ids, currentUser.getId());
+            JSONArray results = new JSONArray();
+            for (String id : visible) {
+                JSONObject entry = resolveOne(id, myShepherd);
+                if (entry != null) results.put(entry);
+            }
+            response.setStatus(200);
+            writeBody(response, results.toString());
+        } catch (Exception ex) {
+            response.setStatus(500);
+            writeBody(response, new JSONObject().put("error", "resolve failed").toString());
+            ex.printStackTrace();
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private void writeError(HttpServletResponse response, int status, String msg) throws IOException {
+        response.setStatus(status);
+        writeBody(response, new JSONObject().put("error", msg).toString());
+    }
+
+    private void writeBody(HttpServletResponse response, String s) throws IOException {
+        response.setHeader("Content-Type", "application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(s);
+        response.getWriter().close();
+    }
+```
+
+This references `gatedVisibleIds` and `resolveOne`, added in Tasks 5–6. To compile now, add temporary stubs at the end of the class (they will be replaced):
+
+```java
+    private Set<String> gatedVisibleIds(Set<String> ids, String userId) throws IOException {
+        return ids; // TEMP — replaced in Task 5
+    }
+
+    private JSONObject resolveOne(String annotationId, Shepherd myShepherd) {
+        return null; // TEMP — replaced in Task 6
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
+Expected: PASS (13 tests total). The validation tests pass; the resolve loop is a no-op (stubs) for now.
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
+git add src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
+git commit -m "media-resolve: endpoint skeleton, token-path enforcement, body validation
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Visibility gate — reuse Spec A ACL filter, sized to ID count
+
+Codex Medium fix: set query `size` to the de-duplicated ID count (SearchApi's default 10 would silently drop visible IDs beyond 10). Admin bypasses the gate (handled in Task 4).
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/api/MediaResolveApi.java` (replace the `gatedVisibleIds` stub)
+- Test: `src/test/java/org/ecocean/api/MediaResolveApiTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the test file. This mocks the constructed `OpenSearch` so no live cluster is needed, and proves the size guard (>10 ids) and that the visible subset is taken from the ACL-gated hits:
+
+```java
+    private JSONObject hitsFor(String... idsThatPass) {
+        JSONArray hits = new JSONArray();
+        for (String id : idsThatPass) hits.put(new JSONObject().put("_id", id));
+        return new JSONObject().put("hits",
+            new JSONObject().put("total", new JSONObject().put("value", idsThatPass.length))
+                            .put("hits", hits));
+    }
+
+    @Test void gate_returns_only_acl_passing_ids_and_sizes_to_id_count() throws Exception {
+        // 12 requested ids; OpenSearch (mocked) returns all 12 as visible -> proves size>=12, not 10.
+        JSONArray req = new JSONArray();
+        String[] all = new String[12];
+        for (int i = 0; i < 12; i++) { all[i] = "ann-" + i; req.put(all[i]); }
+
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+
+        final int[] capturedSize = {-1};
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("viewer", false);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(false);
+                 // resolveOne loads each annotation: return null so the loop is a no-op here
+                 when(m.getAnnotation(anyString())).thenReturn(null);
+             });
+             MockedConstruction<org.ecocean.OpenSearch> os = mockConstruction(org.ecocean.OpenSearch.class,
+                 (m, c) -> {
+                     doNothing().when(m).deletePit(anyString());
+                     when(m.queryPit(eq("annotation"), any(), eq(0), anyInt(), any(), any()))
+                         .thenAnswer(inv -> { capturedSize[0] = inv.getArgument(3); return hitsFor(all); });
+                 })) {
+            su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", req));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(200);
+        assertEquals(12, capturedSize[0], "gate query size must equal the de-duplicated id count, not the default 10");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
+Expected: FAIL — `capturedSize` stays -1 because the stub `gatedVisibleIds` never calls OpenSearch.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add import to `MediaResolveApi.java`:
+
+```java
+import org.ecocean.OpenSearch;
+```
+
+Replace the temporary `gatedVisibleIds` stub with:
+
+```java
+    /**
+     * Visibility gate (non-admin): reuse Spec A's exact annotation ACL filter over an ids query.
+     * Returns the subset of requested ids the token may see. Query size is set to the id count so
+     * none are dropped by the default page size.
+     */
+    private Set<String> gatedVisibleIds(Set<String> ids, String userId) throws IOException {
+        JSONObject query = OpenSearch.buildIdEligibilityQuery(ids);
+        query = OpenSearch.applyAclFilter(query, userId, "annotation");
+        OpenSearch os = new OpenSearch();
+        os.deletePit("annotation");
+        JSONObject res = os.queryPit("annotation", query, 0, ids.size(), null, null);
+        Set<String> visible = new LinkedHashSet<>();
+        JSONObject outer = (res != null) ? res.optJSONObject("hits") : null;
+        JSONArray hits = (outer != null) ? outer.optJSONArray("hits") : null;
+        if (hits != null) {
+            for (int i = 0; i < hits.length(); i++) {
+                JSONObject h = hits.optJSONObject(i);
+                if (h == null) continue;
+                String hid = h.optString("_id", null);
+                if (Util.stringExists(hid)) visible.add(hid);
+            }
+        }
+        return visible;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
+Expected: PASS (14 tests total).
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
+git add src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
+git commit -m "media-resolve: ACL visibility gate reusing Spec A filter, sized to id count
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Per-ID resolution + response assembly + omission
+
+Wires the helpers (`selectSafeDerivative`, `scaleBbox`) and metadata into one response entry; fail-closed omission on any missing piece. Codex Medium: `encounterId`/`individualId` use `findEncounter`'s first parent (documented multi-parent behavior).
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/api/MediaResolveApi.java` (replace the `resolveOne` stub)
+- Test: `src/test/java/org/ecocean/api/MediaResolveApiTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Add imports to the test file:
+
+```java
+import java.net.URL;
+import org.ecocean.Encounter;
+import org.ecocean.media.LocalAssetStore;
+```
+
+Add tests:
+
+```java
+    /** A fully-populated annotation whose 1000x1000 source has a 500x500 _master derivative. */
+    private Annotation fullAnnotation(String id, String encId, String indId) throws Exception {
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.getWidth()).thenReturn(1000.0);
+        when(src.getHeight()).thenReturn(1000.0);
+
+        MediaAsset master = mock(MediaAsset.class);
+        when(master.getStore()).thenReturn(mock(LocalAssetStore.class));
+        ArrayList<String> labels = new ArrayList<>(); labels.add("_master");
+        when(master.getLabels()).thenReturn(labels);
+        when(master.hasLabel("_master")).thenReturn(true);
+        when(master.hasLabel("_original")).thenReturn(false);
+        when(master.getWidth()).thenReturn(500.0);
+        when(master.getHeight()).thenReturn(500.0);
+        when(master.webURL()).thenReturn(new URL("https://h/wildbook_data_dir/x/" + id + "-master.jpg"));
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
+
+        Annotation ann = mock(Annotation.class);
+        when(ann.getId()).thenReturn(id);
+        when(ann.getMediaAsset()).thenReturn(src);
+        when(src.findChildrenByLabel(any(Shepherd.class), eq("_master"))).thenReturn(masters);
+        when(ann.getBbox()).thenReturn(new int[] {100, 200, 300, 400});
+        when(ann.getTheta()).thenReturn(0.0);
+        when(ann.getViewpoint()).thenReturn("up");
+        Encounter enc = mock(Encounter.class);
+        when(enc.getId()).thenReturn(encId);
+        when(ann.findEncounter(any(Shepherd.class))).thenReturn(enc);
+        when(ann.findIndividualId(any(Shepherd.class))).thenReturn(indId);
+        when(ann.getEmbeddings()).thenReturn(null);
+        return ann;
+    }
+
+    @Test void resolve_payload_scaledBbox_and_derivativeUrl() throws Exception {
+        Annotation ann = fullAnnotation("ann-A", "enc-A", "ind-A");
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin", true);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true); // admin path: no OpenSearch gate
+                 when(m.getAnnotation("ann-A")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-A")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(200);
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(1, arr.length(), "one entry resolved");
+        JSONObject e = arr.getJSONObject(0);
+        assertEquals("ann-A", e.getString("id"), "id echoed");
+        assertTrue(e.getString("imageUrl").endsWith("-master.jpg"), "serves the _master derivative url");
+        assertEquals(500, e.getInt("imageWidth"), "imageWidth is the derivative width");
+        assertEquals(500, e.getInt("imageHeight"), "imageHeight is the derivative height");
+        // src 1000x1000 -> dst 500x500 is 0.5x: [100,200,300,400] -> [50,100,150,200]
+        assertEquals("[50,100,150,200]", e.getJSONArray("bbox").toString(),
+            "bbox scaled into derivative pixel space, not raw source coords");
+        assertEquals("up", e.getString("viewpoint"), "viewpoint passed through");
+        assertEquals("enc-A", e.getString("encounterId"), "first-parent encounter id");
+        assertEquals("ind-A", e.getString("individualId"), "individual id");
+    }
+
+    @Test void resolve_omits_unresolvable_and_is_not_an_existence_oracle() throws Exception {
+        Annotation good = fullAnnotation("ann-good", "enc-1", "ind-1");
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin", true);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-good")).thenReturn(good);
+                 when(m.getAnnotation("ann-garbage")).thenReturn(null); // nonexistent
+             })) {
+            su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds",
+                  new JSONArray().put("ann-good").put("ann-garbage")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(200);
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(1, arr.length(), "garbage/nonexistent id is silently absent (no existence oracle)");
+        assertEquals("ann-good", arr.getJSONObject(0).getString("id"), "only the resolvable id returned");
+    }
+
+    @Test void resolve_dedups_repeated_ids() throws Exception {
+        Annotation good = fullAnnotation("ann-d", "enc-d", "ind-d");
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin", true);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-d")).thenReturn(good);
+             })) {
+            su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds",
+                  new JSONArray().put("ann-d").put("ann-d").put("ann-d")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(1, arr.length(), "duplicate ids collapse to a single entry");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
+Expected: FAIL — `resolveOne` stub returns null, so `resolve_payload_*` gets an empty array.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add imports to `MediaResolveApi.java`:
+
+```java
+import java.net.URL;
+
+import org.ecocean.Embedding;
+import org.ecocean.Encounter;
+```
+
+Replace the temporary `resolveOne` stub with:
+
+```java
+    /**
+     * Resolve one visible annotation into a response entry, or null to omit (fail-closed) when any
+     * required piece is missing: annotation, source asset, dimensions, safe derivative, bbox, or url.
+     * encounterId/individualId use findEncounter's first parent (documented multi-parent behavior;
+     * multi-parent annotations are admin-only in the index so a non-admin never reaches here for them).
+     */
+    private JSONObject resolveOne(String annotationId, Shepherd myShepherd) {
+        Annotation ann = myShepherd.getAnnotation(annotationId);
+        if (ann == null) return null;
+        MediaAsset src = ann.getMediaAsset();
+        if (src == null) return null;
+        double srcW = src.getWidth();
+        double srcH = src.getHeight();
+        if ((srcW <= 0) || (srcH <= 0)) return null;
+        MediaAsset deriv = selectSafeDerivative(ann, myShepherd);
+        if (deriv == null) return null;
+        double dstW = deriv.getWidth();
+        double dstH = deriv.getHeight();
+        if ((dstW <= 0) || (dstH <= 0)) return null;
+        int[] scaled = scaleBbox(ann.getBbox(), srcW, srcH, dstW, dstH);
+        if (scaled == null) return null;
+        URL url = deriv.webURL();
+        if (url == null) return null;
+
+        JSONObject e = new JSONObject();
+        e.put("id", ann.getId());
+        e.put("imageUrl", url.toString());
+        e.put("imageWidth", (int) dstW);
+        e.put("imageHeight", (int) dstH);
+        JSONArray bb = new JSONArray();
+        for (int v : scaled) bb.put(v);
+        e.put("bbox", bb);
+        e.put("theta", ann.getTheta());
+        String vp = ann.getViewpoint();
+        e.put("viewpoint", (vp != null) ? vp : JSONObject.NULL);
+        Encounter enc = ann.findEncounter(myShepherd);
+        e.put("encounterId", (enc != null) ? enc.getId() : JSONObject.NULL);
+        String indId = ann.findIndividualId(myShepherd);
+        e.put("individualId",
+            (Util.stringExists(indId) && !"None".equalsIgnoreCase(indId)) ? indId : JSONObject.NULL);
+        JSONArray mvs = new JSONArray();
+        LinkedHashSet<String> seen = new LinkedHashSet<>();
+        if (ann.getEmbeddings() != null) {
+            for (Embedding emb : ann.getEmbeddings()) {
+                String mv = (emb != null) ? emb.getMethodVersion() : null;
+                if (Util.stringExists(mv) && seen.add(mv)) mvs.put(mv);
+            }
+        }
+        e.put("methodVersion", mvs);
+        return e;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
+Expected: PASS (17 tests total).
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
+git add src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
+git commit -m "media-resolve: per-id resolution, scaled-bbox payload, fail-closed omission
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Register the servlet + Shiro token rule in web.xml (+ wiring test)
+
+**Files:**
+- Modify: `src/main/webapp/WEB-INF/web.xml`
+- Modify: `src/test/java/org/ecocean/api/EndpointAuthWiringTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `EndpointAuthWiringTest.java` (mirror the existing `authToken_*` assertions — they assert against the raw web.xml text via the test's existing `fullText()` helper):
+
+```java
+    @Test
+    void mediaResolve_servletClassIsRegistered() {
+        assertTrue(fullText().contains("<servlet-class>org.ecocean.api.MediaResolveApi</servlet-class>"),
+                "web.xml must register the MediaResolveApi servlet");
+    }
+
+    @Test
+    void mediaResolve_urlPatternIsRegistered() {
+        assertTrue(fullText().contains("<url-pattern>/api/v3/media/resolve</url-pattern>"),
+                "web.xml must map /api/v3/media/resolve");
+    }
+
+    @Test
+    void mediaResolve_shiroRuleIsTokenGated() {
+        String ruleLine = fullText().lines()
+                .map(String::trim)
+                .filter(t -> !t.startsWith("#") && t.contains("/api/v3/media/"))
+                .findFirst().orElse(null);
+        assertNotNull(ruleLine, "Shiro [urls] must contain a rule line for /api/v3/media/");
+        assertTrue(ruleLine.contains("tokenAuthSearch"),
+                "Shiro rule for /api/v3/media/ must use the token filter (was: '" + ruleLine + "')");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -Dtest=EndpointAuthWiringTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xmx2g"`
+Expected: FAIL (3 new assertions) — web.xml has no media entries yet.
+
+- [ ] **Step 3: Make the web.xml changes**
+
+(a) In the Shiro `[urls]` block, immediately after the line `/api/v3/search/** = tokenAuthSearch`, add:
+
+```
+				/api/v3/media/** = tokenAuthSearch
+```
+
+(b) In the servlet-registration section (near the other `org.ecocean.api.*` servlets, e.g. after the `ApiUserInfo` servlet+mapping), add:
+
+```xml
+	<servlet>
+		<servlet-name>MediaResolveApi</servlet-name>
+		<servlet-class>org.ecocean.api.MediaResolveApi</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>MediaResolveApi</servlet-name>
+		<url-pattern>/api/v3/media/resolve</url-pattern>
+	</servlet-mapping>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the `mvn test -Dtest=EndpointAuthWiringTest ...` command.
+Expected: PASS (existing + 3 new).
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+grep -c $'\r' src/main/webapp/WEB-INF/web.xml src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
+git add src/main/webapp/WEB-INF/web.xml src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
+git commit -m "media-resolve: register servlet + token-gated shiro rule for /api/v3/media
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Runbook smoke-test addendum
+
+**Files:**
+- Modify: `docs/superpowers/runbooks/childindex-acl-reindex.md`
+
+- [ ] **Step 1: Append the smoke test**
+
+Add this section to the end of `docs/superpowers/runbooks/childindex-acl-reindex.md`:
+
+````markdown
+---
+
+## 6. Media-resolve smoke test (Spec: token-scoped media resolve)
+
+No reindex is needed for `POST /api/v3/media/resolve` (no new index fields). After deploying the
+endpoint, verify with tokens (see `jwt-keypair-setup.md` + `POST /api/v3/auth/token`):
+
+```bash
+# admin token: resolve the two salamander missed-match candidate annotations -> image url + scaled bbox
+curl -s -X POST "$HOST/api/v3/media/resolve" -H "Authorization: Bearer $ADMIN_TOK" \
+  -H 'Content-Type: application/json' \
+  -d '{"annotationIds":["<ann-BGBI_22-168>","<ann-BGBI_23-2716>"]}'
+# -> 200, JSON array with 2 entries: imageUrl (…-master.jpg or …-mid.jpg), imageWidth/Height,
+#    bbox in that image's pixel space, theta, viewpoint, encounterId, individualId, methodVersion.
+# Fetch each imageUrl and confirm it returns image bytes (HTTP 200).
+
+# non-admin token: an annotation whose parent encounter the user cannot see resolves to empty
+curl -s -X POST "$HOST/api/v3/media/resolve" -H "Authorization: Bearer $RESEARCHER_TOK" \
+  -H 'Content-Type: application/json' -d '{"annotationIds":["<private-annotation-id>"]}'
+# -> 200 with [] (silently absent; indistinguishable from a nonexistent id — no existence oracle)
+
+# no token -> 401
+curl -s -o /dev/null -w '%{http_code}\n' -X POST "$HOST/api/v3/media/resolve" \
+  -H 'Content-Type: application/json' -d '{"annotationIds":["x"]}'
+# -> 401
+```
+
+Sanity-check the bbox: crop the returned `imageUrl` to `bbox` — it should frame the animal region the
+embedding was computed from. The bbox is already in the returned image's pixel space (no client
+scaling needed); `imageWidth`/`imageHeight` are provided for verification.
+````
+
+- [ ] **Step 2: Normalize + commit**
+
+```bash
+grep -c $'\r' docs/superpowers/runbooks/childindex-acl-reindex.md
+git add docs/superpowers/runbooks/childindex-acl-reindex.md
+git commit -m "media-resolve: add live smoke-test to childindex-acl-reindex runbook
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] Run the full new test class once more, plus the wiring test:
+  ```
+  mvn test -Dtest=MediaResolveApiTest,EndpointAuthWiringTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -Xmx2g"
+  ```
+  Expected: all green.
+- [ ] `git log --oneline` shows 8 focused commits.
+- [ ] Confirm no temporary stubs remain in `MediaResolveApi.java` (grep for `TEMP`).
+- [ ] Hand off to Codex code review (per the user's standing rule) before any PR/merge.
+- [ ] Do NOT push or open a PR — the user does that explicitly.
+```

--- a/docs/superpowers/plans/2026-06-08-token-scoped-media-resolve-plan.md
+++ b/docs/superpowers/plans/2026-06-08-token-scoped-media-resolve-plan.md
@@ -86,6 +86,17 @@ class MediaResolveApiTest {
         assertNull(MediaResolveApi.scaleBbox(new int[] {0, 0, 10, 10}, 100, 100, 0, 50), "zero dst dim -> null");
     }
 
+    @Test void scaleBbox_negativeOriginClampsCornerAndShrinksWidth() {
+        // src bbox starts at x=-10; clamping the LEFT corner to 0 must shrink width to 10, not keep 20.
+        int[] out = MediaResolveApi.scaleBbox(new int[] {-10, 0, 20, 20}, 100, 100, 100, 100);
+        assertArrayEquals(new int[] {0, 0, 10, 20}, out, "negative origin clamps corner and shrinks width");
+    }
+
+    @Test void scaleBbox_fullyOutsideReturnsNull() {
+        int[] out = MediaResolveApi.scaleBbox(new int[] {-50, -50, 20, 20}, 100, 100, 100, 100);
+        assertNull(out, "a box entirely outside the image collapses to <1px -> null (omit)");
+    }
+
     @Test void scaleBbox_nullWhenScaledRegionVanishes() {
         int[] out = MediaResolveApi.scaleBbox(new int[] {0, 0, 1, 1}, 10000, 10000, 5, 5);
         assertNull(out, "a region that rounds to <1px in the derivative -> null (omit)");
@@ -122,20 +133,22 @@ public class MediaResolveApi extends ApiBase {
         if ((srcW <= 0) || (srcH <= 0) || (dstW <= 0) || (dstH <= 0)) return null;
         double sx = dstW / srcW;
         double sy = dstH / srcH;
-        int x = (int) Math.round(src[0] * sx);
-        int y = (int) Math.round(src[1] * sy);
-        int w = (int) Math.round(src[2] * sx);
-        int h = (int) Math.round(src[3] * sy);
         int maxW = (int) Math.floor(dstW);
         int maxH = (int) Math.floor(dstH);
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > maxW) x = maxW;
-        if (y > maxH) y = maxH;
-        if (x + w > maxW) w = maxW - x;
-        if (y + h > maxH) h = maxH - y;
+        // Scale BOTH corners, clamp each corner to the derivative bounds, THEN derive w/h.
+        // (Clamping only the origin and keeping the scaled w/h would mis-size a negative-origin box.)
+        long x1 = clamp(Math.round(src[0] * sx), 0, maxW);
+        long y1 = clamp(Math.round(src[1] * sy), 0, maxH);
+        long x2 = clamp(Math.round(((long) src[0] + src[2]) * sx), 0, maxW);
+        long y2 = clamp(Math.round(((long) src[1] + src[3]) * sy), 0, maxH);
+        int w = (int) (x2 - x1);
+        int h = (int) (y2 - y1);
         if ((w < 1) || (h < 1)) return null;
-        return new int[] {x, y, w, h};
+        return new int[] {(int) x1, (int) y1, w, h};
+    }
+
+    private static long clamp(long v, long lo, long hi) {
+        return (v < lo) ? lo : (v > hi ? hi : v);
     }
 }
 ```
@@ -143,7 +156,7 @@ public class MediaResolveApi extends ApiBase {
 - [ ] **Step 4: Run test to verify it passes**
 
 Run the same `mvn test -Dtest=MediaResolveApiTest ...` command.
-Expected: PASS (5 tests).
+Expected: PASS (7 tests).
 
 - [ ] **Step 5: Normalize + commit**
 
@@ -177,6 +190,7 @@ import java.util.ArrayList;
 import org.ecocean.Annotation;
 import org.ecocean.media.MediaAsset;
 import org.ecocean.media.URLAssetStore;
+import org.ecocean.media.YouTubeAssetStore;
 import org.ecocean.media.LocalAssetStore;
 import org.ecocean.shepherd.core.Shepherd;
 ```
@@ -241,7 +255,7 @@ Add these tests to the class:
             "URLAssetStore source (external original) must be rejected");
     }
 
-    @Test void selectSafeDerivative_skipsUrlStoreAndOriginalChildren() {
+    @Test void selectSafeDerivative_skipsUrlStoreChildren() {
         Shepherd sh = mock(Shepherd.class);
         MediaAsset src = mock(MediaAsset.class);
         when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
@@ -250,7 +264,30 @@ Add these tests to the class:
         when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
         when(src.findChildrenByLabel(sh, "_mid")).thenReturn(null);
         assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-            "a URLAssetStore-backed child must be skipped");
+            "a non-local (URLAssetStore) child must be skipped");
+    }
+
+    @Test void selectSafeDerivative_rejectsYouTubeStoreSource() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(YouTubeAssetStore.class));
+        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "YouTubeAssetStore source (webURL is a watch page, not image bytes) must be rejected");
+    }
+
+    @Test void selectSafeDerivative_skipsMasterAlsoLabeledOriginal_fallsBackToMid() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        MediaAsset masterButOriginal = child("_master", false);
+        when(masterButOriginal.hasLabel("_original")).thenReturn(true); // also carries _original
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(masterButOriginal);
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
+        MediaAsset mid = child("_mid", false);
+        ArrayList<MediaAsset> mids = new ArrayList<>(); mids.add(mid);
+        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(mids);
+        assertSame(mid, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "a _master child also labeled _original is skipped; falls back to _mid");
     }
 ```
 
@@ -268,7 +305,7 @@ import java.util.ArrayList;
 
 import org.ecocean.Annotation;
 import org.ecocean.media.MediaAsset;
-import org.ecocean.media.URLAssetStore;
+import org.ecocean.media.LocalAssetStore;
 import org.ecocean.shepherd.core.Shepherd;
 ```
 
@@ -277,8 +314,10 @@ Method:
 ```java
     /**
      * Select the safe derivative to serve for an annotation's region: a child of the source asset
-     * labeled _master (preferred) or _mid. Rejects URLAssetStore-backed assets (external/public
-     * originals) and any child also carrying _original. Returns null if none qualifies (caller omits).
+     * labeled _master (preferred) or _mid. Both the source and the chosen derivative must be backed
+     * by a LocalAssetStore — an ALLOWLIST, not a denylist: this rejects URLAssetStore (external/public
+     * originals) AND YouTubeAssetStore (webURL is a watch page, not cropable image bytes). Also skips
+     * any child carrying _original. Returns null if none qualifies (caller omits).
      * Deliberately does NOT use MediaAsset.safeURL/bestSafeAsset, which can return originals for
      * URLAssetStore and does not fall back from a missing _master to _mid.
      */
@@ -286,13 +325,13 @@ Method:
         if (ann == null) return null;
         MediaAsset src = ann.getMediaAsset();
         if (src == null) return null;
-        if (src.getStore() instanceof URLAssetStore) return null;
+        if (!(src.getStore() instanceof LocalAssetStore)) return null;
         for (String label : new String[] {"_master", "_mid"}) {
             ArrayList<MediaAsset> kids = src.findChildrenByLabel(myShepherd, label);
             if (kids == null) continue;
             for (MediaAsset kid : kids) {
                 if (kid == null) continue;
-                if (kid.getStore() instanceof URLAssetStore) continue;
+                if (!(kid.getStore() instanceof LocalAssetStore)) continue;
                 if (kid.hasLabel("_original")) continue;
                 return kid;
             }
@@ -304,14 +343,14 @@ Method:
 - [ ] **Step 4: Run test to verify it passes**
 
 Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
-Expected: PASS (10 tests total).
+Expected: PASS (14 tests total).
 
 - [ ] **Step 5: Normalize + commit**
 
 ```bash
 grep -c $'\r' src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
 git add src/main/java/org/ecocean/api/MediaResolveApi.java src/test/java/org/ecocean/api/MediaResolveApiTest.java
-git commit -m "media-resolve: explicit _master/_mid derivative selection
+git commit -m "media-resolve: explicit local-store _master/_mid derivative selection
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```
@@ -406,16 +445,6 @@ Add a nested helper + tests (these exercise `doPost`):
         return u;
     }
 
-    private MockedConstruction<Shepherd> shepherd(User user, boolean admin) {
-        return mockConstruction(Shepherd.class, (m, c) -> {
-            doNothing().when(m).beginDBTransaction();
-            doNothing().when(m).setAction(anyString());
-            doNothing().when(m).rollbackAndClose();
-            when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
-            when(user.isAdmin(m)).thenReturn(admin);
-        });
-    }
-
     @Test void doPost_non_token_request_401() throws Exception {
         HttpServletRequest req = mock(HttpServletRequest.class);
         when(req.getMethod()).thenReturn("POST");
@@ -427,17 +456,32 @@ Add a nested helper + tests (these exercise `doPost`):
         verify(resp).setStatus(401);
     }
 
-    @Test void doPost_empty_ids_400() throws Exception {
+    @Test void doPost_token_but_missing_context_401_noShepherd() throws Exception {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getMethod()).thenReturn("POST");
+        when(req.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR)).thenReturn(Boolean.TRUE);
+        when(req.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_CONTEXT_ATTR)).thenReturn(null);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class)) {
+            new MediaResolveApi().doPostForTest(req, resp);
+            assertTrue(sh.constructed().isEmpty(), "no Shepherd may be constructed without a verified context");
+        }
+        verify(resp).setStatus(401);
+    }
+
+    @Test void doPost_empty_ids_400_noShepherd() throws Exception {
         HttpServletRequest req = tokenRequest();
         HttpServletResponse resp = mock(HttpServletResponse.class);
         StringWriter out = new StringWriter();
         when(resp.getWriter()).thenReturn(new PrintWriter(out));
         try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
-             MockedConstruction<Shepherd> sh = shepherd(mockUser("u1", false), false)) {
-            su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class)) {
             su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
               .thenReturn(new JSONObject("{\"annotationIds\":[]}"));
             new MediaResolveApi().doPostForTest(req, resp);
+            assertTrue(sh.constructed().isEmpty(), "body validation must happen before any Shepherd/DB work");
         }
         verify(resp).setStatus(400);
     }
@@ -450,11 +494,25 @@ Add a nested helper + tests (these exercise `doPost`):
         JSONArray big = new JSONArray();
         for (int i = 0; i < MediaResolveApi.MAX_IDS + 1; i++) big.put("id-" + i);
         try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
-             MockedConstruction<Shepherd> sh = shepherd(mockUser("u1", false), false)) {
-            su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class)) {
             su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
               .thenReturn(new JSONObject().put("annotationIds", big));
             new MediaResolveApi().doPostForTest(req, resp);
+        }
+        verify(resp).setStatus(400);
+    }
+
+    @Test void doPost_malformed_body_400() throws Exception {
+        HttpServletRequest req = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class)) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenThrow(new org.json.JSONException("bad json"));
+            new MediaResolveApi().doPostForTest(req, resp);
+            assertTrue(sh.constructed().isEmpty(), "malformed body must be rejected before Shepherd construction");
         }
         verify(resp).setStatus(400);
     }
@@ -509,9 +567,38 @@ Add the servlet methods. `doPostForTest` is a thin package-visible delegate so t
             writeError(response, 401, "token auth required");
             return;
         }
-        String tokenContext = (String) request.getAttribute(
+        // Verified context ONLY — never fall back to ServletUtilities.getContext() (no session on
+        // this endpoint, so a caller must not be able to steer context via ?context=/cookie/host).
+        String context = (String) request.getAttribute(
             WildbookTokenAuthenticationFilter.TOKEN_CONTEXT_ATTR);
-        String context = (tokenContext != null) ? tokenContext : ServletUtilities.getContext(request);
+        if (!Util.stringExists(context)) {
+            writeError(response, 401, "unauthorized");
+            return;
+        }
+        // Parse + validate the body BEFORE constructing a Shepherd or touching the DB/OpenSearch.
+        // Malformed JSON throws here -> 400 (not the 500 a later broad catch would give).
+        Set<String> ids;
+        try {
+            JSONObject body = ServletUtilities.jsonFromHttpServletRequest(request);
+            JSONArray idArr = (body != null) ? body.optJSONArray("annotationIds") : null;
+            if ((idArr == null) || (idArr.length() == 0) || (idArr.length() > MAX_IDS)) {
+                writeError(response, 400, "annotationIds must be a non-empty array of <= " + MAX_IDS);
+                return;
+            }
+            ids = new LinkedHashSet<>();
+            for (int i = 0; i < idArr.length(); i++) {
+                String s = idArr.optString(i, null);
+                if (Util.stringExists(s)) ids.add(s);
+            }
+            if (ids.isEmpty()) {
+                writeError(response, 400, "annotationIds must contain at least one valid id");
+                return;
+            }
+        } catch (Exception ex) {
+            writeError(response, 400, "malformed request body");
+            return;
+        }
+
         Shepherd myShepherd = new Shepherd(context);
         myShepherd.setAction("api.MediaResolveApi.POST");
         myShepherd.beginDBTransaction();
@@ -519,21 +606,6 @@ Add the servlet methods. `doPostForTest` is a thin package-visible delegate so t
             User currentUser = myShepherd.getUser(request);
             if ((currentUser == null) || (currentUser.getId() == null)) {
                 writeError(response, 401, "unauthorized");
-                return;
-            }
-            JSONObject body = ServletUtilities.jsonFromHttpServletRequest(request);
-            JSONArray idArr = (body != null) ? body.optJSONArray("annotationIds") : null;
-            if ((idArr == null) || (idArr.length() == 0) || (idArr.length() > MAX_IDS)) {
-                writeError(response, 400, "annotationIds must be a non-empty array of <= " + MAX_IDS);
-                return;
-            }
-            Set<String> ids = new LinkedHashSet<>();
-            for (int i = 0; i < idArr.length(); i++) {
-                String s = idArr.optString(i, null);
-                if (Util.stringExists(s)) ids.add(s);
-            }
-            if (ids.isEmpty()) {
-                writeError(response, 400, "annotationIds must contain at least one valid id");
                 return;
             }
             boolean isAdmin = currentUser.isAdmin(myShepherd);
@@ -582,7 +654,7 @@ This references `gatedVisibleIds` and `resolveOne`, added in Tasks 5–6. To com
 - [ ] **Step 4: Run test to verify it passes**
 
 Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
-Expected: PASS (13 tests total). The validation tests pass; the resolve loop is a no-op (stubs) for now.
+Expected: PASS (19 tests total). The validation/auth tests pass; the resolve loop is a no-op (stubs) for now.
 
 - [ ] **Step 5: Normalize + commit**
 
@@ -729,6 +801,9 @@ Add imports to the test file:
 
 ```java
 import java.net.URL;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.ecocean.Embedding;
 import org.ecocean.Encounter;
 import org.ecocean.media.LocalAssetStore;
 ```
@@ -860,12 +935,142 @@ Add tests:
         JSONArray arr = new JSONArray(out.toString());
         assertEquals(1, arr.length(), "duplicate ids collapse to a single entry");
     }
+
+    @Test void resolve_nonAdmin_onlyGateVisibleResolved_noOracle_andNoLoadForHidden() throws Exception {
+        // Non-admin: OpenSearch gate returns ONLY "ann-vis". Hidden (real-but-invisible) and garbage
+        // ids must be absent AND must never trigger a Shepherd.getAnnotation load.
+        Annotation vis = fullAnnotation("ann-vis", "enc-v", "ind-v");
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("viewer", false);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(false);
+                 when(m.getAnnotation("ann-vis")).thenReturn(vis);
+             });
+             MockedConstruction<org.ecocean.OpenSearch> os = mockConstruction(org.ecocean.OpenSearch.class,
+                 (m, c) -> {
+                     doNothing().when(m).deletePit(anyString());
+                     when(m.queryPit(eq("annotation"), any(), eq(0), anyInt(), any(), any()))
+                         .thenReturn(hitsFor("ann-vis")); // only ann-vis passes the ACL gate
+                 })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds",
+                  new JSONArray().put("ann-vis").put("ann-hidden").put("ann-garbage")));
+            new MediaResolveApi().doPostForTest(request, resp);
+            Shepherd constructed = sh.constructed().get(0);
+            verify(constructed, never()).getAnnotation("ann-hidden");
+            verify(constructed, never()).getAnnotation("ann-garbage");
+        }
+        verify(resp).setStatus(200);
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(1, arr.length(), "non-admin sees only gate-passed ids; hidden/garbage absent (no oracle)");
+        assertEquals("ann-vis", arr.getJSONObject(0).getString("id"), "only the visible id resolved");
+    }
+
+    @Test void resolve_nonAdmin_moreThan10VisibleAllResolve() throws Exception {
+        // 12 visible ids -> all 12 must appear in the response (proves no default-10 truncation end-to-end).
+        JSONArray reqIds = new JSONArray();
+        String[] all = new String[12];
+        for (int i = 0; i < 12; i++) { all[i] = "ann-" + i; reqIds.put(all[i]); }
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("viewer", false);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(false);
+                 when(m.getAnnotation(anyString())).thenAnswer(inv -> {
+                     String id = inv.getArgument(0);
+                     return fullAnnotation(id, "enc-" + id, "ind-" + id);
+                 });
+             });
+             MockedConstruction<org.ecocean.OpenSearch> os = mockConstruction(org.ecocean.OpenSearch.class,
+                 (m, c) -> {
+                     doNothing().when(m).deletePit(anyString());
+                     when(m.queryPit(eq("annotation"), any(), eq(0), anyInt(), any(), any()))
+                         .thenReturn(hitsFor(all));
+                 })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", reqIds));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(200);
+        assertEquals(12, new JSONArray(out.toString()).length(), "all 12 visible ids resolve (no default-10 truncation)");
+    }
+
+    @Test void resolve_thetaDefault_and_nullViewpoint() throws Exception {
+        Annotation ann = fullAnnotation("ann-t", "enc-t", "ind-t");
+        when(ann.getViewpoint()).thenReturn(null);
+        when(ann.getTheta()).thenReturn(0.0);
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin", true);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-t")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-t")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        JSONObject e = new JSONArray(out.toString()).getJSONObject(0);
+        assertTrue(e.isNull("viewpoint"), "null viewpoint serialized as JSON null");
+        assertEquals(0.0, e.getDouble("theta"), 0.0001, "theta defaults to 0.0");
+    }
+
+    @Test void resolve_methodVersion_dedupAndOrder() throws Exception {
+        Annotation ann = fullAnnotation("ann-m", "enc-m", "ind-m");
+        Embedding e1 = mock(Embedding.class); when(e1.getMethodVersion()).thenReturn("msv4.1");
+        Embedding e2 = mock(Embedding.class); when(e2.getMethodVersion()).thenReturn("msv4.1");
+        Embedding e3 = mock(Embedding.class); when(e3.getMethodVersion()).thenReturn("msv3");
+        Set<Embedding> embs = new LinkedHashSet<>(); embs.add(e1); embs.add(e2); embs.add(e3);
+        when(ann.getEmbeddings()).thenReturn(embs);
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin", true);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-m")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-m")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        JSONArray mvs = new JSONArray(out.toString()).getJSONObject(0).getJSONArray("methodVersion");
+        assertEquals("[\"msv4.1\",\"msv3\"]", mvs.toString(), "method versions de-duplicated, first-seen order");
+    }
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
-Expected: FAIL — `resolveOne` stub returns null, so `resolve_payload_*` gets an empty array.
+Expected: FAIL — `resolveOne` stub returns null, so `resolve_payload_*` and the new resolution tests get empty arrays.
 
 - [ ] **Step 3: Write minimal implementation**
 
@@ -937,7 +1142,7 @@ Replace the temporary `resolveOne` stub with:
 - [ ] **Step 4: Run test to verify it passes**
 
 Run the `mvn test -Dtest=MediaResolveApiTest ...` command.
-Expected: PASS (17 tests total).
+Expected: PASS (27 tests total).
 
 - [ ] **Step 5: Normalize + commit**
 
@@ -975,14 +1180,20 @@ Add to `EndpointAuthWiringTest.java` (mirror the existing `authToken_*` assertio
     }
 
     @Test
-    void mediaResolve_shiroRuleIsTokenGated() {
-        String ruleLine = fullText().lines()
-                .map(String::trim)
-                .filter(t -> !t.startsWith("#") && t.contains("/api/v3/media/"))
+    void mediaResolve_shiroRuleIsTokenFilterOnly() {
+        // Mirror searchPath_wiredToTokenFilterOnly: exact value equality, not a loose contains().
+        String ruleLine = lines.stream()
+                .filter(l -> {
+                    String t = l.stripLeading();
+                    return !t.startsWith("#") && t.contains("/api/v3/media/**");
+                })
                 .findFirst().orElse(null);
-        assertNotNull(ruleLine, "Shiro [urls] must contain a rule line for /api/v3/media/");
-        assertTrue(ruleLine.contains("tokenAuthSearch"),
-                "Shiro rule for /api/v3/media/ must use the token filter (was: '" + ruleLine + "')");
+        assertNotNull(ruleLine, "Shiro [urls] must contain a rule for /api/v3/media/**");
+        String value = ruleLine.substring(
+                ruleLine.indexOf("/api/v3/media/**") + "/api/v3/media/**".length()).trim();
+        if (value.startsWith("=")) value = value.substring(1).trim();
+        assertEquals("tokenAuthSearch", value,
+                "media path must map to tokenAuthSearch ONLY (no authc/roles chained); was: '" + value + "'");
     }
 ```
 

--- a/docs/superpowers/runbooks/childindex-acl-reindex.md
+++ b/docs/superpowers/runbooks/childindex-acl-reindex.md
@@ -1,0 +1,119 @@
+# Child-Index ACL Migration + Corrective Reindex (Spec A)
+
+This runbook covers deploying the token-scoped individual + annotation reads (Spec A). It adds
+denormalized ACL fields (`publiclyReadable`, `submitterUserIds`, `viewUsers`) to the **annotation**
+and **individual** OpenSearch indices so the token pre-filter can gate them by encounter access.
+Existing installs need a one-time mapping addition + corrective reindex; fresh installs index the
+fields automatically.
+
+---
+
+## What changed (code)
+
+- The annotation serializer now writes its single parent encounter's ACL (`publiclyReadable`/
+  `submitterUserIds`/`viewUsers`); 0 or >1 parents → fail-closed (admin-only).
+- The individual serializer now writes the **union** over member encounters' ACL; an encounterless
+  individual → `publiclyReadable=true` (world-readable, matching `canUserAccessMarkedIndividual`).
+- All three fields are computed from one source (`Encounter.opensearchAclFields`), so encounter,
+  annotation, and individual ACLs agree.
+- Reindex triggers refresh children on ACL changes (the permissions pass enqueues a changed
+  encounter's deep reindex) and on encounter↔individual membership changes (reassign/merge/split).
+- `viewUsers` is already in `Base.opensearchMapping()`; only `publiclyReadable` (boolean) and
+  `submitterUserIds` (keyword) are new in the annotation/individual mappings.
+
+---
+
+## 1. Add the new fields to the live mappings (additive)
+
+OpenSearch allows adding fields to an existing mapping without recreating the index. For both the
+`annotation` and `individual` indices:
+
+```bash
+# annotation
+curl -s -X PUT "$OS_URL/annotation/_mapping" -H 'Content-Type: application/json' -d '{
+  "properties": {
+    "publiclyReadable": { "type": "boolean" },
+    "submitterUserIds": { "type": "keyword" }
+  }
+}'
+# individual
+curl -s -X PUT "$OS_URL/individual/_mapping" -H 'Content-Type: application/json' -d '{
+  "properties": {
+    "publiclyReadable": { "type": "boolean" },
+    "submitterUserIds": { "type": "keyword" }
+  }
+}'
+```
+
+(`viewUsers` is already mapped as `keyword` on both via the `Base` mapping — do not re-add it.)
+No drop/recreate is required. If you prefer a clean index version, create new indices from the
+updated mappings and reindex into them instead.
+
+---
+
+## 2. One-time corrective reindex (ordered)
+
+Backfill the new fields onto existing docs. Run **in this order** (analogue of Artifact A's
+`viewUsers` corrective pass), using the install's existing full-reindex tooling:
+
+1. **Encounter pass** — ensures encounter `viewUsers`/`publiclyReadable`/`submitterUserId` are current
+   (the source the children derive from). Run the existing Artifact A corrective `viewUsers` reindex /
+   permissions pass first. Anonymous-owned encounters must be `publiclyReadable=true`; invalid/deleted
+   non-anonymous owners stay admin-only (fail-closed) — this is handled by `Encounter.opensearchAclFields`.
+2. **Annotation reindex (THE LONG POLE)** — there are typically several annotations per encounter, so
+   on large installs this is the biggest job (can be 100K+ docs). Full reindex of the `annotation` index.
+3. **Individual reindex** — full reindex of the `individual` index (computes the union per individual).
+
+After this one-time pass, the reindex triggers keep the fields current incrementally; there is no
+ongoing bulk cost.
+
+---
+
+## 3. Fail-closed during reindex (safe ordering)
+
+Until step 2 completes for an index, the new ACL fields are simply **absent** on those child docs →
+the token pre-filter's `should` clauses match nothing → a non-admin token sees **nothing** on that
+index (admins are unaffected; they bypass the filter). A partial or in-progress reindex therefore
+degrades to "too restrictive," **never** "leaky." Order does not create an exposure window.
+
+---
+
+## 4. Engineering note — reindex cost
+
+The child serializers compute `Encounter.computeViewUsers` per related encounter at serialize time
+(the per-doc computation Artifact A's bulk pass was designed to avoid for scale). This makes the
+one-time annotation/individual reindex (step 2/3) CPU- and DB-heavy on large installs. It is a
+one-time cost; incremental updates afterward are cheap (single-object deep reindex on change).
+
+If the one-time reindex proves prohibitively slow on a very large install, a deferred optimization is
+to extend Artifact A's bulk `opensearchIndexPermissions` map-building pass (which already builds the
+collaboration/org maps once) to also write child `viewUsers` via `indexUpdate`, rather than
+recomputing per child doc. This is an optimization only — not required for correctness — and is
+intentionally out of scope for the initial Spec A implementation.
+
+---
+
+## 5. Verify (smoke test)
+
+After the reindex, with a non-admin researcher's token (see `jwt-keypair-setup.md` + `POST
+/api/v3/auth/token`):
+
+```bash
+# individual: only individuals with >=1 visible encounter; response carries identity fields only
+curl -s -X POST "$HOST/api/v3/search/individual" -H "Authorization: Bearer $TOK" \
+  -H 'Content-Type: application/json' -d '{"query":{"match_all":{}}}'
+# -> hits contain id/displayName/names/sex/taxonomy only; NO numberEncounters/users/encounterIds;
+#    NO publiclyReadable/submitterUserIds/viewUsers; X-Wildbook-Total-Hits is the scoped count.
+
+# annotation: only annotations whose parent encounter is visible; embeddings present; no ACL fields
+curl -s -X POST "$HOST/api/v3/search/annotation" -H "Authorization: Bearer $TOK" \
+  -H 'Content-Type: application/json' -d '{"query":{"match_all":{}}}'
+
+# occurrence/media_asset via token -> 403 (still deferred)
+curl -s -o /dev/null -w '%{http_code}\n' -X POST "$HOST/api/v3/search/occurrence" \
+  -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' -d '{"query":{"match_all":{}}}'
+# -> 403
+```
+
+Compare an **admin** token: it is unscoped (sees all individuals/annotations), with the internal ACL
+fields still scrubbed from responses.

--- a/docs/superpowers/runbooks/childindex-acl-reindex.md
+++ b/docs/superpowers/runbooks/childindex-acl-reindex.md
@@ -117,3 +117,34 @@ curl -s -o /dev/null -w '%{http_code}\n' -X POST "$HOST/api/v3/search/occurrence
 
 Compare an **admin** token: it is unscoped (sees all individuals/annotations), with the internal ACL
 fields still scrubbed from responses.
+
+---
+
+## 6. Media-resolve smoke test (Spec: token-scoped media resolve)
+
+No reindex is needed for `POST /api/v3/media/resolve` (no new index fields). After deploying the
+endpoint, verify with tokens (see `jwt-keypair-setup.md` + `POST /api/v3/auth/token`):
+
+```bash
+# admin token: resolve the two salamander missed-match candidate annotations -> image url + scaled bbox
+curl -s -X POST "$HOST/api/v3/media/resolve" -H "Authorization: Bearer $ADMIN_TOK" \
+  -H 'Content-Type: application/json' \
+  -d '{"annotationIds":["<ann-BGBI_22-168>","<ann-BGBI_23-2716>"]}'
+# -> 200, JSON array with 2 entries: imageUrl (…-master.jpg or …-mid.jpg), imageWidth/Height,
+#    bbox in that image's pixel space, theta, viewpoint, encounterId, individualId, methodVersion.
+# Fetch each imageUrl and confirm it returns image bytes (HTTP 200).
+
+# non-admin token: an annotation whose parent encounter the user cannot see resolves to empty
+curl -s -X POST "$HOST/api/v3/media/resolve" -H "Authorization: Bearer $RESEARCHER_TOK" \
+  -H 'Content-Type: application/json' -d '{"annotationIds":["<private-annotation-id>"]}'
+# -> 200 with [] (silently absent; indistinguishable from a nonexistent id — no existence oracle)
+
+# no token -> 401
+curl -s -o /dev/null -w '%{http_code}\n' -X POST "$HOST/api/v3/media/resolve" \
+  -H 'Content-Type: application/json' -d '{"annotationIds":["x"]}'
+# -> 401
+```
+
+Sanity-check the bbox: crop the returned `imageUrl` to `bbox` — it should frame the animal region the
+embedding was computed from. The bbox is already in the returned image's pixel space (no client
+scaling needed); `imageWidth`/`imageHeight` are provided for verification.

--- a/docs/superpowers/runbooks/jwt-keypair-setup.md
+++ b/docs/superpowers/runbooks/jwt-keypair-setup.md
@@ -1,0 +1,98 @@
+# JWT Keypair Setup — Wildbook Scoped-Access Tokens
+
+This runbook covers generating the RSA-2048 keypair for `POST /api/v3/auth/token`,
+configuring Wildbook, and maintaining key hygiene + rotation.
+
+---
+
+## 1. Generate an RSA-2048 Keypair
+
+Run these commands on a secure workstation (not inside the container):
+
+```bash
+# 1. Generate the RSA-2048 private key in PEM form
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out jwt_private.pem
+
+# 2. Produce the Base64-encoded PKCS8 DER form → value for jwtPrivateKeyBase64
+openssl pkcs8 -topk8 -nocrypt -in jwt_private.pem -outform DER | base64 -w0
+
+# 3. Produce the Base64-encoded X.509 DER public key → value for jwtPublicKeyBase64
+openssl rsa -in jwt_private.pem -pubout -outform DER | base64 -w0
+```
+
+Copy the output of steps 2 and 3 into `commonConfiguration.properties` (see below).
+**Immediately restrict the PEM file permissions** (`chmod 600 jwt_private.pem`).
+
+---
+
+## 2. `commonConfiguration.properties` Keys
+
+Add these to the Docker-mounted `commonConfiguration.properties` (never to the git-tracked one):
+
+```properties
+# Required — Base64(PKCS8 DER) of the RSA-2048 private key (Wildbook signs tokens)
+jwtPrivateKeyBase64=<output of step 2 above>
+
+# Recommended — Base64(X.509 DER) of the RSA-2048 public key (optional Wildbook-side verify)
+jwtPublicKeyBase64=<output of step 3 above>
+
+# JWT issuer claim — default: wildbook
+jwtIssuer=wildbook
+
+# JWT audience claim — default: wildbook-scoped-api
+jwtAudience=wildbook-scoped-api
+
+# Token lifetime in seconds — default: 1800 (30 min), clamped to [60, 86400]
+jwtTtlSeconds=1800
+
+# Optional: sets the JWT 'kid' header for key rotation (see section 4)
+# jwtKeyId=v1
+
+# Optional: the context tokens are pinned to — default: context0
+# Do NOT derive this from the HTTP request; it is a server-side configuration value.
+# jwtContext=context0
+```
+
+All keys are read via `CommonConfiguration.getProperty(key, context)`.
+
+---
+
+## 3. Signing Split: Wildbook vs. Kernel
+
+| Component | Holds | Purpose |
+|---|---|---|
+| Wildbook | **Private key** (`jwtPrivateKeyBase64`) | Signs / mints tokens |
+| External scoped-query kernel | **Public key** (`jwtPublicKeyBase64` output) | Verifies token signature |
+
+- Wildbook signs (`RS256`); the kernel verifies. The public key is distributed to the kernel
+  **out of band** (config, not an endpoint — a JWKS endpoint is a planned follow-up).
+- If `jwtPrivateKeyBase64` is **unset**, `POST /api/v3/auth/token` returns **503
+  Service Unavailable** (`{"success":false,"error":"token issuance not configured"}`).
+- The public key (`jwtPublicKeyBase64`) is optional from Wildbook's perspective; its absence
+  only disables the Wildbook-side `JwtService.verify()` path (used in tests and future auditing).
+
+---
+
+## 4. Key Rotation
+
+1. **Generate a new keypair** (steps 1–3 above). Assign a distinct `jwtKeyId`, e.g. `v2`.
+2. **Distribute the new public key** to the kernel. Configure the kernel to accept BOTH
+   the old (`v1`) and new (`v2`) public keys, selected by the `kid` JWT header claim.
+   The kernel must keep the old public key for **at least one full TTL** after the new key
+   is deployed so that in-flight tokens minted with the old key continue to verify.
+3. **Update Wildbook** `commonConfiguration.properties`: set `jwtPrivateKeyBase64` to the
+   new private key and set `jwtKeyId=v2`. Reload/restart Wildbook.
+4. After the old TTL window has elapsed (all tokens signed with `v1` have expired), remove
+   the old public key from the kernel configuration.
+
+---
+
+## 5. Secret Hygiene
+
+- **NEVER commit** the private key (PEM or Base64) to git. It belongs only in the
+  Docker-mounted `commonConfiguration.properties`, which is excluded from version control.
+- **chmod 600** any `.pem` or key file on disk immediately after creation.
+- **Never log** the `jwtPrivateKeyBase64` value, the raw PEM, or any minted token string.
+  Wildbook's logging does not emit these, but verify any custom log lines before adding them.
+- Rotate immediately if there is any suspicion the private key was exposed.
+- The Base64 config value should be treated with the same care as a database password.

--- a/docs/superpowers/specs/2026-05-29-wildbook-acl-prereqs-design.md
+++ b/docs/superpowers/specs/2026-05-29-wildbook-acl-prereqs-design.md
@@ -104,7 +104,7 @@ Each must explicitly enqueue permissions-recompute for the affected encounters (
 
 Net-new, additive. No token/JWT/API-key infrastructure exists today (only Shiro HTTP Basic). Keep this off Artifact A's clean security diff.
 
-### B1 — `POST /api/auth/token` (short-lived token issuance)
+### B1 — `POST /api/v3/auth/token` (short-lived token issuance)
 - Gated by the **existing** Shiro authentication (an already-authenticated user calls it).
 - Mints a short-lived **signed** token. Claims: subject = user UUID, `context`, `iss`, `aud`, `jti`, `exp` (~30–60 min), `iat`. **No** admin/orgAdmin/role claims (privileges are resolved fresh by the kernel per request).
 - Signing: **asymmetric** (decided — the service runs remote). Wildbook holds the private signing key; the remote kernel validates with the public key only, so a kernel compromise cannot mint tokens. Key id in header + rotation support.

--- a/docs/superpowers/specs/2026-05-29-wildbook-acl-prereqs-design.md
+++ b/docs/superpowers/specs/2026-05-29-wildbook-acl-prereqs-design.md
@@ -1,0 +1,133 @@
+# Wildbook ACL Prerequisites — Design Spec
+
+**Date:** 2026-05-29
+**Status:** Draft — incorporated Codex design review (2026-05-29); pending user approval
+**Repo:** Wildbook (this repo)
+**Related specs:** [AI Co-Scientist + Scoped Query Kernel](2026-05-29-ai-coscientist-design.md)
+**Related memory:** `project_viewusers_acl_bug.md`, `project_ai_coscientist.md`
+
+## Purpose
+
+The AI Co-Scientist project (separate spec) needs a *sound* authorization boundary so an external read-only service can scope OpenSearch queries to exactly the data a given Wildbook user may see. A code review (Codex, 2026-05-29, verified in source) found that Wildbook's existing `viewUsers[]` OpenSearch ACL field — already relied on by Wildbook's *own* search via `Encounter.opensearchAccess` and `EncounterQueryProcessor` — is **not trustworthy as written**. This spec covers the Wildbook-side prerequisites:
+
+- **Artifact A — `viewUsers` ACL hardening.** A standalone security bugfix. Valuable independent of the co-scientist: it closes a live data-exposure path in Wildbook's existing search.
+- **Artifact B — Integration endpoints.** Net-new API the external kernel needs: short-lived token issuance and a live "can user access encounter" check used as a defense-in-depth backstop.
+
+These are **two separate branches/PRs** (A is a pure security bugfix; B is feature additions) so A's security diff stays clean and independently reviewable.
+
+## Background: the two confirmed defects
+
+Both verified in current source on 2026-05-29.
+
+### Defect 1 — revocation can leak indefinitely
+`Encounter.opensearchIndexPermissions()` (the correct background ACL writer) only pushes an update when the computed set is non-empty:
+
+```java
+// Encounter.java ~4224
+if (viewUsers.length() > 0) {
+    updateData.put("viewUsers", viewUsers);
+    os.indexUpdate("encounter", id, updateData);
+}
+```
+
+When the **last** collaborator/orgAdmin loses access, the computed set is empty, so **nothing is written** — the previously-indexed `viewUsers` array persists in OpenSearch until some unrelated full reindex happens to overwrite the document. A revoked user retains read access via the field for an unbounded period. This is not the ~10–45 min background-pass latency; it is potentially permanent.
+
+### Defect 2 — a second, contradictory `viewUsers` writer
+`Encounter.userIdsWithViewAccess()` is a *different* ACL computation used by the full-document serializer:
+
+```java
+// Encounter.java ~3351 — NO state filter, BACKWARDS direction
+List<Collaboration> collabs =
+    Collaboration.collaborationsForUser(myShepherd, this.getSubmitterID());
+for (Collaboration collab : collabs) {
+    User user = myShepherd.getUser(collab.getOtherUsername(this.getSubmitterID()));
+    if (user != null) ids.add(user.getId());
+}
+```
+
+It is invoked whenever `opensearchProcessPermissions == true` (`Encounter.java` ~4605–4615), which ordinary single-encounter edit servlets set (e.g. `EncounterSetLocationID`). Versus the correct background writer it:
+
+1. **Applies no state filter** — `collaborationsForUser(..., state=null)` returns `initialized`/`rejected`/`pending` collaborations, granting view access to users who never had it (or were rejected).
+2. **Uses the backwards direction** the background pass explicitly warns against (`Encounter.java` 4189–4193): it asks "who is the submitter collaborating with" rather than "who can see this submitter," which also **inverts orgAdmin one-way visibility** (org members would gain sight of the orgAdmin's own encounters).
+
+So in production `viewUsers` is a race between a correct writer (background pass) and a buggy writer (edit-triggered), and the buggy one runs on routine edits.
+
+### Impact beyond the co-scientist
+`EncounterQueryProcessor` post-filters search hits with `Encounter.opensearchAccess(doc, user, shepherd)`, which reads these exact fields. Both defects therefore affect **Wildbook's existing search authorization today**, independent of any new service.
+
+## Artifact A — `viewUsers` ACL hardening
+
+### Goals
+1. Exactly one ACL computation, used by every writer.
+2. `viewUsers` is always written for non-public encounters, including the empty set `[]` (revocation propagates).
+3. Revocation/rejection/removal of a collaboration or orgAdmin triggers reindex of affected encounters.
+4. Full-document reindex includes `viewUsers` (or never drops it).
+5. A one-time corrective full reindex repairs already-stale docs in existing installs.
+
+### Design
+
+**Single ACL writer.** Extract the correct logic (currently inline in `opensearchIndexPermissions()`, `Encounter.java` 4208–4222) into one method — e.g. `Encounter.computeViewUsers(Shepherd)` — that:
+- returns the set of user UUIDs who can see this encounter via **approved/edit** collaborations, in the correct "who can see the submitter" direction, including correctly-directed assumed orgAdmin collaborations;
+- returns `[]` for a non-public encounter with no viewers;
+- is the **only** producer of `viewUsers`.
+
+Replace `userIdsWithViewAccess()`'s body with a call to this method (or delete it and repoint callers). Delete the divergent state-less/backwards logic.
+
+**Always-write semantics.** Remove the `if (viewUsers.length() > 0)` guard at `Encounter.java` ~4224; always write the field (including `[]`) for non-public encounters. Public encounters set `publiclyReadable=true` and need no `viewUsers`.
+
+**Full-reindex includes the field — via two explicit code paths (resolves prior open Q1).** A full reindex must never emit a `viewUsers` it did not compute, and must never re-emit the stale indexed value (that would preserve exactly the bug A repairs, and cannot serve the corrective reindex). But naively computing the ACL on *every* full index is a real scale risk — generic per-doc `viewUsers` computation was previously removed from the base serializer as too expensive (`Base.java:214–216`); the background pass is only affordable because it builds the user/collab maps **once** and SQL-scans encounters (`Encounter.java:4143–4167`). Therefore define two paths, both sourced from the single `computeViewUsers` logic:
+- **Single-encounter recompute** — for edit servlets and lifecycle-triggered reindex of one encounter (live JDO collaboration scan; acceptable for one doc).
+- **Bulk ACL-computation service** — for full reindex and the background/corrective passes: build the maps once, pass a precomputed ACL snapshot into the reindex job. The full-document serializer takes `viewUsers` from this snapshot, never from the stale index and never dropping the field.
+
+Add timing metrics before adopting any always-compute path.
+
+**Revocation triggers reindex — enumerate every trigger; `IndexingManager` alone is insufficient.** The JDO lifecycle listener only special-cases `Base` and `Collaboration` objects (`WildbookLifecycleListener.java:53–68`), but several revocation paths mutate *other* objects and would silently fail to reindex:
+- Collaboration → `rejected`/deleted (already covered by the listener).
+- **orgAdmin role removal** — roles are plain `Role` objects (`UserCreate.java:194–200`), not `Base`/`Collaboration`.
+- **Org membership / hierarchy edits** — mutate `User`/`Organization` (`User.java:452–458`, `Organization.java:119–124`).
+- **User deletion / consolidation / rename** — affects both the old and new owner's encounters.
+
+Each must explicitly enqueue permissions-recompute for the affected encounters (submitter's encounters; for orgAdmin/org changes, the org members' encounters) via the bulk path.
+
+**Invalid/deleted/renamed submitters must fail closed.** Current permissions indexing *skips* an encounter when `submitterID` doesn't map to a user (`Encounter.java:4178–4184`), and full indexing omits `submitterUserId` when the user is missing (`Encounter.java:4344–4345`) — leaving any prior `viewUsers` orphaned. `computeViewUsers` must instead return and write `[]` for non-public encounters with invalid/missing owners (and log/audit them), so such encounters become admin-only, not stale-open. User rename/consolidation must enqueue both the old and new owner's encounters.
+
+**One-time corrective reindex.** Document an operator step (and/or a startup migration flag) to run a full permissions reindex once after deploy to repair already-stale `viewUsers` in existing installs.
+
+### Tests (required, security-sensitive)
+- Sole collaborator rejected → `viewUsers` becomes `[]`; previously-permitted user no longer matches.
+- orgAdmin role removed → org members' encounters drop that admin from `viewUsers`.
+- Edit servlet (e.g. set location) on an encounter does **not** introduce rejected/pending users and does **not** invert orgAdmin direction (regression test for Defect 2).
+- Full reindex of an encounter preserves correct `viewUsers`.
+- Cross-check: for a sample of encounters/users, the indexed `viewUsers`-based decision matches a live `Collaboration.canUserAccessEncounter` computation.
+
+## Artifact B — Integration endpoints
+
+Net-new, additive. No token/JWT/API-key infrastructure exists today (only Shiro HTTP Basic). Keep this off Artifact A's clean security diff.
+
+### B1 — `POST /api/auth/token` (short-lived token issuance)
+- Gated by the **existing** Shiro authentication (an already-authenticated user calls it).
+- Mints a short-lived **signed** token. Claims: subject = user UUID, `context`, `iss`, `aud`, `jti`, `exp` (~30–60 min), `iat`. **No** admin/orgAdmin/role claims (privileges are resolved fresh by the kernel per request).
+- Signing: **asymmetric** (decided — the service runs remote). Wildbook holds the private signing key; the remote kernel validates with the public key only, so a kernel compromise cannot mint tokens. Key id in header + rotation support.
+- Must have an **explicit** Shiro filter rule in `web.xml` (existing config covers only selected `/api/v3/...` paths; do not assume coverage). CSRF protection if the caller is cookie-authenticated.
+- No server-side session state required beyond signing keys; refresh = re-call with Basic auth.
+
+### B2 — Live `canUserAccess` check (defense-in-depth backstop)
+- An authenticated endpoint (admin/service-scoped) that, given a user UUID and a set of encounter IDs, returns the subset that user may access — computed from **live** `Collaboration`/role objects, **not** from the indexed `viewUsers`.
+- **Use the correct authorization entry point.** `Collaboration.canUserAccessEncounter(enc, context, username)` does **not** check admin and only does username-based collaboration (`Collaboration.java:465–470`); admin handling lives in `Encounter.canUserView` (`Encounter.java:3316–3318`). B2 must resolve the UUID to a `User` **in the requested context** and call `Encounter.canUserView(user, shepherd)` (or an audited equivalent), never the bare string overload — otherwise admins are wrongly denied and the result is unsound.
+- Batched (accept up to a page of IDs per call) so the kernel can re-validate a result page cheaply.
+- Purpose: closes the residual `viewUsers` staleness window for the user-facing API even after Artifact A; the kernel pre-filters on `viewUsers` for speed, then confirms the returned page against this live check.
+
+### Tests
+- Token: valid/expired/tampered signature; wrong `aud`/`iss`; context isolation (a token issued in `context0` cannot be used to read another context's data); admin claim in token is ignored (privileges resolved fresh).
+- canUserAccess: matches `Encounter.canUserView` for owner / approved-collab / orgAdmin / rejected-collab / public / admin cases; correctly excludes a just-rejected collaborator even when `viewUsers` is still stale.
+
+## Out of scope / follow-ups
+- Denormalizing ACL fields onto annotation/individual/occurrence indices (the external API is encounter-index-only for v1; see co-scientist spec).
+- Write/agentic endpoints (v1 is read-only).
+- Multi-context productionization beyond a mandatory indexed `context` field + per-request context scoping (see co-scientist spec § ACL boundary).
+
+## Open questions for review
+1. ~~Cost of computing the ACL on every full index~~ — **resolved** (Codex design review): two paths, single-encounter recompute + bulk ACL snapshot; never re-emit stale index value.
+2. ~~Symmetric vs. asymmetric token signing~~ — **resolved: asymmetric.** The service runs remote, so the signing (minting) key must never leave Wildbook; the remote kernel holds only the public verify key. Support key id + rotation.
+3. Should revocation-triggered reindex be synchronous-ish (security) or rely on the existing async queue (simplicity)? What revocation latency is acceptable given B2 backstops the user-facing path?
+4. Context handling (see co-scientist spec): v1 targets a single Wildbook context (typically `context0`); true multi-context scoping requires a mandatory indexed `context` field on **both** the encounter and annotation indices (none exists today) — confirm v1 may assume single-context.

--- a/docs/superpowers/specs/2026-06-06-token-auth-scoped-search-design.md
+++ b/docs/superpowers/specs/2026-06-06-token-auth-scoped-search-design.md
@@ -1,0 +1,71 @@
+# Artifact D — Token-Authenticated Scoped Search (Wildbook, Java)
+
+**Date:** 2026-06-06
+**Status:** Draft for Codex design review
+**Repo/branch:** Wildbook, `token-auth-scoped-search` (off the A+B integration base; reuses B's `JwtService`).
+**Depends on:** Artifact A (merged, PR #1592 — hardened `viewUsers`) and Artifact B (PR #1594 — `JwtService` + `AuthToken`). D reuses `JwtService` for verification and Wildbook's existing enforced search for filtering.
+
+## Purpose
+
+Make **Java the hard permission boundary** for user-facing scoped queries. An external client (Claude / an MCP shim) presents a B-issued bearer JWT to Wildbook's **existing enforced read/search endpoints**; Wildbook verifies the token, resolves the user, and runs its *own* permission-filtered search. The external side never reads OpenSearch directly, so a buggy/compromised external client cannot exceed what the user's roles/collaborations/org-memberships allow.
+
+This supersedes the Python Scoped-Query Kernel's user-facing scoped-read (which enforced in Python). See the kernel-retirement note below.
+
+## Scope
+
+**In:** read-only. The token filter is wired ONLY onto Wildbook's enforced **read/search** endpoints (primarily `SearchApi` at `/api/v3/search/*`, plus encounter/individual read endpoints we choose to expose). A valid token authenticates the user for reads only — it cannot reach write/edit/merge endpoints.
+
+**Out (deferred):** write/agentic actions over token auth; a long-lived revocable PAT scheme (v1 accepts B's short-lived JWT — a PAT, if later desired, either mints/exchanges into the same JWT the filter verifies, or adds a second verification path); non-search read surfaces beyond what's listed.
+
+## Components
+
+1. **Token verification — reuse B's `JwtService`.** Wildbook holds the keypair, so `JwtService.fromConfig(context).verify(token)` checks RS256 (pinned), `iss`, `aud`, and `exp`. **D adds a context check**: the token's `context` claim must equal the server context (`context0`); reject otherwise. (B's `JwtService.verify` enforces iss/aud/alg/exp but not context — the consumer owns the context check; D is that consumer on the Wildbook side.)
+
+2. **`WildbookTokenAuthenticationFilter`** (new — the only substantive new code). A Shiro filter on the read/search paths that:
+   - Reads `Authorization: Bearer <jwt>`.
+   - **No Bearer** → do nothing, let the chain proceed (existing session/behaviour unchanged — the endpoints still work for browser sessions).
+   - **Bearer present** → verify via `JwtService`; on failure (bad sig / expired / wrong iss-aud / wrong context) → **401**.
+   - On success → resolve the user via `Shepherd.getUserByUUID(sub)`; if absent → 401. Establish that user as the authenticated subject so downstream `myShepherd.getUser(request)` / `request.getUserPrincipal()` return the token's user.
+
+3. **Establishing the Shiro principal from a pre-verified JWT.** `ShepherdRealm` today only authenticates a `UsernamePasswordToken` (compares a hashed password) — a JWT login has no password. Two candidate mechanisms (recommend the first; Codex to confirm against the live Shiro config):
+   - **(Recommended) Shiro-native pre-authenticated realm.** Add a `JwtAuthenticationToken(username)` (no credentials) and a small `JwtRealm` that `supports(JwtAuthenticationToken)`, loads the user, and returns auth info that matches (the token was already cryptographically verified by the filter, so no password check). The filter does `subject.login(new JwtAuthenticationToken(username))`. Register `JwtRealm` alongside `ShepherdRealm` in the Shiro `securityManager`. Result: both `request.getUserPrincipal()` AND `SecurityUtils.getSubject()` reflect the user — fully consistent with how Wildbook auth works.
+   - **(Alternative, simpler) request-principal wrapper.** The filter wraps the request in an `HttpServletRequestWrapper` overriding `getUserPrincipal()`/`getRemoteUser()` to return the token username, and forwards. `SearchApi.getUser(request)` resolves the user via `getUserPrincipal()`, so this suffices for the read path — but `SecurityUtils.getSubject()` would NOT reflect the user (only the servlet principal). Acceptable only if every read endpoint in scope uses `getUser(request)`, not the Shiro subject.
+
+4. **`web.xml` Shiro `[urls]` wiring.** Apply the token filter to the read/search paths only (e.g. `/api/v3/search/** = authcTokenOptional`), composed so a Bearer authenticates and absence falls through to the existing rule. The search path currently has no explicit `[urls]` auth rule, so the filter both authenticates token requests and leaves existing behaviour intact for non-token requests.
+
+5. **No new search/enforcement code.** `SearchApi` → `EncounterQueryProcessor` → `Encounter.opensearchAccess` already filter every hit by the live user's roles/collaborations/org-membership/admin (and A made `viewUsers` trustworthy). The token only supplies the principal.
+
+## Data flow
+
+```
+Claude/MCP --Bearer JWT--> /api/v3/search/* (Wildbook)
+  WildbookTokenAuthenticationFilter: verify JWT (RS256/iss/aud/exp/context) -> getUserByUUID(sub) -> establish subject
+  SearchApi.doPost: getUser(request) == token user
+  EncounterQueryProcessor + opensearchAccess: filter every hit by THAT user's roles/collabs/orgs/admin
+  -> returns only what the user may see (sanitizeDoc redacts the rest)
+```
+
+## Security
+
+- **Read-only blast radius:** filter on read/search paths only; a leaked token can read (as that user, expiring within the token TTL ≤ 30 min default) but never write.
+- **Java is the enforcer:** the external side never touches OpenSearch; per-hit filtering is Wildbook's existing `opensearchAccess` (live permissions), not a re-implementation.
+- **Context isolation:** reject tokens whose `context` claim ≠ server context.
+- **No credential in the token:** identity-only (`sub`=uuid); the filter trusts it ONLY after full RS256 verification. The `JwtRealm` must not be reachable except via the verified-token filter (it accepts pre-verified principals).
+- **No secret logging** (token strings, keys).
+
+## Testing
+
+- **Filter unit tests:** valid Bearer → subject/principal established + chain proceeds; expired/tampered/wrong-iss-aud/wrong-context Bearer → 401; **no Bearer → chain proceeds unchanged** (session path intact); unknown `sub` → 401.
+- **Enforcement integration test:** a token-authenticated `/api/v3/search/encounter` returns only the token user's permitted encounters (reuse the `EncounterExportImagesTest`/embedded-Jetty + Shiro test harness; seed a user with a collaboration and assert scoping). Confirms Java filters, not the token.
+- **Realm test:** `JwtRealm` authenticates a `JwtAuthenticationToken` to the right principal and is not usable with other token types.
+
+## Kernel retirement (separate, tracked)
+
+This makes the Python kernel's user-facing scoped-read redundant. Retirement (separate task in the `wildbook-coscientist` repo): remove `tokens.py`, `permission_filter.py`, `opensearch_client.py` (user-scoped), `redaction.py`, `operations.py`, `app.py`, `main.py`, and the kernel `models`/`config` fields specific to user-facing reads; **keep** the `coscientist/` operator-scope detection package and the `can-user-access` client (reused by the co-scientist delivery gate); trim `wbk.config.Settings` to the OpenSearch connection + B2 settings the co-scientist still needs.
+
+## Open questions for review
+
+1. **Principal mechanism:** Shiro-native `JwtRealm` (recommended) vs request-principal wrapper — which composes cleanly with the existing `IniShiroFilter`/`ShepherdRealm` config and the way `SearchApi` resolves the user? (Codex to verify against the live Shiro setup + `securityManager` realms list.)
+2. **Endpoint set:** just `SearchApi` (`/api/v3/search/*`) for v1, or also specific encounter/individual read endpoints? Which read endpoints does the Claude/MCP use-case actually need first?
+3. **Filter behaviour on invalid Bearer:** hard 401 (chosen) vs. fall through to anon — 401 is safer (an explicitly-presented bad token shouldn't silently downgrade to anonymous), confirm.
+4. **PR strategy:** D depends on B (`JwtService`). Stack D on B's PR, or hold D until B merges then branch off `main`?

--- a/docs/superpowers/specs/2026-06-06-token-auth-scoped-search-design.md
+++ b/docs/superpowers/specs/2026-06-06-token-auth-scoped-search-design.md
@@ -1,7 +1,7 @@
 # Artifact D — Token-Authenticated Scoped Search (Wildbook, Java)
 
 **Date:** 2026-06-06
-**Status:** Draft — incorporated Codex design review (2026-06-06, verified against real SearchApi/Shiro/ShepherdRealm); pending user review
+**Status:** Draft — incorporated **two** Codex design-review rounds (2026-06-06, verified against real `SearchApi`/`Shiro`/`ShepherdRealm`/`OpenSearch`/`Encounter`). Round 2 verdict was FIX-FIRST on one blocking item (encounter-only index gating for direct + stored-query token paths) — now folded into components 4/7. Pending user review.
 **Repo/branch:** Wildbook, `token-auth-scoped-search` (off the A+B integration base; reuses B's `JwtService`).
 **Depends on:** Artifact A (merged, PR #1592 — hardened `viewUsers`) and Artifact B (PR #1594 — `JwtService` + `AuthToken`). D reuses `JwtService` for verification and Wildbook's existing enforced search for filtering.
 
@@ -35,9 +35,10 @@ This supersedes the Python Scoped-Query Kernel's user-facing scoped-read; the ke
 
 3. **Establishing the principal — request wrapper, NOT `subject.login` (Codex Critical).** Do **not** call `subject.login(...)`: Wildbook is session-based (`JSESSIONID`), and a Shiro login on a bearer request can mint/persist a session whose principal could later satisfy *write* endpoints — defeating the read-only containment. Instead the filter wraps the request in an `HttpServletRequestWrapper` overriding `getUserPrincipal()`/`getRemoteUser()` to return the token user's **username**, and forwards. `SearchApi` resolves identity via `myShepherd.getUser(request)` → `request.getUserPrincipal().toString()` (`Shepherd.java:1199`), so the wrapper suffices and is **stateless** (no session, no Set-Cookie, no write reuse). Ensure the principal's `toString()` yields the username. (A Shiro-native `JwtRealm` is feasible but riskier here for exactly the session-persistence reason; deferred.)
 
-4. **`web.xml` Shiro `[urls]` wiring + scope.** Apply the token filter to **`/api/v3/search/*`** (mapped to `SearchApi`, read-only), with v1 enabling/testing the **`encounter`** index only (the filter rejects token requests targeting other indices until each is reviewed). Do **NOT** put it on the `BaseObject` `/api/v3/encounters/*` / `/api/v3/individuals/*` paths — those servlets handle `GET`+`POST`+`PATCH` on one mapping, so token auth there would expose writes (Codex High). The token filter is **optional**: a valid Bearer authenticates (request wrapped); an invalid/expired/bad-context Bearer → **401**; no Bearer → chain proceeds unchanged (session path intact; `SearchApi` already self-401s unauthenticated requests). The filter also **method-gates** to safe methods as defence-in-depth.
+4. **`web.xml` Shiro `[urls]` wiring + scope.** Apply the token filter to **`/api/v3/search/*`** (mapped to `SearchApi`, read-only), with v1 enabling/testing the **`encounter`** index only (index gating enforced in `SearchApi` — see component 7). Do **NOT** put it on the `BaseObject` `/api/v3/encounters/*` / `/api/v3/individuals/*` paths — those servlets handle `GET`+`POST`+`PATCH` on one mapping, so token auth there would expose writes (Codex High). Wire the search path to the **token filter only** — do NOT chain Shiro `authc`/`roles` after it (Codex: that would re-introduce a subject/session). The token filter is **optional**: a valid Bearer authenticates (request wrapped); an invalid/expired/bad-context Bearer → **401**; no Bearer → chain proceeds unchanged (session path intact; `SearchApi` already self-401s unauthenticated requests).
+   - **Method allowlist, not "safe methods" (Codex Medium).** Encounter search is a `POST`, so a literal GET-only "safe method" gate would break it. The gate is an explicit allowlist: `POST /api/v3/search/encounter` and `GET /api/v3/search/{uuid}` (stored query); reject `PUT`/`PATCH`/`DELETE`.
 
-5. **Context-drift rejection (Codex High).** The filter requires the token's `context` claim == `context0` AND rejects the request if the resolved request context (`ServletUtilities.getContext`, which honors `?context=`) is not `context0` — so a token can't be aimed at another context via a query param.
+5. **Context-drift rejection (Codex High).** The filter requires the token's `context` claim == `context0` AND rejects the request if the **resolved** request context is not `context0`. `ServletUtilities.getContext` resolves context from several sources — `?context=` query param, the `wildbookContext` cookie, host→context mapping, and the configured default (`ServletUtilities.java:764–807`) — so reject on *any* resolved non-`context0`, not just the query param, before user resolution. Tests must cover query-param, cookie, and host/default drift.
 
 6. **Token-path ACL pre-filter (the real enforcement — Codex Critical).** `SearchApi` must, **when the request is token-authenticated and the user is non-admin**, inject an ACL clause into the OpenSearch query *before execution* so totals + pagination + hits are all scoped:
    ```json
@@ -47,8 +48,13 @@ This supersedes the Python Scoped-Query Kernel's user-facing scoped-read; the ke
        {"term": {"viewUsers": "<uuid>"}}
      ], "minimum_should_match": 1 } }
    ```
-   (Same predicate as `Encounter.opensearchAccess`, and as the now-retired Python kernel's `permission_filter` — moved authoritatively into Java.) **Admin** token users get no pre-filter (full access, matching `opensearchAccess`' admin bypass). The token filter marks the request (e.g. a `wildbook.tokenAuth` request attribute + resolved uuid/admin) so `SearchApi` knows to apply this on the token path only; the existing session path is untouched (its pre-existing post-sanitize leak is a separate follow-up).
-7. **Stored-query owner check (Codex Medium).** `SearchApi` replays any saved-query UUID without checking ownership; on the token path, require the saved query's `creator == user.uuid` (or admin), else 403.
+   (Same predicate as `Encounter.opensearchAccess` — verified by Codex against `Encounter.java:4753–4764`: public OR submitter-UUID OR admin-bypass OR `viewUsers`; `editUsers` is **not** consulted and orgAdmin access is carried *through* `viewUsers`, so the three-term clause is complete. Same predicate as the now-retired Python kernel's `permission_filter` — moved authoritatively into Java.) **Admin** token users get no pre-filter (full access, matching `opensearchAccess`' admin bypass). The token filter marks the request (e.g. a `wildbook.tokenAuth` request attribute + resolved uuid/admin) so `SearchApi` knows to apply this on the token path only; the existing session path is untouched (its pre-existing post-sanitize leak is a separate follow-up).
+   - **Exact injection point (Codex Medium).** The clause must wrap the **top-level OpenSearch `query`** in a `bool` (`must`: original query; `filter`: the ACL clause) **before `queryPit`/execution** (`OpenSearch.java:~918`, `SearchApi.java:~91`), so totals + pagination + hits are all scoped. Adding a sibling field, or filtering after results, would NOT scope totals. **Fail closed** on a malformed/unparseable query rather than executing it unscoped.
+7. **Stored-query + index gating in `SearchApi` (Codex High + Medium).** On the token path, after the query is loaded (direct body or `/api/v3/search/{uuid}`) and before execution:
+   - **Index gate:** require the resolved/target `indexName == "encounter"`, else 403. The Shiro filter cannot see a stored query's index from the `{uuid}` URL alone, so this MUST be enforced inside `SearchApi` for **both** the direct and stored-query paths — otherwise a stored query over `individual` (returned unsanitized) or `occurrence` (weakly sanitized) bypasses the encounter-only scope.
+   - **Owner check:** for a stored-query UUID, require `creator == user.uuid` (or admin), else 403 — `SearchApi` otherwise replays any saved query.
+   - Apply the component-6 ACL pre-filter after these gates pass.
+8. **Fail-closed if a Bearer reaches `SearchApi` unmarked (Codex Medium).** Defence against filter misordering/misconfig: if an `Authorization: Bearer` header is present but the `wildbook.tokenAuth` request attribute is absent, `SearchApi` returns 401 (misconfiguration) rather than silently falling through to the session path.
 
 ## Data flow
 
@@ -57,7 +63,8 @@ Claude/MCP --Bearer JWT--> /api/v3/search/encounter (Wildbook)
   WildbookTokenAuthenticationFilter: verify JWT (RS256/iss/aud/exp/context) + reject ?context drift
     -> getUserByUUID(sub) -> wrap request (getUserPrincipal()=username) + mark tokenAuth(uuid,isAdmin) -> forward (NO subject.login, NO session)
   SearchApi.doPost: getUser(request) == token user; sees tokenAuth marker
-    -> non-admin: inject ACL pre-filter (publiclyReadable OR submitterUserId==uuid OR viewUsers==uuid) BEFORE execution
+    -> gate: index == "encounter" (403 else); stored-query owner == uuid (403 else)
+    -> non-admin: wrap top-level query in bool{must:orig, filter:ACL} (publiclyReadable OR submitterUserId==uuid OR viewUsers==uuid) BEFORE queryPit/execution; fail closed on malformed
     -> admin: no pre-filter
   OpenSearch executes the scoped query -> totals + pagination + hits all reflect only permitted encounters
 ```
@@ -73,9 +80,11 @@ Claude/MCP --Bearer JWT--> /api/v3/search/encounter (Wildbook)
 
 ## Testing
 
-- **Filter unit tests:** valid Bearer → request wrapped so `getUserPrincipal().toString()` == username + tokenAuth marker set + chain proceeds; expired/tampered/wrong-iss-aud/wrong-context Bearer → 401; `?context=` drift → reject; non-safe method → reject; **no Bearer → chain proceeds unchanged** (session path intact); unknown `sub` → 401.
+- **Filter unit tests:** valid Bearer → request wrapped so `getUserPrincipal().toString()` == username + tokenAuth marker set + chain proceeds; expired/tampered/wrong-iss-aud/wrong-context Bearer → 401; context drift via **query param, cookie, and host/default** → reject; method outside the allowlist (`PUT`/`PATCH`/`DELETE`) → reject; **no Bearer → chain proceeds unchanged** (session path intact); unknown `sub` → 401.
 - **No-session assertion (Codex Critical):** a token request produces no `Set-Cookie`/`JSESSIONID` and leaves no authenticated Shiro subject behind for a subsequent request on the same connection.
-- **Enforcement integration test:** a token-authenticated `/api/v3/search/encounter` returns only the token user's permitted encounters AND the reported `total`/pagination reflect the scoped set (assert an inaccessible encounter is absent from hits AND not counted — guards against the post-sanitize leak). Reuse the `EncounterExportImagesTest`/embedded-Jetty + Shiro harness; seed a user with one approved collaboration + one unrelated private encounter. Admin token → unscoped. Confirms Java filters, not the token.
+- **Index + stored-query gating (Codex High):** token `POST /api/v3/search/individual` (or `occurrence`) → 403; stored-query `{uuid}` owned by another user → 403; stored-query whose `indexName != encounter` → 403; valid own encounter stored-query → scoped results.
+- **Fail-closed:** malformed/unparseable query on the token path → not executed (no unscoped results); `Authorization: Bearer` present at `SearchApi` without the tokenAuth marker → 401.
+- **Enforcement integration test:** a token-authenticated `/api/v3/search/encounter` returns only the token user's permitted encounters AND the reported `total`/pagination reflect the scoped set (assert an inaccessible encounter is absent from hits AND not counted — guards against the post-sanitize leak). Reuse the `EncounterExportImagesTest`/embedded-Jetty + Shiro harness; seed a user with one approved collaboration + one unrelated private encounter, plus an orgAdmin-visible encounter (asserts `viewUsers` carries orgAdmin). Admin token → unscoped. Confirms Java filters, not the token.
 
 ## Kernel retirement (separate, tracked)
 

--- a/docs/superpowers/specs/2026-06-06-token-auth-scoped-search-design.md
+++ b/docs/superpowers/specs/2026-06-06-token-auth-scoped-search-design.md
@@ -1,63 +1,81 @@
 # Artifact D — Token-Authenticated Scoped Search (Wildbook, Java)
 
 **Date:** 2026-06-06
-**Status:** Draft for Codex design review
+**Status:** Draft — incorporated Codex design review (2026-06-06, verified against real SearchApi/Shiro/ShepherdRealm); pending user review
 **Repo/branch:** Wildbook, `token-auth-scoped-search` (off the A+B integration base; reuses B's `JwtService`).
 **Depends on:** Artifact A (merged, PR #1592 — hardened `viewUsers`) and Artifact B (PR #1594 — `JwtService` + `AuthToken`). D reuses `JwtService` for verification and Wildbook's existing enforced search for filtering.
 
 ## Purpose
 
-Make **Java the hard permission boundary** for user-facing scoped queries. An external client (Claude / an MCP shim) presents a B-issued bearer JWT to Wildbook's **existing enforced read/search endpoints**; Wildbook verifies the token, resolves the user, and runs its *own* permission-filtered search. The external side never reads OpenSearch directly, so a buggy/compromised external client cannot exceed what the user's roles/collaborations/org-memberships allow.
+Make **Java the hard permission boundary** for user-facing scoped queries. An external client (Claude / an MCP shim) presents a B-issued bearer JWT to Wildbook's encounter search; Wildbook verifies the token, resolves the user, and runs a **permission-filtered** search. The external side never reads OpenSearch directly, so a buggy/compromised external client cannot exceed what the user's roles/collaborations/org-memberships allow.
 
-This supersedes the Python Scoped-Query Kernel's user-facing scoped-read (which enforced in Python). See the kernel-retirement note below.
+> **Codex Critical — the premise corrected.** Wildbook's `SearchApi` does NOT pre-filter: it runs the caller's query, reads the **raw `total`**, and only *post-sanitizes* hits — inaccessible encounters are still returned as `access:"none"` **carrying ids, dates, location, taxonomy, assigned username**, and are counted in totals/pagination (`OpenSearch.querySanitize` is a no-op). So D cannot just "reuse the enforced search" — on the token path it must **inject a real ACL pre-filter into the query before execution**. (That pre-existing session-search metadata leak is real but out of D's scope — flagged as a separate follow-up; we chose to fix only the token path here.)
+
+This supersedes the Python Scoped-Query Kernel's user-facing scoped-read; the kernel's pre-filter logic now lives authoritatively in Java. See the kernel-retirement note below.
 
 ## Scope
 
-**In:** read-only. The token filter is wired ONLY onto Wildbook's enforced **read/search** endpoints (primarily `SearchApi` at `/api/v3/search/*`, plus encounter/individual read endpoints we choose to expose). A valid token authenticates the user for reads only — it cannot reach write/edit/merge endpoints.
+**In:** read-only, **encounter search only**. The token filter is wired ONLY onto `SearchApi` at `/api/v3/search/encounter` (and the `encounter` index). A valid token authenticates the user for that read only.
 
-**Out (deferred):** write/agentic actions over token auth; a long-lived revocable PAT scheme (v1 accepts B's short-lived JWT — a PAT, if later desired, either mints/exchanges into the same JWT the filter verifies, or adds a second verification path); non-search read surfaces beyond what's listed.
+**Out (deferred):** any write/edit/merge (the filter is not on the `BaseObject` paths); `individual`/`occurrence`/`annotation` search via token (Codex: `individual` is returned unsanitized, `occurrence` access is weaker/custom, `annotation` is admin-only — each needs its own review before token exposure); write/agentic actions; a long-lived revocable PAT (v1 accepts B's short-lived JWT — a PAT later either mints/exchanges into the same JWT or adds a verification path).
+
+**Flagged follow-ups (NOT in D):**
+- **Global SearchApi metadata leak** — the pre-existing session-path behavior (inaccessible encounters returned as `access:"none"` with ids/dates/location/taxonomy/username, plus unscoped totals) is a real data-exposure bug for *all* search, not just token. Its own security issue/PR (sibling to the `viewUsers` bug), with React-search-UI review — out of D's contained scope.
+- **Verify orgAdmin coverage in `viewUsers`** — Codex flags the background permissions writer may not include orgAdmins consistently with `computeViewUsers` (A). D's pre-filter trusts `viewUsers`; confirm the background pass delegates to / matches `computeViewUsers` so orgAdmin-scoped search is correct.
 
 ## Components
 
 1. **Token verification — reuse B's `JwtService`.** Wildbook holds the keypair, so `JwtService.fromConfig(context).verify(token)` checks RS256 (pinned), `iss`, `aud`, and `exp`. **D adds a context check**: the token's `context` claim must equal the server context (`context0`); reject otherwise. (B's `JwtService.verify` enforces iss/aud/alg/exp but not context — the consumer owns the context check; D is that consumer on the Wildbook side.)
 
-2. **`WildbookTokenAuthenticationFilter`** (new — the only substantive new code). A Shiro filter on the read/search paths that:
+2. **`WildbookTokenAuthenticationFilter`** (new — the only substantive new code). A Shiro filter on the encounter-search path that:
    - Reads `Authorization: Bearer <jwt>`.
    - **No Bearer** → do nothing, let the chain proceed (existing session/behaviour unchanged — the endpoints still work for browser sessions).
    - **Bearer present** → verify via `JwtService`; on failure (bad sig / expired / wrong iss-aud / wrong context) → **401**.
-   - On success → resolve the user via `Shepherd.getUserByUUID(sub)`; if absent → 401. Establish that user as the authenticated subject so downstream `myShepherd.getUser(request)` / `request.getUserPrincipal()` return the token's user.
+   - On success → resolve the user via `Shepherd.getUserByUUID(sub)`; if absent → 401. Wrap the request (component 3) so downstream `myShepherd.getUser(request)` / `request.getUserPrincipal()` return the token's user, mark the request token-authenticated (uuid + isAdmin), then forward.
 
-3. **Establishing the Shiro principal from a pre-verified JWT.** `ShepherdRealm` today only authenticates a `UsernamePasswordToken` (compares a hashed password) — a JWT login has no password. Two candidate mechanisms (recommend the first; Codex to confirm against the live Shiro config):
-   - **(Recommended) Shiro-native pre-authenticated realm.** Add a `JwtAuthenticationToken(username)` (no credentials) and a small `JwtRealm` that `supports(JwtAuthenticationToken)`, loads the user, and returns auth info that matches (the token was already cryptographically verified by the filter, so no password check). The filter does `subject.login(new JwtAuthenticationToken(username))`. Register `JwtRealm` alongside `ShepherdRealm` in the Shiro `securityManager`. Result: both `request.getUserPrincipal()` AND `SecurityUtils.getSubject()` reflect the user — fully consistent with how Wildbook auth works.
-   - **(Alternative, simpler) request-principal wrapper.** The filter wraps the request in an `HttpServletRequestWrapper` overriding `getUserPrincipal()`/`getRemoteUser()` to return the token username, and forwards. `SearchApi.getUser(request)` resolves the user via `getUserPrincipal()`, so this suffices for the read path — but `SecurityUtils.getSubject()` would NOT reflect the user (only the servlet principal). Acceptable only if every read endpoint in scope uses `getUser(request)`, not the Shiro subject.
+3. **Establishing the principal — request wrapper, NOT `subject.login` (Codex Critical).** Do **not** call `subject.login(...)`: Wildbook is session-based (`JSESSIONID`), and a Shiro login on a bearer request can mint/persist a session whose principal could later satisfy *write* endpoints — defeating the read-only containment. Instead the filter wraps the request in an `HttpServletRequestWrapper` overriding `getUserPrincipal()`/`getRemoteUser()` to return the token user's **username**, and forwards. `SearchApi` resolves identity via `myShepherd.getUser(request)` → `request.getUserPrincipal().toString()` (`Shepherd.java:1199`), so the wrapper suffices and is **stateless** (no session, no Set-Cookie, no write reuse). Ensure the principal's `toString()` yields the username. (A Shiro-native `JwtRealm` is feasible but riskier here for exactly the session-persistence reason; deferred.)
 
-4. **`web.xml` Shiro `[urls]` wiring.** Apply the token filter to the read/search paths only (e.g. `/api/v3/search/** = authcTokenOptional`), composed so a Bearer authenticates and absence falls through to the existing rule. The search path currently has no explicit `[urls]` auth rule, so the filter both authenticates token requests and leaves existing behaviour intact for non-token requests.
+4. **`web.xml` Shiro `[urls]` wiring + scope.** Apply the token filter to **`/api/v3/search/*`** (mapped to `SearchApi`, read-only), with v1 enabling/testing the **`encounter`** index only (the filter rejects token requests targeting other indices until each is reviewed). Do **NOT** put it on the `BaseObject` `/api/v3/encounters/*` / `/api/v3/individuals/*` paths — those servlets handle `GET`+`POST`+`PATCH` on one mapping, so token auth there would expose writes (Codex High). The token filter is **optional**: a valid Bearer authenticates (request wrapped); an invalid/expired/bad-context Bearer → **401**; no Bearer → chain proceeds unchanged (session path intact; `SearchApi` already self-401s unauthenticated requests). The filter also **method-gates** to safe methods as defence-in-depth.
 
-5. **No new search/enforcement code.** `SearchApi` → `EncounterQueryProcessor` → `Encounter.opensearchAccess` already filter every hit by the live user's roles/collaborations/org-membership/admin (and A made `viewUsers` trustworthy). The token only supplies the principal.
+5. **Context-drift rejection (Codex High).** The filter requires the token's `context` claim == `context0` AND rejects the request if the resolved request context (`ServletUtilities.getContext`, which honors `?context=`) is not `context0` — so a token can't be aimed at another context via a query param.
+
+6. **Token-path ACL pre-filter (the real enforcement — Codex Critical).** `SearchApi` must, **when the request is token-authenticated and the user is non-admin**, inject an ACL clause into the OpenSearch query *before execution* so totals + pagination + hits are all scoped:
+   ```json
+   { "bool": { "should": [
+       {"term": {"publiclyReadable": true}},
+       {"term": {"submitterUserId": "<uuid>"}},
+       {"term": {"viewUsers": "<uuid>"}}
+     ], "minimum_should_match": 1 } }
+   ```
+   (Same predicate as `Encounter.opensearchAccess`, and as the now-retired Python kernel's `permission_filter` — moved authoritatively into Java.) **Admin** token users get no pre-filter (full access, matching `opensearchAccess`' admin bypass). The token filter marks the request (e.g. a `wildbook.tokenAuth` request attribute + resolved uuid/admin) so `SearchApi` knows to apply this on the token path only; the existing session path is untouched (its pre-existing post-sanitize leak is a separate follow-up).
+7. **Stored-query owner check (Codex Medium).** `SearchApi` replays any saved-query UUID without checking ownership; on the token path, require the saved query's `creator == user.uuid` (or admin), else 403.
 
 ## Data flow
 
 ```
-Claude/MCP --Bearer JWT--> /api/v3/search/* (Wildbook)
-  WildbookTokenAuthenticationFilter: verify JWT (RS256/iss/aud/exp/context) -> getUserByUUID(sub) -> establish subject
-  SearchApi.doPost: getUser(request) == token user
-  EncounterQueryProcessor + opensearchAccess: filter every hit by THAT user's roles/collabs/orgs/admin
-  -> returns only what the user may see (sanitizeDoc redacts the rest)
+Claude/MCP --Bearer JWT--> /api/v3/search/encounter (Wildbook)
+  WildbookTokenAuthenticationFilter: verify JWT (RS256/iss/aud/exp/context) + reject ?context drift
+    -> getUserByUUID(sub) -> wrap request (getUserPrincipal()=username) + mark tokenAuth(uuid,isAdmin) -> forward (NO subject.login, NO session)
+  SearchApi.doPost: getUser(request) == token user; sees tokenAuth marker
+    -> non-admin: inject ACL pre-filter (publiclyReadable OR submitterUserId==uuid OR viewUsers==uuid) BEFORE execution
+    -> admin: no pre-filter
+  OpenSearch executes the scoped query -> totals + pagination + hits all reflect only permitted encounters
 ```
 
 ## Security
 
-- **Read-only blast radius:** filter on read/search paths only; a leaked token can read (as that user, expiring within the token TTL ≤ 30 min default) but never write.
-- **Java is the enforcer:** the external side never touches OpenSearch; per-hit filtering is Wildbook's existing `opensearchAccess` (live permissions), not a re-implementation.
-- **Context isolation:** reject tokens whose `context` claim ≠ server context.
-- **No credential in the token:** identity-only (`sub`=uuid); the filter trusts it ONLY after full RS256 verification. The `JwtRealm` must not be reachable except via the verified-token filter (it accepts pre-verified principals).
+- **Read-only blast radius:** filter on `/api/v3/search/encounter` only (not the read+write `BaseObject` paths); a leaked token can read (as that user, expiring within the token TTL ≤ 30 min default) but never write.
+- **Stateless / no session reuse (Codex Critical):** the filter does NOT call `subject.login` — it wraps the request and forwards. No `JSESSIONID` is minted, no `Set-Cookie`, so a token can never be parlayed into a session that satisfies a write endpoint.
+- **Java is the enforcer:** the external side never touches OpenSearch; the ACL pre-filter is injected into the query *before execution* (matching `Encounter.opensearchAccess`), so totals/pagination/hits are all scoped — not a post-sanitize that leaks metadata.
+- **Context isolation:** reject tokens whose `context` claim ≠ `context0` AND reject a `?context=` that drifts from `context0`.
+- **No credential in the token:** identity-only (`sub`=uuid); the filter trusts it ONLY after full RS256 verification (alg pinned).
 - **No secret logging** (token strings, keys).
 
 ## Testing
 
-- **Filter unit tests:** valid Bearer → subject/principal established + chain proceeds; expired/tampered/wrong-iss-aud/wrong-context Bearer → 401; **no Bearer → chain proceeds unchanged** (session path intact); unknown `sub` → 401.
-- **Enforcement integration test:** a token-authenticated `/api/v3/search/encounter` returns only the token user's permitted encounters (reuse the `EncounterExportImagesTest`/embedded-Jetty + Shiro test harness; seed a user with a collaboration and assert scoping). Confirms Java filters, not the token.
-- **Realm test:** `JwtRealm` authenticates a `JwtAuthenticationToken` to the right principal and is not usable with other token types.
+- **Filter unit tests:** valid Bearer → request wrapped so `getUserPrincipal().toString()` == username + tokenAuth marker set + chain proceeds; expired/tampered/wrong-iss-aud/wrong-context Bearer → 401; `?context=` drift → reject; non-safe method → reject; **no Bearer → chain proceeds unchanged** (session path intact); unknown `sub` → 401.
+- **No-session assertion (Codex Critical):** a token request produces no `Set-Cookie`/`JSESSIONID` and leaves no authenticated Shiro subject behind for a subsequent request on the same connection.
+- **Enforcement integration test:** a token-authenticated `/api/v3/search/encounter` returns only the token user's permitted encounters AND the reported `total`/pagination reflect the scoped set (assert an inaccessible encounter is absent from hits AND not counted — guards against the post-sanitize leak). Reuse the `EncounterExportImagesTest`/embedded-Jetty + Shiro harness; seed a user with one approved collaboration + one unrelated private encounter. Admin token → unscoped. Confirms Java filters, not the token.
 
 ## Kernel retirement (separate, tracked)
 
@@ -65,7 +83,8 @@ This makes the Python kernel's user-facing scoped-read redundant. Retirement (se
 
 ## Open questions for review
 
-1. **Principal mechanism:** Shiro-native `JwtRealm` (recommended) vs request-principal wrapper — which composes cleanly with the existing `IniShiroFilter`/`ShepherdRealm` config and the way `SearchApi` resolves the user? (Codex to verify against the live Shiro setup + `securityManager` realms list.)
-2. **Endpoint set:** just `SearchApi` (`/api/v3/search/*`) for v1, or also specific encounter/individual read endpoints? Which read endpoints does the Claude/MCP use-case actually need first?
-3. **Filter behaviour on invalid Bearer:** hard 401 (chosen) vs. fall through to anon — 401 is safer (an explicitly-presented bad token shouldn't silently downgrade to anonymous), confirm.
-4. **PR strategy:** D depends on B (`JwtService`). Stack D on B's PR, or hold D until B merges then branch off `main`?
+1. ~~Principal mechanism~~ — **resolved (Codex Critical): request-principal wrapper, NOT `subject.login`** (avoids session minting / write-endpoint reuse). `SearchApi` resolves identity via `getUser(request)`→`getUserPrincipal()`, so the wrapper suffices and stays stateless. A Shiro-native `JwtRealm` is deferred for the same session-persistence reason.
+2. ~~Endpoint set~~ — **resolved (Codex High): `/api/v3/search/encounter` only.** The `BaseObject` `/api/v3/encounters|individuals/*` paths serve GET+POST+PATCH on one mapping, so token auth there would expose writes; `individual`/`occurrence`/`annotation` search each have their own gaps and are deferred.
+3. ~~Filter behaviour on invalid Bearer~~ — **resolved: hard 401.** An explicitly-presented bad token must not silently downgrade to anonymous; absence of a Bearer still falls through to the session path.
+4. **PR strategy:** D depends on B (`JwtService`). Stack D on B's PR, or hold D until B merges then branch off `main`? (Still open — pending B #1594 merge decision.)
+5. **Still to confirm with reviewer:** the two flagged follow-ups in Scope (global SearchApi metadata leak as its own security PR; orgAdmin coverage in the background `viewUsers` writer) — agree they are out of D's contained scope?

--- a/docs/superpowers/specs/2026-06-07-token-scoped-individual-annotation-design.md
+++ b/docs/superpowers/specs/2026-06-07-token-scoped-individual-annotation-design.md
@@ -1,0 +1,120 @@
+# Token-Scoped Individual + Annotation Reads (Spec A) — Design
+
+**Date:** 2026-06-07
+**Status:** Draft — pending Codex design review + user review
+**Repo/branch:** Wildbook; new branch off `token-auth-scoped-search` (Artifact D) — or off `main` once A/B/D have landed. Reuses D's `WildbookTokenAuthenticationFilter` + `SearchApi` token path and A's permissions-indexing pattern.
+**Depends on:** Artifact A (merged — `viewUsers` hardening / encounter ACL denormalization), Artifact B (`JwtService`/`AuthToken`), Artifact D (token-scoped encounter search — live-verified on flakebook.wildme.org).
+**Sibling (deferred):** Spec B — detection-via-service-account-token + nested-kNN ACL injection (separate design).
+
+## Purpose
+
+Extend the token-scoped read boundary (Artifact D) from the `encounter` index to the **`individual`** and **`annotation`** indices, so an agent acting on a user's behalf (via a bearer token) can read individuals and annotations — seeing **exactly** what that user would see on Wildbook's own individual page, and never more. The encounter remains the unit of ACL truth; individual and annotation visibility are **projections gated by encounter access**. An admin token is the "universal access agent" (no filter), matching a Wildbook admin.
+
+This is the user-facing read extension (Consumer 2). It also lays the groundwork for detection (Spec B) by making the annotation index reachable via token.
+
+## Background — the authoritative Wildbook logic (verified in source)
+
+- **Individual view gate:** `Collaboration.canUserAccessMarkedIndividual(mi, request)` (`Collaboration.java:555`) returns true iff the user can access **≥1 of the individual's member encounters** (an individual with zero encounters is visible to anyone). Per-encounter access is the collaboration predicate `canUserAccessEncounter` → `canUserAccessOwnedObject` → `canCollaborate` (`Collaboration.java:452,477,309`): admin, or security-disabled, or **anonymous/null owner** (`enc.getSubmitterID()==null` → true), or same user, or an **approved/edit** collaboration between viewer and owner.
+- **Individual page content:** `individuals.jsp:196–216` recomputes all aggregates (sighting count, locations, dates) from the **security-scrubbed** encounter list (`HiddenEncReporter.securityScrubbedResults`) — i.e. only the encounters that viewer can access. The page is **precise per-viewer**, never leaking aggregates from hidden encounters.
+- **API redaction when no access:** `MarkedIndividual.sanitizeJson` (`:2123`) returns only `displayName` + `_sanitized:true`, stripping `sex`, `numberEncounters`, `numberLocations`, `timeOfBirth/Death`, `maxYearsBetweenResightings`, `nickName/nickNamer`.
+- **Encounter ACL denormalization (Artifact A):** `Encounter.opensearchAccess` (`Encounter.java:4753`) = `publiclyReadable` OR `submitterUserId==user` OR admin OR `viewUsers` contains user. A built `viewUsers` to be the **materialized** collaboration result, and cross-tested that the indexed decision matches the live `Collaboration.canUserAccessEncounter`. So the indexed encounter predicate is the denormalized form of the live collaboration gate.
+- **Today's child indices have no ACL:** the `annotation` and `individual` OpenSearch docs carry no `publiclyReadable`/`submitterUserId`/`viewUsers`; the individual doc's aggregates are computed over **all** encounters (`MarkedIndividual.opensearchDocumentSerializer`, ~`:2723`). Annotation `_source` includes `embeddings`.
+
+## Architecture & access model
+
+**The encounter index is the gatekeeper.** We extend A's denormalization onto the two child indices so the *same* token pre-filter (D) enforces all three.
+
+Per-index ACL fields (written at index time):
+
+| Index | Fields | Source |
+|---|---|---|
+| `encounter` (exists) | `publiclyReadable`, `submitterUserId`, `viewUsers` | A |
+| `annotation` (new) | `publiclyReadable`, `submitterUserId`, `viewUsers` | copied verbatim from the one parent encounter |
+| `individual` (new) | `publiclyReadable`, `submitterUserIds`, `viewUsers` | **unions** over member encounters |
+
+Individual unions (chosen so the indexed gate is provably equal to `canUserAccessMarkedIndividual`):
+- `publiclyReadable` = `OR` over member encounters' `publiclyReadable` (i.e. *any* member encounter is world-readable).
+- `submitterUserIds` = the **set** of member encounter submitter UUIDs.
+- `viewUsers` = the **union** of member encounters' `viewUsers`.
+
+Then: *user can access individual* ⟺ `publiclyReadable` OR `user ∈ submitterUserIds` OR `user ∈ viewUsers` ⟺ ∃ member encounter the user can access. ✔ matches the live gate.
+
+**Token-path enforcement** (in `SearchApi`, building on D): for a non-admin token request, inject the ACL pre-filter using *that index's* field names, before execution. **Admin token → no filter** (universal access). Token-exposed indices become **`encounter`, `annotation`, `individual`**; `occurrence` and `media_asset` remain **403**. The non-token/session path is **unchanged**.
+
+**Fail-closed during reindex:** until the corrective reindex populates the new fields, they are simply absent on child docs → the pre-filter matches nothing → a non-admin sees *nothing* on those indices. A partial/in-progress reindex degrades to "too restrictive," never "leaky."
+
+## Read surfaces
+
+### Annotation (`POST /api/v3/search/annotation`, token path)
+Annotation is 1:1 with an encounter, so each annotation doc carries the parent encounter's three ACL fields. The token path injects the **same** pre-filter as encounter (identical field names): a non-admin sees only annotations whose encounter they can access; admin bypasses. **Embeddings are returned as-is** (deemed not sensitive). The annotation doc is otherwise gated **wholesale** by the encounter ACL — no content redaction — **except** the internal denormalized ACL fields (`viewUsers`, and the copied `submitterUserId`/`publiclyReadable` if not otherwise meaningful) are removed from the returned doc, consistent with how Artifact D strips `viewUsers` from encounter responses (`sanitizeDoc` → `clean.remove("viewUsers")`). This also gives detection (Spec B) a real annotation read surface.
+
+Note: the existing **session** path keeps annotation admin-only (`SearchApi`'s `"annotation".equals(indexName) && !isAdmin → 403`). That gate must NOT block the token path — the token path is governed by the ACL pre-filter instead. The implementation must ensure the annotation-admin-only branch applies only to non-token requests.
+
+### Individual (`POST /api/v3/search/individual`, token path)
+Two parts:
+
+1. **Gate** — inject the pre-filter against the individual union fields:
+   ```json
+   { "bool": { "should": [
+       {"term": {"publiclyReadable": true}},
+       {"term": {"submitterUserIds": "<uuid>"}},
+       {"term": {"viewUsers": "<uuid>"}}
+     ], "minimum_should_match": 1 } }
+   ```
+   The user's own query (name/taxonomy/sex/etc.) runs normally, `must`-combined with this gate. (`term` on the keyword-array fields `submitterUserIds`/`viewUsers` matches if any element equals the uuid.)
+
+2. **Strip leaky aggregates** — a token-path sanitizer removes fields computed across *all* member encounters (which would reveal hidden ones), keeping individual-identity attributes:
+
+   | Keep (identity attributes) | Strip (cross-encounter aggregates → leak) |
+   |---|---|
+   | `id`, `displayName`, `names`/`nameMap`, `sex`, `taxonomy`, `timeOfBirth`, `timeOfDeath` | `encounterIds`, `numberEncounters`, `users`, `locationGeoPoints`, `numberLocations`, `maxYearsBetweenResightings`, `socialUnits`, `relationships`, `cooccurrenceIndividualMap`, occurrence-derived counts |
+   | (plus the new ACL fields `publiclyReadable`/`submitterUserIds`/`viewUsers` are stripped from the response) | |
+
+   The final keep/strip list is pinned against `MarkedIndividual.opensearchDocumentSerializer` during implementation; any field derived from the full member-encounter set is stripped. `sex`/`timeOfBirth`/`timeOfDeath` are individual-level attributes Wildbook shows to anyone who can access the individual, so they are kept.
+
+**Two-hop richness:** the agent obtains the *per-viewer* sighting list, locations, dates, co-occurrences for an individual by querying `POST /api/v3/search/encounter` with `{"query":{"term":{"individualId":"<id>"}}}` — already ACL-scoped. The rich record is assembled across two indices, each enforcing the ACL independently; nothing leaks and individual search keeps full query expressiveness.
+
+## Indexing & sync
+
+**Serializer changes:**
+- **Annotation serializer** — emit the parent encounter's `publiclyReadable`, `submitterUserId`, `viewUsers`.
+- **Individual serializer** (`MarkedIndividual.opensearchDocumentSerializer`) — in the existing all-member-encounters pass, also compute and emit `publiclyReadable` (OR), `submitterUserIds` (set), `viewUsers` (union).
+- **Mappings** are additive: add the new fields (boolean / keyword) to the existing annotation + individual index mappings (OpenSearch allows adding fields to a live mapping); no drop/recreate required.
+
+**Sync triggers (correctness-critical).** Artifact A reindexes an encounter when its ACL changes (collaboration approve/reject, orgAdmin role change, org membership, user delete/rename/consolidation). Spec A **extends those same trigger points** so that when an encounter's `viewUsers`/`publiclyReadable`/`submitterUserId` changes, we also enqueue reindex of (a) its annotations and (b) its individual. Without this, a revoked viewer could linger on the child indices after the encounter is corrected — the bug class A hardened, now for two more indices. Use the existing bulk/queue path; document any best-effort-vs-guaranteed nuance as A did.
+
+**Parity edge — anonymous / null-submitter encounters.** Wildbook's live gate grants these to everyone (`Collaboration.java:477`). The pre-filter only grants via `publiclyReadable`/submitter/`viewUsers`, so indexing must mark anonymous/null-owner encounters as `publiclyReadable=true` (or an equivalent world-readable flag the filter treats as public) — on the **encounter** index too, since today it may under-grant those. This is a small correction that also tightens encounter parity. (Confirm against A's existing handling of invalid/missing owners, which currently writes `[]`/admin-only — reconcile: anonymous-owned ≠ invalid-owner; anonymous-owned is world-readable, invalid/deleted-owner is admin-only/fail-closed.)
+
+**Equivalence test (extends A's cross-check).** Add the analogue of A's indexed-vs-live cross-check: for a sample of individuals/annotations, the indexed gate decision matches live `Collaboration.canUserAccessMarkedIndividual` / `canUserAccessEncounter`.
+
+**One-time corrective reindex.** A runbook step (analogue of A's `viewUsers` corrective pass), run once at deploy, in order: (1) encounter anon-owner correction (or full encounter pass), (2) full annotation reindex (**the long pole** — several annotations per encounter; can be 100K+ on large installs), (3) full individual reindex. After this, the extended triggers keep fields current incrementally. Until it runs, child-index token reads fail closed (non-admin sees nothing there).
+
+## `SearchApi` changes
+
+Small, building on D's structure:
+- Index gate flips from "encounter-only" to a token **allowlist `{encounter, annotation, individual}`**; `occurrence`/`media_asset` still 403.
+- Generalize `OpenSearch.applyEncounterAclFilter(query, uuid)` → `applyAclFilter(query, uuid, indexName)` that selects field names per index (`submitterUserId` for encounter/annotation; `submitterUserIds` for individual; `publiclyReadable`/`viewUsers` common). Same `bool{must:[orig], filter:[should…]}` shape, injected before `queryPit`, admin-bypassed.
+- **Individual result sanitizer**: a token-path branch (in `sanitizeDoc` or a sibling) that strips the cross-encounter aggregate fields (the keep/strip table) from individual hits. Annotation hits pass through whole (embeddings included). Encounter unchanged.
+- Ensure the existing **annotation-admin-only** branch applies only to **non-token** requests (token path uses the ACL filter instead).
+- Stored-query owner check, method allowlist, fail-closed-unmarked, verified-context binding — **unchanged** from D; already per-index.
+
+## Testing
+
+- **Unit:** `applyAclFilter` builds the correct clause per index (field names); the individual sanitizer strips exactly the leak set and keeps identity; index allowlist (occurrence/media_asset → 403, annotation/individual allowed on token path).
+- **Serializer unit:** annotation emits parent ACL; individual emits unions (incl. anon-owner → `publiclyReadable=true`); indexed gate matches live `canUserAccessMarkedIndividual` for owner/approved-collab/orgAdmin/rejected-collab/public/anonymous cases.
+- **Integration (real OpenSearch — the decisive proof):** seed encounters with mixed ACLs + their annotations + a shared individual spanning multiple owners; with a non-admin token assert: (a) annotation hits + totals are gated by visible encounters; (b) individual gate = ≥1 visible encounter, hits scoped, leaky aggregates absent from the response, identity present; (c) an individual the user can't see → absent (or stub); (d) admin token → unscoped. Mirrors the live `testy1` proof, extended to the two indices.
+
+## Scope
+
+**In:** token reads for `individual` + `annotation`; denormalized indexing (serializers + mappings) + extended sync triggers; anonymous-owner `publiclyReadable` correction; `SearchApi` index-aware ACL filter + individual aggregate-strip; corrective-reindex runbook; tests.
+
+**Out (Spec B / later):** detection-via-service-account-token; nested-kNN ACL injection on the annotation embeddings; `occurrence` and `media_asset` token exposure; any write/agentic actions.
+
+**Carried-forward follow-ups (unchanged):** the global session-path metadata leak (separate security PR); orgAdmin `viewUsers` coverage verification — now also load-bearing for the individual `viewUsers` union.
+
+## Open questions for review
+
+1. **Keep/strip field list for individuals** — confirm the exact split against the current `MarkedIndividual.opensearchDocumentSerializer` output; decide whether `sex`/`timeOfBirth`/`timeOfDeath` are "identity" (kept) or sensitive (stripped). Default: kept (matches the page showing them to anyone who can access the individual).
+2. **Anonymous-owner vs invalid-owner reconciliation** — confirm A's current handling so anonymous-owned encounters become `publiclyReadable=true` (world-readable) while invalid/deleted-owner stays admin-only/fail-closed; ensure the two cases aren't conflated in the serializer.
+3. **Sync-trigger guarantee level** — reuse A's queue/bulk path; confirm acceptable latency for child-index ACL propagation (the live `canUserAccess`/B2 backstop is encounter-only; individuals/annotations rely on the indexed gate, so propagation latency = visibility latency).
+4. **Branch/PR strategy** — stack Spec A on the D branch, or wait until A/B/D land on `main` and branch fresh?

--- a/docs/superpowers/specs/2026-06-07-token-scoped-individual-annotation-design.md
+++ b/docs/superpowers/specs/2026-06-07-token-scoped-individual-annotation-design.md
@@ -1,7 +1,7 @@
 # Token-Scoped Individual + Annotation Reads (Spec A) — Design
 
 **Date:** 2026-06-07
-**Status:** Draft — pending Codex design review + user review
+**Status:** Draft — incorporated Codex design review (2026-06-07, verified against real source; FIX-FIRST findings folded). Pending user review.
 **Repo/branch:** Wildbook; new branch off `token-auth-scoped-search` (Artifact D) — or off `main` once A/B/D have landed. Reuses D's `WildbookTokenAuthenticationFilter` + `SearchApi` token path and A's permissions-indexing pattern.
 **Depends on:** Artifact A (merged — `viewUsers` hardening / encounter ACL denormalization), Artifact B (`JwtService`/`AuthToken`), Artifact D (token-scoped encounter search — live-verified on flakebook.wildme.org).
 **Sibling (deferred):** Spec B — detection-via-service-account-token + nested-kNN ACL injection (separate design).
@@ -29,24 +29,28 @@ Per-index ACL fields (written at index time):
 | Index | Fields | Source |
 |---|---|---|
 | `encounter` (exists) | `publiclyReadable`, `submitterUserId`, `viewUsers` | A |
-| `annotation` (new) | `publiclyReadable`, `submitterUserId`, `viewUsers` | copied verbatim from the one parent encounter |
-| `individual` (new) | `publiclyReadable`, `submitterUserIds`, `viewUsers` | **unions** over member encounters |
+| `annotation` (new) | `publiclyReadable`, `submitterUserIds`, `viewUsers` | **union over its parent encounter(s)** |
+| `individual` (new) | `publiclyReadable`, `submitterUserIds`, `viewUsers` | **union over member encounters** |
 
-Individual unions (chosen so the indexed gate is provably equal to `canUserAccessMarkedIndividual`):
-- `publiclyReadable` = `OR` over member encounters' `publiclyReadable` (i.e. *any* member encounter is world-readable).
-- `submitterUserIds` = the **set** of member encounter submitter UUIDs.
-- `viewUsers` = the **union** of member encounters' `viewUsers`.
+**Both child indices use union-over-related-encounters** (Codex High — an annotation is *not* provably 1:1 to one encounter: `Annotation.findByAnnotation`/`findByMediaAsset` can return zero or multiple parent encounters, `Annotation.java:218,1330`; `Encounter.java:3650`). So annotation ACL is the union over **all** its parent encounters, exactly like individual over member encounters — usually a single parent, but correct for 0/many:
+- `publiclyReadable` = `OR` over related encounters' `publiclyReadable` (any related encounter world-readable). **A related encounter set of size 0 → fail closed (admin-only)** for annotations; for **individuals, 0 member encounters → world-readable** (matches `canUserAccessMarkedIndividual` returning true for an encounterless individual — Codex Medium).
+- `submitterUserIds` = the **set** of related encounter submitter UUIDs.
+- `viewUsers` = the **union** of related encounters' `viewUsers`.
 
-Then: *user can access individual* ⟺ `publiclyReadable` OR `user ∈ submitterUserIds` OR `user ∈ viewUsers` ⟺ ∃ member encounter the user can access. ✔ matches the live gate.
+Then: *user can access* ⟺ `publiclyReadable` OR `user ∈ submitterUserIds` OR `user ∈ viewUsers` ⟺ ∃ related encounter the user can access. ✔ matches the live gate (`canUserAccessMarkedIndividual` / per-encounter `canUserAccessEncounter`).
+
+**Single ACL source — no divergence (Codex Medium).** All three indices must derive these fields from **one** centralized computation over **live** encounter state — the same logic Artifact A established (`computeViewUsers` + the public/submitter determination). The annotation/individual serializers must call that same method on their related encounter(s) rather than reading a possibly-stale denormalized value, so the encounter, annotation, and individual ACLs cannot drift. (A's `viewUsers` is written by a bulk permissions pass; the child serializers must invoke the identical computation, not assume the parent doc is already current.)
 
 **Token-path enforcement** (in `SearchApi`, building on D): for a non-admin token request, inject the ACL pre-filter using *that index's* field names, before execution. **Admin token → no filter** (universal access). Token-exposed indices become **`encounter`, `annotation`, `individual`**; `occurrence` and `media_asset` remain **403**. The non-token/session path is **unchanged**.
 
 **Fail-closed during reindex:** until the corrective reindex populates the new fields, they are simply absent on child docs → the pre-filter matches nothing → a non-admin sees *nothing* on those indices. A partial/in-progress reindex degrades to "too restrictive," never "leaky."
 
+**Universal ACL-field stripping from responses (Codex High).** Denormalizing the ACL onto annotation/individual means those internal fields (`publiclyReadable`, `submitterUserId`, `submitterUserIds`, `viewUsers`, and `editUsers` if present) would otherwise be returned in `_source` — and the **session** path returns raw `_source` for annotation/individual today (`OpenSearch.sanitizeDoc:963` returns the doc unchanged for those indices). So `sanitizeDoc` must strip these ACL fields from **every** returned doc, for **all three indices, on both the token and session paths** — independent of, and in addition to, the token-only aggregate-strip for individuals. (D already removes `viewUsers` from encounter responses; generalize that to a universal ACL-field scrub.)
+
 ## Read surfaces
 
 ### Annotation (`POST /api/v3/search/annotation`, token path)
-Annotation is 1:1 with an encounter, so each annotation doc carries the parent encounter's three ACL fields. The token path injects the **same** pre-filter as encounter (identical field names): a non-admin sees only annotations whose encounter they can access; admin bypasses. **Embeddings are returned as-is** (deemed not sensitive). The annotation doc is otherwise gated **wholesale** by the encounter ACL — no content redaction — **except** the internal denormalized ACL fields (`viewUsers`, and the copied `submitterUserId`/`publiclyReadable` if not otherwise meaningful) are removed from the returned doc, consistent with how Artifact D strips `viewUsers` from encounter responses (`sanitizeDoc` → `clean.remove("viewUsers")`). This also gives detection (Spec B) a real annotation read surface.
+Each annotation doc carries the **union** ACL over its parent encounter(s) (`publiclyReadable`/`submitterUserIds`/`viewUsers`; 0 parents → admin-only/fail-closed). The token path injects the **same** `should`-pre-filter (a non-admin sees only annotations whose parent encounter they can access; admin bypasses). **Embeddings are returned as-is** (deemed not sensitive). The annotation doc is otherwise gated **wholesale** by the encounter ACL — no content redaction — except the internal ACL fields are removed by the universal ACL-field scrub (above). This also gives detection (Spec B) a real annotation read surface.
 
 Note: the existing **session** path keeps annotation admin-only (`SearchApi`'s `"annotation".equals(indexName) && !isAdmin → 403`). That gate must NOT block the token path — the token path is governed by the ACL pre-filter instead. The implementation must ensure the annotation-admin-only branch applies only to non-token requests.
 
@@ -63,14 +67,13 @@ Two parts:
    ```
    The user's own query (name/taxonomy/sex/etc.) runs normally, `must`-combined with this gate. (`term` on the keyword-array fields `submitterUserIds`/`viewUsers` matches if any element equals the uuid.)
 
-2. **Strip leaky aggregates** — a token-path sanitizer removes fields computed across *all* member encounters (which would reveal hidden ones), keeping individual-identity attributes:
+2. **Allowlist sanitizer (Codex High — not a denylist).** A token-path sanitizer keeps **only** an explicit allowlist of individual-identity fields and **drops everything else** — so any present-or-future serializer field that's derived from the full member-encounter set is hidden by default (a denylist would silently miss fields like `cooccurrenceIndividualIds`, `numberMediaAssets`, `numberOccurrences`, `MarkedIndividual.java:2813,2839,2858`).
 
-   | Keep (identity attributes) | Strip (cross-encounter aggregates → leak) |
+   | Keep (allowlist — identity attributes) | Everything else → dropped |
    |---|---|
-   | `id`, `displayName`, `names`/`nameMap`, `sex`, `taxonomy`, `timeOfBirth`, `timeOfDeath` | `encounterIds`, `numberEncounters`, `users`, `locationGeoPoints`, `numberLocations`, `maxYearsBetweenResightings`, `socialUnits`, `relationships`, `cooccurrenceIndividualMap`, occurrence-derived counts |
-   | (plus the new ACL fields `publiclyReadable`/`submitterUserIds`/`viewUsers` are stripped from the response) | |
+   | `id`, `displayName`, `names`/`nameMap`, `sex`, `taxonomy`, `timeOfBirth`, `timeOfDeath` | all cross-encounter aggregates: `encounterIds`, `numberEncounters`, `users`, `locationGeoPoints`, `numberLocations`, `maxYearsBetweenResightings`, `socialUnits`, `relationships`, `cooccurrenceIndividualMap`/`cooccurrenceIndividualIds`, `numberMediaAssets`, `numberOccurrences`, occurrence-derived counts, **and any field not in the keep-list** |
 
-   The final keep/strip list is pinned against `MarkedIndividual.opensearchDocumentSerializer` during implementation; any field derived from the full member-encounter set is stripped. `sex`/`timeOfBirth`/`timeOfDeath` are individual-level attributes Wildbook shows to anyone who can access the individual, so they are kept.
+   The allowlist is pinned against the current `MarkedIndividual.opensearchDocumentSerializer` output during implementation, and a test asserts **every** emitted serializer field is either in the keep-list or dropped (so adding a serializer field later can't silently leak). `sex`/`timeOfBirth`/`timeOfDeath` are individual-level attributes Wildbook shows to anyone who can access the individual (page parity), so they are kept — see Open Question 1 for the `names`/`sex`/`taxonomy` "contributed by a hidden encounter" residual.
 
 **Two-hop richness:** the agent obtains the *per-viewer* sighting list, locations, dates, co-occurrences for an individual by querying `POST /api/v3/search/encounter` with `{"query":{"term":{"individualId":"<id>"}}}` — already ACL-scoped. The rich record is assembled across two indices, each enforcing the ACL independently; nothing leaks and individual search keeps full query expressiveness.
 
@@ -81,9 +84,15 @@ Two parts:
 - **Individual serializer** (`MarkedIndividual.opensearchDocumentSerializer`) — in the existing all-member-encounters pass, also compute and emit `publiclyReadable` (OR), `submitterUserIds` (set), `viewUsers` (union).
 - **Mappings** are additive: add the new fields (boolean / keyword) to the existing annotation + individual index mappings (OpenSearch allows adding fields to a live mapping); no drop/recreate required.
 
-**Sync triggers (correctness-critical).** Artifact A reindexes an encounter when its ACL changes (collaboration approve/reject, orgAdmin role change, org membership, user delete/rename/consolidation). Spec A **extends those same trigger points** so that when an encounter's `viewUsers`/`publiclyReadable`/`submitterUserId` changes, we also enqueue reindex of (a) its annotations and (b) its individual. Without this, a revoked viewer could linger on the child indices after the encounter is corrected — the bug class A hardened, now for two more indices. Use the existing bulk/queue path; document any best-effort-vs-guaranteed nuance as A did.
+**Sync triggers (correctness-critical) — two distinct trigger classes:**
 
-**Parity edge — anonymous / null-submitter encounters.** Wildbook's live gate grants these to everyone (`Collaboration.java:477`). The pre-filter only grants via `publiclyReadable`/submitter/`viewUsers`, so indexing must mark anonymous/null-owner encounters as `publiclyReadable=true` (or an equivalent world-readable flag the filter treats as public) — on the **encounter** index too, since today it may under-grant those. This is a small correction that also tightens encounter parity. (Confirm against A's existing handling of invalid/missing owners, which currently writes `[]`/admin-only — reconcile: anonymous-owned ≠ invalid-owner; anonymous-owned is world-readable, invalid/deleted-owner is admin-only/fail-closed.)
+*(i) ACL-change triggers.* Artifact A reindexes an encounter when its ACL changes (collaboration approve/reject, orgAdmin role change, org membership, user delete/rename/consolidation). Spec A **extends those same trigger points** so the encounter's annotations and its individual are also enqueued. Without this, a revoked viewer lingers on the child indices — the bug class A hardened, now for two more indices.
+
+*(ii) Membership-change triggers (Codex High — easy to miss).* The union fields also change when an encounter's *relationship* changes, even if no ACL changed: encounter↔individual reassignment, encounter removal from an individual, and individual **merge/split**. On any such event we must reindex **both the old and the new individual** (capture both IDs *before* the mutation — e.g. `IndividualRemoveEncounter.java:60`, `Encounter.setIndividual`/`MarkedIndividual.removeEncounter`/merge paths), and the affected annotations. Reindexing only "its individual" after the fact misses the stale **old** individual whose union must shrink. Enumerate and cover: encounter added to / removed from / reassigned between individuals, individual merge, individual split, encounter delete/unindex.
+
+Use the existing bulk/queue path; document any best-effort-vs-guaranteed nuance as A did.
+
+**Parity edge — anonymous-owned vs invalid-owner (Codex Medium — use the right predicate).** Wildbook's live gate grants **anonymous-owned** encounters to everyone, where "anonymous" is precisely `User.isUsernameAnonymous(submitterID)` — `null`, blank, `"N/A"`, or `"public"` (`User.java:392`, `Collaboration.java:452-458`, `Encounter.isPubliclyReadable` `Encounter.java:4107`). The indexer must mark those `publiclyReadable=true`. It must **NOT** treat a non-anonymous owner whose `User` lookup happens to be `null` (deleted/invalid) as public — that stays **admin-only/fail-closed** (A's existing invalid-owner handling, `Encounter.java:4398`). So: use `User.isUsernameAnonymous(submitterID)` / `Encounter.isPubliclyReadable()`, never `getSubmitterUser()==null`, to avoid accidentally world-readabling a genuinely-private encounter. This correction belongs in the single ACL source so encounter, annotation, and individual all inherit it.
 
 **Equivalence test (extends A's cross-check).** Add the analogue of A's indexed-vs-live cross-check: for a sample of individuals/annotations, the indexed gate decision matches live `Collaboration.canUserAccessMarkedIndividual` / `canUserAccessEncounter`.
 
@@ -94,15 +103,18 @@ Two parts:
 Small, building on D's structure:
 - Index gate flips from "encounter-only" to a token **allowlist `{encounter, annotation, individual}`**; `occurrence`/`media_asset` still 403.
 - Generalize `OpenSearch.applyEncounterAclFilter(query, uuid)` → `applyAclFilter(query, uuid, indexName)` that selects field names per index (`submitterUserId` for encounter/annotation; `submitterUserIds` for individual; `publiclyReadable`/`viewUsers` common). Same `bool{must:[orig], filter:[should…]}` shape, injected before `queryPit`, admin-bypassed.
-- **Individual result sanitizer**: a token-path branch (in `sanitizeDoc` or a sibling) that strips the cross-encounter aggregate fields (the keep/strip table) from individual hits. Annotation hits pass through whole (embeddings included). Encounter unchanged.
-- Ensure the existing **annotation-admin-only** branch applies only to **non-token** requests (token path uses the ACL filter instead).
+- **Universal ACL-field scrub** (all indices, all paths): `sanitizeDoc` removes `publiclyReadable`/`submitterUserId`/`submitterUserIds`/`viewUsers`/`editUsers` from every returned doc (generalizes D's encounter `viewUsers` removal).
+- **Individual allowlist sanitizer** (token, non-admin): keep only the allowlisted identity fields, drop everything else (see Read surfaces). Annotation hits pass through whole (embeddings included, ACL fields scrubbed). Encounter unchanged beyond the universal scrub.
+- **Resolve the effective index BEFORE the annotation-admin-only gate (Codex Medium).** Today the non-token `"annotation" → admin-only` check runs before a stored query's real `indexName` is resolved, so a stored query over the annotation index could slip past it. Compute the effective index first (direct path index, or the loaded stored query's `indexName`), then apply: on the **non-token/session** path the annotation-admin-only gate uses the effective index; on the **token** path the ACL filter governs instead.
 - Stored-query owner check, method allowlist, fail-closed-unmarked, verified-context binding — **unchanged** from D; already per-index.
 
 ## Testing
 
-- **Unit:** `applyAclFilter` builds the correct clause per index (field names); the individual sanitizer strips exactly the leak set and keeps identity; index allowlist (occurrence/media_asset → 403, annotation/individual allowed on token path).
-- **Serializer unit:** annotation emits parent ACL; individual emits unions (incl. anon-owner → `publiclyReadable=true`); indexed gate matches live `canUserAccessMarkedIndividual` for owner/approved-collab/orgAdmin/rejected-collab/public/anonymous cases.
-- **Integration (real OpenSearch — the decisive proof):** seed encounters with mixed ACLs + their annotations + a shared individual spanning multiple owners; with a non-admin token assert: (a) annotation hits + totals are gated by visible encounters; (b) individual gate = ≥1 visible encounter, hits scoped, leaky aggregates absent from the response, identity present; (c) an individual the user can't see → absent (or stub); (d) admin token → unscoped. Mirrors the live `testy1` proof, extended to the two indices.
+- **Unit:** `applyAclFilter` builds the correct clause per index (field names: `submitterUserId` for encounter, `submitterUserIds` for annotation/individual); index allowlist (occurrence/media_asset → 403; annotation/individual allowed on token path); the **universal ACL-field scrub** removes the ACL fields from encounter, annotation, and individual responses on **both** token and session paths; the effective-index-first ordering blocks a session annotation stored-query from bypassing the admin gate.
+- **Allowlist-completeness test (Codex High):** assert that for the current `MarkedIndividual.opensearchDocumentSerializer` output, **every** emitted field is either in the keep-allowlist or dropped by the sanitizer — guards against a future serializer field silently leaking.
+- **Serializer unit:** annotation emits the **union over parent encounter(s)** (and **0 parents → admin-only**); individual emits unions (and **0 member encounters → `publiclyReadable=true`/world-readable**); anonymous-owned (`isUsernameAnonymous`) → `publiclyReadable=true` while invalid/deleted non-anonymous owner → fail-closed; indexed gate matches live `canUserAccessMarkedIndividual` / `canUserAccessEncounter` for owner/approved-collab/orgAdmin/rejected-collab/public/anonymous/zero-encounter cases (the single-ACL-source guarantees encounter==annotation==individual agreement).
+- **Sync-trigger tests (Codex High):** encounter reassigned between individuals → **both** old and new individual reindexed (old union shrinks); individual merge/split → affected individuals reindexed; encounter ACL change → its annotations + individual reindexed.
+- **Integration (real OpenSearch — the decisive proof):** seed encounters with mixed ACLs + their annotations + a shared individual spanning multiple owners; with a non-admin token assert: (a) annotation hits + totals gated by visible encounters, no ACL fields in `_source`; (b) individual gate = ≥1 visible encounter, hits scoped, only allowlisted identity fields present (no aggregates, no ACL fields); (c) an individual the user can't see → absent; (d) a zero-encounter individual → visible to anyone; (e) admin token → unscoped. Mirrors the live `testy1` proof, extended to the two indices.
 
 ## Scope
 
@@ -114,7 +126,7 @@ Small, building on D's structure:
 
 ## Open questions for review
 
-1. **Keep/strip field list for individuals** — confirm the exact split against the current `MarkedIndividual.opensearchDocumentSerializer` output; decide whether `sex`/`timeOfBirth`/`timeOfDeath` are "identity" (kept) or sensitive (stripped). Default: kept (matches the page showing them to anyone who can access the individual).
+1. **Identity allowlist + the "hidden-encounter-contributed attribute" residual (Codex Medium/Low).** Confirm the allowlist against the current serializer. Note: `names`/`nameMap`, `sex`, and `taxonomy` are individual-level fields that can be *contributed by a member encounter the viewer can't see*, yet Wildbook's individual page shows them wholesale once the individual is visible (`MarkedIndividual.java:2738`, `individuals.jsp:557`). Default = **keep** (exact page parity). Decision for the reviewer: accept this page-parity residual (a name/sex/taxonomy sourced from a hidden encounter is visible), or add a stricter mode that filters name entries to those from visible encounters (more faithful to confidentiality, less faithful to the page, materially more work). Recommend: keep (page parity), document the residual.
 2. **Anonymous-owner vs invalid-owner reconciliation** — confirm A's current handling so anonymous-owned encounters become `publiclyReadable=true` (world-readable) while invalid/deleted-owner stays admin-only/fail-closed; ensure the two cases aren't conflated in the serializer.
 3. **Sync-trigger guarantee level** — reuse A's queue/bulk path; confirm acceptable latency for child-index ACL propagation (the live `canUserAccess`/B2 backstop is encounter-only; individuals/annotations rely on the indexed gate, so propagation latency = visibility latency).
 4. **Branch/PR strategy** — stack Spec A on the D branch, or wait until A/B/D land on `main` and branch fresh?

--- a/docs/superpowers/specs/2026-06-08-token-scoped-media-resolve-design.md
+++ b/docs/superpowers/specs/2026-06-08-token-scoped-media-resolve-design.md
@@ -93,23 +93,35 @@ Response — `200`:
 ]
 ```
 
-**`bbox` is expressed in the pixel space of the returned `imageUrl`** (not the source asset). The
-agent crops `imageUrl` directly to `bbox` with no further scaling; `imageWidth`/`imageHeight` are the
-returned image's dimensions so the agent can sanity-check. `theta` is the annotation's rotation (in
-the same convention Wildbook stores it); the axis-aligned `bbox` bounds the region and the agent may
-rotate the crop by `theta` about the bbox center for an upright view.
+**`bbox` is expressed in the coordinate space given by `imageWidth`×`imageHeight`** — the annotation
+asset's own (reliably-stored) pixel frame, the space `Annotation.getBbox()` uses. The served
+`imageUrl` is an access-controlled derivative whose *actual* pixel size may differ from
+`imageWidth`/`imageHeight` (e.g. a downscaled `_master`). **The consumer fetches `imageUrl`, reads its
+real dimensions, and scales `bbox` by `realW/imageWidth`, `realH/imageHeight` before cropping** —
+typically a no-op (factor 1.0) since `_master` usually equals the source size. `theta` is the
+annotation's rotation; the axis-aligned `bbox` bounds the region and the agent may rotate the crop by
+`theta` about the bbox center for an upright view.
+
+> **Why the consumer scales, not the server (design decision, validated live):** Wildbook extracts
+> image metadata (dimensions) on the **annotation asset**, but does **not** reliably populate it on
+> the generated `_master`/`_mid` **derivative** children — so `derivative.getWidth()` is often `0`. A
+> server that scaled the bbox into the *derivative's* stored dims would therefore omit nearly every
+> annotation (confirmed on flakebook: 0/60 resolved). The server instead uses only data it can trust —
+> the annotation asset's dimensions and Wildbook's own `safeURL` (which already walks to the
+> `_original` and masks the upload) — and the consumer, which holds the fetched image's true pixels,
+> does the final scale.
 
 The endpoint:
 
 1. runs **Spec A's token-ACL-filtered annotation query** over exactly the requested IDs (with query
    `size` = the de-duplicated ID count — **not** SearchApi's default 10) to determine the visible
    subset (single source of ACL truth — Approach A);
-2. for each visible ID, loads the `Annotation` via `Shepherd`, **explicitly selects a safe derivative
-   asset** (try `_master`, then `_mid`; reject `_original` and any other/unknown label — see
-   *Derivative selection* below), reads the source-asset and derivative dimensions, and **scales +
-   clamps** `getBbox()` into the derivative's pixel space;
-3. returns the array. Non-visible / unknown / unresolvable IDs (no safe derivative, missing
-   dimensions, null bbox) are simply **absent** (fail-closed; no existence oracle).
+2. for each visible ID, loads the `Annotation` via `Shepherd`, requires its asset `LocalAssetStore`-backed,
+   reads the annotation asset's own dimensions, clamps `getBbox()` to them (no scaling), and obtains
+   the servable URL (serve the annotation asset's own `webURL` when it is not the raw `_original`,
+   else a `_master`/`_mid` child of it) — see *Servable URL selection*;
+3. returns the array. Non-visible / unknown / unresolvable IDs (source not local, dimensions ≤0, null
+   bbox, no servable URL) are simply **absent** (fail-closed; no existence oracle).
 
 Admin tokens bypass the filter (consistent with Spec A). No new index fields, no image proxy, no UI.
 
@@ -140,44 +152,41 @@ token already passes the search gate for, hand back URL + bbox."*
    all requested IDs as candidates. No DB work for IDs that fail the gate.
 4. For each visible ID, via a read-only `Shepherd`:
    - load `Annotation`; get its source `MediaAsset` (`getMediaAsset()` — the asset the bbox feature
-     lives on) and read source dimensions `(srcW, srcH)`;
-   - **select the safe derivative** (see *Derivative selection*) → the served `MediaAsset`, its
-     `webURL`, and its dimensions `(dstW, dstH)`;
-   - `getBbox()` → `[x, y, w, h]` in source space; **scale into derivative space**:
-     `bbox' = [round(x·dstW/srcW), round(y·dstH/srcH), round(w·dstW/srcW), round(h·dstH/srcH)]`, then
-     **clamp** to `[0,dstW]×[0,dstH]`;
+     lives on); require it `LocalAssetStore`-backed; read its dimensions `(W, H)` (reliably stored on
+     the annotation asset — see the metadata note above);
+   - `clampBbox(getBbox(), W, H)` → `[x, y, w, h]` clamped to `[0,W]×[0,H]` (**no scaling**; bbox stays
+     in the source frame);
+   - obtain the servable URL (see *Servable URL selection*);
    - read `theta`, `viewpoint`, parent `encounterId`/`individualId` (first parent — see *Multi-parent*),
      `methodVersion`(s);
-   - emit `{id, imageUrl, imageWidth:dstW, imageHeight:dstH, bbox:bbox', theta, viewpoint, ...}`.
+   - emit `{id, imageUrl, imageWidth:W, imageHeight:H, bbox, theta, viewpoint, ...}`.
 5. Return the array; rollback + close the `Shepherd` transaction (read-only).
 
-### Derivative selection (Codex High + Medium)
+### Servable URL selection
 
-Do **not** trust `safeURL`/`bestSafeAsset` to avoid originals or to fall back: `bestSafeAsset` forces
-`bestType="original"` for `URLAssetStore` (`MediaAsset.java:770`), returns `this` when it already
-carries the requested label (`:777`), and only checks the *exact* requested type (the `gotBest` reset
-at `:790` means a missing `master` does **not** fall through to `mid`). Instead, select explicitly:
+The served image must be in the **same coordinate frame as the bbox** (the annotation asset's frame),
+so the consumer's scale-only transform is correct (a scale cannot recover a crop offset). Therefore:
 
-- look for a child labeled `_master`; if absent, one labeled `_mid`;
-- the selected asset **must** be `_master` or `_mid` and **must be `LocalAssetStore`-backed** (an
-  allowlist, not a denylist): this rejects `_original`, `URLAssetStore` (external/public originals),
-  and `YouTubeAssetStore` (whose `webURL` is a watch page, not cropable image bytes). The source asset
-  must also be `LocalAssetStore`-backed;
-- if no qualifying `_master`/`_mid` derivative exists, **omit the entry** (fail-closed for that ID).
+- If the annotation asset is **not** the raw upload (`!hasLabel("_original")`) it *is* the bbox frame —
+  serve its own `webURL()` directly. The served image equals the source asset, so `imageWidth/Height`
+  are its real pixels and the consumer scale is exactly 1.0.
+- If the annotation asset **is** the `_original` (raw upload), we must not serve it directly — serve a
+  `_master` (else `_mid`) **child of it** via `bestSafeAsset(myShepherd, null, type)`. That child is an
+  aspect-preserving scale of the *same* frame, so the consumer scales by `realPixels/originalDims`.
+- The chosen asset must be `LocalAssetStore`-backed and not `_original`; any lookup error or a null URL
+  → **omit** (fail-soft, never 500 the batch). We never serve a *different-frame* asset (e.g. a
+  parent's derivative for a crop child), which would make the bbox unrecoverable by scaling.
 
-Both `master` (≤4096²) and `mid` (≤1024×768) are aspect-preserving resizes, so the scale factors
-`dstW/srcW` and `dstH/srcH` are equal up to rounding; the spec scales each axis independently and
-clamps, which is robust to either. Because the bytes are open-by-URL regardless, v1 does **not** tier
-the derivative by caller privilege — every token caller that passes the discovery gate gets the same
-safe (non-original) derivative.
+Do **not** trust `safeURL`/`bestSafeAsset` blindly: `bestSafeAsset` forces `bestType="original"` for
+`URLAssetStore` and `"master"` alone does not fall back to `"mid"` — hence the explicit
+`LocalAssetStore`/non-`_original` guards and the master→mid retry, and the source must be
+`LocalAssetStore` (rejecting `URLAssetStore` externals and `YouTubeAssetStore` watch pages).
 
 ### Null-safety / fail-closed omission
 
 An annotation is **omitted** from the response (not returned blank) when any of: no source MediaAsset;
-null/invalid bbox; no `_master`/`_mid` derivative; missing source or derivative dimensions (`≤0`,
-which would make scaling undefined). Same treatment as a gate miss — indistinguishable from "not
-visible." Omissions are logged server-side at debug so a catalog data problem is diagnosable without
-leaking to the caller.
+source not `LocalAssetStore`; source dimensions `≤0`; null/invalid/empty bbox; no servable URL. Same
+treatment as a gate miss — indistinguishable from "not visible."
 
 ---
 
@@ -211,10 +220,10 @@ one. No new ACL logic is introduced; resolve inherits Spec A's fail-closed multi
 - **Duplicate IDs** → de-duplicated; each appears at most once.
 - **Mixed visible/invisible/nonexistent** → only visible-and-resolvable subset returned; response
   order not guaranteed, so each entry carries its `id`.
-- **Annotation visible but asset/bbox/derivative/dimensions missing** → omitted (fail-closed), debug-logged.
+- **Annotation visible but asset/bbox/dimensions/URL missing** → omitted (fail-closed).
 - **Batch all-invisible** → `200` with `[]`.
 - **`viewpoint` absent** → returned as `null`; **`theta` absent** → returned as `0.0` (the no-rotation
-  default); `imageUrl` + scaled `bbox` + `imageWidth`/`imageHeight` still provided.
+  default); `imageUrl` + source-frame `bbox` + `imageWidth`/`imageHeight` still provided.
 
 ---
 
@@ -227,16 +236,16 @@ one. No new ACL logic is introduced; resolve inherits Spec A's fail-closed multi
 - **Admin bypass:** admin token gets all requested resolvable IDs regardless of ownership.
 - **No existence oracle:** a real-but-invisible ID and a fabricated/garbage ID return the same shape
   (both absent) — assert indistinguishable.
-- **Resolution payload correctness:** for a visible annotation, `imageUrl` is a `_master`/`_mid`
-  derivative URL (never `original`); `viewpoint`/`encounterId`/`individualId`/`methodVersion` match the
-  object.
-- **BBox scaled into derivative space (Codex High):** for an annotation whose source asset is larger
-  than its `_master`/`_mid` derivative, assert the returned `bbox` equals `getBbox()` scaled by
-  `dst/src` and clamped — **not** the raw source-space bbox — and that `imageWidth`/`imageHeight` equal
-  the derivative's dimensions.
-- **Derivative selection (Codex High/Medium):** `_original`-only asset → omitted; `URLAssetStore`-backed
-  asset → omitted; `_master` absent but `_mid` present → resolves via `_mid` (asserts the no-fallback
-  `bestSafeAsset` bug is bypassed); unknown-label-only → omitted.
+- **Resolution payload correctness:** for a visible annotation, `viewpoint`/`encounterId`/
+  `individualId`/`methodVersion` match the object.
+- **Source-frame bbox (Codex High):** the returned `bbox` equals `getBbox()` clamped to the annotation
+  asset's dimensions (**not** scaled), and `imageWidth`/`imageHeight` equal the annotation asset's
+  dimensions — so the consumer's scale to the fetched image is correct even for a crop source.
+- **Servable URL selection:** non-`_original` source asset → served via its own `webURL`; `_original`
+  source → served via a `_master`/`_mid` child of it; non-`LocalAssetStore` source → omitted; null URL
+  → omitted; a lookup error → omitted (fail-soft, batch still 200).
+- **Clamp (Codex High):** negative-origin bbox clamps both corners (width shrinks, not preserved);
+  fully-out-of-bounds or inverted bbox → omitted.
 - **Size guard (Codex Medium):** with > 10 visible IDs in one request, **all** of them resolve (proves
   query `size` = ID count, not the default 10).
 - **Null-safety omission:** annotation with no MediaAsset, null bbox, or missing dimensions is omitted, not blank.
@@ -259,17 +268,17 @@ non-admin token, confirm a private annotation resolves empty.
 
 - `MediaResolveApi.java` (new) — the servlet/endpoint: token-path enforcement (`TOKEN_AUTH_ATTR` +
   verified context), validation, visibility gate (sized to ID count), per-ID resolution, response.
-- A small **derivative-selection + bbox-scaling helper** (in `MediaResolveApi`, or a static helper on
-  `Annotation`/`MediaAsset` if cleaner): selects `_master`→`_mid`, rejects `_original`/`URLAssetStore`/
-  unknown, reads source + derivative dimensions, scales + clamps the bbox. This is the one piece of
-  genuinely new logic; **do not** route it through `safeURL`/`bestSafeAsset` (which the review showed
-  can return originals and won't fall back).
+- Two small static helpers in `MediaResolveApi`: `safeServableUrl(src, shepherd)` (serve the
+  annotation asset's own `webURL` when non-`_original`, else a `_master`/`_mid` child via
+  `bestSafeAsset`; `LocalAssetStore`/non-`_original` guards; fail-soft) and `clampBbox(bbox, W, H)`
+  (corner-clamp to the source frame, no scaling).
 - Reuse: `OpenSearch.applyAclFilter` (annotation gate), `WildbookTokenAuthenticationFilter`,
-  `Annotation.getBbox()`/`getTheta()`/`findEncounter()`, `MediaAsset.findChildrenByLabel`/`webURL`/
-  dimensions, `Shepherd`.
+  `Annotation.getBbox()`/`getTheta()`/`getViewpoint()`/`findEncounter()`/`getEmbeddings()`,
+  `MediaAsset.getWidth()`/`getHeight()`/`getStore()`/`hasLabel()`/`bestSafeAsset()`/`webURL()`,
+  `Encounter.getId()`/`hasMarkedIndividual()`/`getIndividualID()`, `Shepherd`.
 - `web.xml` — register the new endpoint mapping (if not covered by an existing `/api/v3/*` dispatch).
 - Tests: `MediaResolveApiTest.java` (new).
 - Runbook: smoke-test addendum to `childindex-acl-reindex.md`.
 
-This is a self-contained increment off the Spec A branch; it adds one endpoint plus a derivative/bbox
-helper and one test class, and changes no existing ACL or index code paths.
+This is a self-contained increment off the Spec A branch; it adds one endpoint plus the
+`safeServableUrl`/`clampBbox` helpers and one test class, and changes no existing ACL or index code paths.

--- a/docs/superpowers/specs/2026-06-08-token-scoped-media-resolve-design.md
+++ b/docs/superpowers/specs/2026-06-08-token-scoped-media-resolve-design.md
@@ -124,12 +124,14 @@ token already passes the search gate for, hand back URL + bbox."*
 
 ## Data flow
 
-1. **Token-path enforcement (Codex Low).** Require `request.getAttribute(TOKEN_AUTH_ATTR) == true`;
-   otherwise `401` — no session fallback. Resolve `context` from the filter-**verified**
-   `TOKEN_CONTEXT_ATTR` (never request-derived), exactly as `SearchApi` does (`SearchApi.java:25-32`),
-   so a caller can't steer context via `?context=`/cookie/host.
-2. Validate body: `annotationIds` present, is an array, non-empty, size ≤ 100 → else `400`.
-   De-duplicate IDs.
+1. **Token-path enforcement.** Require `request.getAttribute(TOKEN_AUTH_ATTR) == true`; otherwise
+   `401` — no session fallback. Take `context` **only** from the filter-verified `TOKEN_CONTEXT_ATTR`;
+   if it is null/blank → `401`. Unlike `SearchApi` (which still serves session traffic and so falls
+   back to `ServletUtilities.getContext`), this endpoint **never** calls `getContext` — a caller must
+   not be able to steer context via `?context=`/cookie/host.
+2. Validate body **before constructing a `Shepherd`**: parse JSON (unparseable → `400`);
+   `annotationIds` present, is an array, non-empty, size ≤ 100 → else `400`. De-duplicate IDs. No DB
+   or OpenSearch work happens until the body is valid.
 3. **Visibility gate:** build the Spec A token-ACL annotation query (`applyAclFilter`, which wraps the
    query in `bool.must` + ACL in `bool.filter` — composes correctly), with the user query being a
    `terms` filter on `_id ∈ annotationIds`. **Set the query `size` to the de-duplicated ID count
@@ -157,9 +159,11 @@ carries the requested label (`:777`), and only checks the *exact* requested type
 at `:790` means a missing `master` does **not** fall through to `mid`). Instead, select explicitly:
 
 - look for a child labeled `_master`; if absent, one labeled `_mid`;
-- the selected asset **must** be `_master` or `_mid` — reject `_original` and any other/unknown label,
-  and reject `URLAssetStore`-backed assets (treated as public originals);
-- if no `_master`/`_mid` derivative exists, **omit the entry** (fail-closed for that ID).
+- the selected asset **must** be `_master` or `_mid` and **must be `LocalAssetStore`-backed** (an
+  allowlist, not a denylist): this rejects `_original`, `URLAssetStore` (external/public originals),
+  and `YouTubeAssetStore` (whose `webURL` is a watch page, not cropable image bytes). The source asset
+  must also be `LocalAssetStore`-backed;
+- if no qualifying `_master`/`_mid` derivative exists, **omit the entry** (fail-closed for that ID).
 
 Both `master` (≤4096²) and `mid` (≤1024×768) are aspect-preserving resizes, so the scale factors
 `dstW/srcW` and `dstH/srcH` are equal up to rounding; the spec scales each axis independently and
@@ -182,7 +186,7 @@ leaking to the caller.
 | Status | When |
 |--------|------|
 | `200` | Well-formed request + valid token. Body = resolved array; **may be empty** (none visible/exist). Never distinguishes "not visible" from "doesn't exist" — no existence oracle. |
-| `400` | Malformed body: missing/empty `annotationIds`, not an array, or size > 100. |
+| `400` | Malformed body: unparseable JSON, missing/empty `annotationIds`, not an array, or size > 100. Validated **before** any DB/OpenSearch work (no `Shepherd` constructed on a validation failure). |
 | `401` | Missing/invalid/expired token (upstream filter, same as rest of token API). |
 | `500` | Genuine server fault (DB/OpenSearch unreachable) only — never per-ID resolution failure. |
 

--- a/docs/superpowers/specs/2026-06-08-token-scoped-media-resolve-design.md
+++ b/docs/superpowers/specs/2026-06-08-token-scoped-media-resolve-design.md
@@ -119,8 +119,9 @@ The endpoint:
    subset (single source of ACL truth — Approach A);
 2. for each visible ID, loads the `Annotation` via `Shepherd`, requires its asset `LocalAssetStore`-backed,
    reads the annotation asset's own dimensions, clamps `getBbox()` to them (no scaling), and obtains
-   the servable URL (serve the annotation asset's own `webURL` when it is not the raw `_original`,
-   else a `_master`/`_mid` child of it) — see *Servable URL selection*;
+   the servable URL (serve the annotation asset's own `webURL` when it is a child derivative, else —
+   for a raw root, `getParentId()==null` or `_original` — a `_master`/`_mid` child of it) — see
+   *Servable URL selection*;
 3. returns the array. Non-visible / unknown / unresolvable IDs (source not local, dimensions ≤0, null
    bbox, no servable URL) are simply **absent** (fail-closed; no existence oracle).
 
@@ -244,8 +245,9 @@ one. No new ACL logic is introduced; resolve inherits Spec A's fail-closed multi
 - **Source-frame bbox (Codex High):** the returned `bbox` equals `getBbox()` clamped to the annotation
   asset's dimensions (**not** scaled), and `imageWidth`/`imageHeight` equal the annotation asset's
   dimensions — so the consumer's scale to the fetched image is correct even for a crop source.
-- **Servable URL selection:** non-`_original` source asset → served via its own `webURL`; `_original`
-  source → served via a `_master`/`_mid` child of it; non-`LocalAssetStore` source → omitted; null URL
+- **Servable URL selection:** child-derivative source asset (`parentId!=null`, not `_original`) →
+  served via its own `webURL`; raw root (`parentId==null` or `_original`) → served via a `_master`/
+  `_mid` child of it; non-`LocalAssetStore` source → omitted; null URL
   → omitted; a lookup error → omitted (fail-soft, batch still 200).
 - **Clamp (Codex High):** negative-origin bbox clamps both corners (width shrinks, not preserved);
   fully-out-of-bounds or inverted bbox → omitted.
@@ -272,8 +274,9 @@ non-admin token, confirm a private annotation resolves empty.
 - `MediaResolveApi.java` (new) — the servlet/endpoint: token-path enforcement (`TOKEN_AUTH_ATTR` +
   verified context), validation, visibility gate (sized to ID count), per-ID resolution, response.
 - Two small static helpers in `MediaResolveApi`: `safeServableUrl(src, shepherd)` (serve the
-  annotation asset's own `webURL` when non-`_original`, else a `_master`/`_mid` child via
-  `bestSafeAsset`; `LocalAssetStore`/non-`_original` guards; fail-soft) and `clampBbox(bbox, W, H)`
+  annotation asset's own `webURL` when it is a child derivative, else — raw root: `parentId==null`
+  or `_original` — a `_master`/`_mid` child via `bestSafeAsset`; `LocalAssetStore`/non-`_original`/
+  child guards; fail-soft) and `clampBbox(bbox, W, H)`
   (corner-clamp to the source frame, no scaling).
 - Reuse: `OpenSearch.applyAclFilter` (annotation gate), `WildbookTokenAuthenticationFilter`,
   `Annotation.getBbox()`/`getTheta()`/`getViewpoint()`/`findEncounter()`/`getEmbeddings()`,

--- a/docs/superpowers/specs/2026-06-08-token-scoped-media-resolve-design.md
+++ b/docs/superpowers/specs/2026-06-08-token-scoped-media-resolve-design.md
@@ -95,10 +95,10 @@ Response — `200`:
 
 **`bbox` is expressed in the coordinate space given by `imageWidth`×`imageHeight`** — the annotation
 asset's own (reliably-stored) pixel frame, the space `Annotation.getBbox()` uses. The served
-`imageUrl` is an access-controlled derivative whose *actual* pixel size may differ from
-`imageWidth`/`imageHeight` (e.g. a downscaled `_master`). **The consumer fetches `imageUrl`, reads its
-real dimensions, and scales `bbox` by `realW/imageWidth`, `realH/imageHeight` before cropping** —
-typically a no-op (factor 1.0) since `_master` usually equals the source size. `theta` is the
+`imageUrl` is in that same frame: usually the annotation asset itself (so the consumer scale is 1.0),
+or — when the annotation asset is a raw root — a `_master`/`_mid` child whose *actual* pixel size may
+differ. **The consumer fetches `imageUrl`, reads its real dimensions, and scales `bbox` by
+`realW/imageWidth`, `realH/imageHeight` before cropping** (a no-op in the common case). `theta` is the
 annotation's rotation; the axis-aligned `bbox` bounds the region and the agent may rotate the crop by
 `theta` about the bbox center for an upright view.
 
@@ -107,8 +107,9 @@ annotation's rotation; the axis-aligned `bbox` bounds the region and the agent m
 > the generated `_master`/`_mid` **derivative** children — so `derivative.getWidth()` is often `0`. A
 > server that scaled the bbox into the *derivative's* stored dims would therefore omit nearly every
 > annotation (confirmed on flakebook: 0/60 resolved). The server instead uses only data it can trust —
-> the annotation asset's dimensions and Wildbook's own `safeURL` (which already walks to the
-> `_original` and masks the upload) — and the consumer, which holds the fetched image's true pixels,
+> the annotation asset's own dimensions, and a same-frame servable URL (the asset itself when it's a
+> child derivative, else a `_master`/`_mid` child of a raw root) — and the consumer, which holds the
+> fetched image's true pixels,
 > does the final scale.
 
 The endpoint:
@@ -167,11 +168,13 @@ token already passes the search gate for, hand back URL + bbox."*
 The served image must be in the **same coordinate frame as the bbox** (the annotation asset's frame),
 so the consumer's scale-only transform is correct (a scale cannot recover a crop offset). Therefore:
 
-- If the annotation asset is **not** the raw upload (`!hasLabel("_original")`) it *is* the bbox frame —
-  serve its own `webURL()` directly. The served image equals the source asset, so `imageWidth/Height`
-  are its real pixels and the consumer scale is exactly 1.0.
-- If the annotation asset **is** the `_original` (raw upload), we must not serve it directly — serve a
-  `_master` (else `_mid`) **child of it** via `bestSafeAsset(myShepherd, null, type)`. That child is an
+- If the annotation asset is a **child** (`getParentId() != null` and not labeled `_original`) it is a
+  derivative and *is* the bbox frame — serve its own `webURL()` directly. The served image equals the
+  source asset, so `imageWidth/Height` are its real pixels and the consumer scale is exactly 1.0.
+- If the annotation asset is a **raw root** — `getParentId() == null` **or** labeled `_original` — we
+  must not serve it directly (it may be the unmasked upload; some import paths create raw roots
+  *without* the `_original` label, so the tree position, not just the label, is the signal). Serve a
+  `_master` (else `_mid`) **child of it** via `bestSafeAsset(myShepherd, null, type)` — an
   aspect-preserving scale of the *same* frame, so the consumer scales by `realPixels/originalDims`.
 - The chosen asset must be `LocalAssetStore`-backed and not `_original`; any lookup error or a null URL
   → **omit** (fail-soft, never 500 the batch). We never serve a *different-frame* asset (e.g. a

--- a/docs/superpowers/specs/2026-06-08-token-scoped-media-resolve-design.md
+++ b/docs/superpowers/specs/2026-06-08-token-scoped-media-resolve-design.md
@@ -1,0 +1,271 @@
+# Token-Scoped Media Resolve — Design
+
+**Date:** 2026-06-08
+**Status:** Draft — incorporated Codex design review (2026-06-08, verified against real source; all High/Medium/Low findings folded). Pending user review.
+**Builds on:** Spec A — token-scoped individual + annotation reads
+(`2026-06-07-token-scoped-individual-annotation-design.md`) and the token-auth filter / search API
+already shipped in PR #1613.
+
+---
+
+## Problem
+
+The AI co-scientist's embedding sweeps surface candidate "missed matches" (two annotations whose
+MiewID embeddings are suspiciously similar across different individuals). To make a sweep result
+*verifiable*, a human or agent needs to **see the two annotation regions side by side** — the exact
+bbox + viewpoint the embedding was computed from, not the whole photo.
+
+Today the token API exposes `encounter`, `annotation`, and `individual`, but:
+
+- the `annotation` index returns only a bare integer `mediaAssetId` — **no fetchable image URL**;
+- the `media_asset` index is `403` (deferred);
+- so a token-only agent (no web session) **cannot resolve an annotation to an image** it can display.
+
+This design closes that gap with the minimum surface needed for visual verification.
+
+## Goal
+
+Let a token-bearing agent resolve a set of annotation IDs it is **already allowed to see** into the
+data needed to render a side-by-side crop comparison: an access-controlled image URL plus the
+annotation's bounding box and orientation metadata. The agent fetches the image and crops it itself
+(no server-side cropping, no new Wildbook UI).
+
+## Non-Goals
+
+- Server-side crop rendering or stored crop derivatives (consumer/agent renders).
+- A hosted comparison-view UI page (consumer/agent renders).
+- Exposing the full `media_asset` index or its store internals.
+- Privilege-tiered derivatives (master vs mid by caller) — noted as future, not built (YAGNI).
+- Signed/expiring image URLs — noted as future hardening, not built (YAGNI).
+
+---
+
+## Security model (explicit)
+
+Empirically verified on flakebook: Wildbook's derivative image URLs
+(`/wildbook_data_dir/.../<uuid>-mid.jpg`) are **open-by-URL** — the same bytes return with no auth at
+all (HTTP 200) as with credentials. They are UUID-path files served directly by the webserver; there
+is no ACL check at fetch time. (`ImgFilter` covers only `/di/ImgFilter/*`, a dynamic-resize path, not
+derivative serving.)
+
+Therefore the access-control model for this feature is:
+
+> **ACL is enforced at URL-*discovery* time, not at fetch time.** The endpoint reveals an image URL
+> only for annotations the token is permitted to see. Image bytes themselves are protected solely by
+> unguessable-UUID paths (a capability-URL model). You cannot fetch what you cannot discover.
+
+**Accepted tradeoff:** a URL handed to an agent is bearer-less and never expires; if logged, cached,
+or copied, anyone with the string can fetch the image indefinitely. This is *not a new* weakness — it
+is exactly how Wildbook already serves every image — but this endpoint makes such URLs easier to
+harvest. For the intended use (admin-token co-scientist over a research catalog) this is acceptable.
+The future hardening, if sensitive imagery becomes a concern, is signed/expiring URLs.
+
+---
+
+## Architecture & boundary
+
+A single new token-gated endpoint:
+
+```
+POST /api/v3/media/resolve
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{ "annotationIds": ["<uuid>", "<uuid>", ...] }   // 1..100 ids
+```
+
+Response — `200`:
+
+```json
+[
+  {
+    "id": "<annotationId>",
+    "imageUrl": "https://host/wildbook_data_dir/.../<uuid>-master.jpg",
+    "imageWidth": 1024,
+    "imageHeight": 768,
+    "bbox": [x, y, width, height],
+    "theta": 0.0,
+    "viewpoint": "up",
+    "encounterId": "<encId>",
+    "individualId": "<indivId or null>",
+    "methodVersion": ["msv4.1"]
+  }
+]
+```
+
+**`bbox` is expressed in the pixel space of the returned `imageUrl`** (not the source asset). The
+agent crops `imageUrl` directly to `bbox` with no further scaling; `imageWidth`/`imageHeight` are the
+returned image's dimensions so the agent can sanity-check. `theta` is the annotation's rotation (in
+the same convention Wildbook stores it); the axis-aligned `bbox` bounds the region and the agent may
+rotate the crop by `theta` about the bbox center for an upright view.
+
+The endpoint:
+
+1. runs **Spec A's token-ACL-filtered annotation query** over exactly the requested IDs (with query
+   `size` = the de-duplicated ID count — **not** SearchApi's default 10) to determine the visible
+   subset (single source of ACL truth — Approach A);
+2. for each visible ID, loads the `Annotation` via `Shepherd`, **explicitly selects a safe derivative
+   asset** (try `_master`, then `_mid`; reject `_original` and any other/unknown label — see
+   *Derivative selection* below), reads the source-asset and derivative dimensions, and **scales +
+   clamps** `getBbox()` into the derivative's pixel space;
+3. returns the array. Non-visible / unknown / unresolvable IDs (no safe derivative, missing
+   dimensions, null bbox) are simply **absent** (fail-closed; no existence oracle).
+
+Admin tokens bypass the filter (consistent with Spec A). No new index fields, no image proxy, no UI.
+
+### Why Approach A (reuse the Spec A gate)
+
+The ACL decision reuses the already-reviewed, already-deployed token-filtered annotation query rather
+than introducing a second permission check. This avoids the dual-writer/dual-evaluator drift that has
+repeatedly bitten the `viewUsers` ACL work. The resolve endpoint is a thin layer: *"given IDs the
+token already passes the search gate for, hand back URL + bbox."*
+
+---
+
+## Data flow
+
+1. **Token-path enforcement (Codex Low).** Require `request.getAttribute(TOKEN_AUTH_ATTR) == true`;
+   otherwise `401` — no session fallback. Resolve `context` from the filter-**verified**
+   `TOKEN_CONTEXT_ATTR` (never request-derived), exactly as `SearchApi` does (`SearchApi.java:25-32`),
+   so a caller can't steer context via `?context=`/cookie/host.
+2. Validate body: `annotationIds` present, is an array, non-empty, size ≤ 100 → else `400`.
+   De-duplicate IDs.
+3. **Visibility gate:** build the Spec A token-ACL annotation query (`applyAclFilter`, which wraps the
+   query in `bool.must` + ACL in `bool.filter` — composes correctly), with the user query being a
+   `terms` filter on `_id ∈ annotationIds`. **Set the query `size` to the de-duplicated ID count
+   (Codex Medium)** — SearchApi's default is 10, which would silently drop visible IDs beyond the
+   first 10. Run it; returned hit IDs = the visible subset. Admin token → skip the ACL filter, treat
+   all requested IDs as candidates. No DB work for IDs that fail the gate.
+4. For each visible ID, via a read-only `Shepherd`:
+   - load `Annotation`; get its source `MediaAsset` (`getMediaAsset()` — the asset the bbox feature
+     lives on) and read source dimensions `(srcW, srcH)`;
+   - **select the safe derivative** (see *Derivative selection*) → the served `MediaAsset`, its
+     `webURL`, and its dimensions `(dstW, dstH)`;
+   - `getBbox()` → `[x, y, w, h]` in source space; **scale into derivative space**:
+     `bbox' = [round(x·dstW/srcW), round(y·dstH/srcH), round(w·dstW/srcW), round(h·dstH/srcH)]`, then
+     **clamp** to `[0,dstW]×[0,dstH]`;
+   - read `theta`, `viewpoint`, parent `encounterId`/`individualId` (first parent — see *Multi-parent*),
+     `methodVersion`(s);
+   - emit `{id, imageUrl, imageWidth:dstW, imageHeight:dstH, bbox:bbox', theta, viewpoint, ...}`.
+5. Return the array; rollback + close the `Shepherd` transaction (read-only).
+
+### Derivative selection (Codex High + Medium)
+
+Do **not** trust `safeURL`/`bestSafeAsset` to avoid originals or to fall back: `bestSafeAsset` forces
+`bestType="original"` for `URLAssetStore` (`MediaAsset.java:770`), returns `this` when it already
+carries the requested label (`:777`), and only checks the *exact* requested type (the `gotBest` reset
+at `:790` means a missing `master` does **not** fall through to `mid`). Instead, select explicitly:
+
+- look for a child labeled `_master`; if absent, one labeled `_mid`;
+- the selected asset **must** be `_master` or `_mid` — reject `_original` and any other/unknown label,
+  and reject `URLAssetStore`-backed assets (treated as public originals);
+- if no `_master`/`_mid` derivative exists, **omit the entry** (fail-closed for that ID).
+
+Both `master` (≤4096²) and `mid` (≤1024×768) are aspect-preserving resizes, so the scale factors
+`dstW/srcW` and `dstH/srcH` are equal up to rounding; the spec scales each axis independently and
+clamps, which is robust to either. Because the bytes are open-by-URL regardless, v1 does **not** tier
+the derivative by caller privilege — every token caller that passes the discovery gate gets the same
+safe (non-original) derivative.
+
+### Null-safety / fail-closed omission
+
+An annotation is **omitted** from the response (not returned blank) when any of: no source MediaAsset;
+null/invalid bbox; no `_master`/`_mid` derivative; missing source or derivative dimensions (`≤0`,
+which would make scaling undefined). Same treatment as a gate miss — indistinguishable from "not
+visible." Omissions are logged server-side at debug so a catalog data problem is diagnosable without
+leaking to the caller.
+
+---
+
+## Error model
+
+| Status | When |
+|--------|------|
+| `200` | Well-formed request + valid token. Body = resolved array; **may be empty** (none visible/exist). Never distinguishes "not visible" from "doesn't exist" — no existence oracle. |
+| `400` | Malformed body: missing/empty `annotationIds`, not an array, or size > 100. |
+| `401` | Missing/invalid/expired token (upstream filter, same as rest of token API). |
+| `500` | Genuine server fault (DB/OpenSearch unreachable) only — never per-ID resolution failure. |
+
+**No `403` in v1.** Resolving an annotation's image is conceptually an annotation read, and Spec A
+already permits *any* valid token to query the annotation index (gating happens per-document). This
+endpoint follows the same rule: every valid token may call it, and per-ID visibility governs what
+comes back. A `403` (endpoint-level scope denial) is reserved for a future per-token-scope model and
+is not emitted in v1.
+
+### Multi-parent annotations (Codex Medium)
+
+An annotation can have 0 or >1 parent encounters. Spec A's `Annotation.writeAclFields`
+(`Annotation.java:1344`) indexes any 0-or-many-parent annotation as **admin-only** (fail-closed), so a
+non-admin token **never** resolves such an annotation — the visibility gate already excludes it. For
+the admin path (which bypasses the gate) and for the returned `encounterId`/`individualId`, resolve
+uses `findEncounter()` (`Encounter.java:3695`), which returns the **first** parent. This is documented
+behavior: `encounterId`/`individualId` denote *a* parent of a multi-parent annotation, not the sole
+one. No new ACL logic is introduced; resolve inherits Spec A's fail-closed multi-parent treatment.
+
+### Edge cases
+
+- **Duplicate IDs** → de-duplicated; each appears at most once.
+- **Mixed visible/invisible/nonexistent** → only visible-and-resolvable subset returned; response
+  order not guaranteed, so each entry carries its `id`.
+- **Annotation visible but asset/bbox/derivative/dimensions missing** → omitted (fail-closed), debug-logged.
+- **Batch all-invisible** → `200` with `[]`.
+- **`viewpoint` absent** → returned as `null`; **`theta` absent** → returned as `0.0` (the no-rotation
+  default); `imageUrl` + scaled `bbox` + `imageWidth`/`imageHeight` still provided.
+
+---
+
+## Testing
+
+**Unit / integration (JUnit 5, message-last assertions, mirroring Spec A test style):**
+
+- **Visibility gate honored:** non-admin token requesting {own-encounter, other-user-private,
+  publicly-readable} annotations gets back only own + public; the private one is absent.
+- **Admin bypass:** admin token gets all requested resolvable IDs regardless of ownership.
+- **No existence oracle:** a real-but-invisible ID and a fabricated/garbage ID return the same shape
+  (both absent) — assert indistinguishable.
+- **Resolution payload correctness:** for a visible annotation, `imageUrl` is a `_master`/`_mid`
+  derivative URL (never `original`); `viewpoint`/`encounterId`/`individualId`/`methodVersion` match the
+  object.
+- **BBox scaled into derivative space (Codex High):** for an annotation whose source asset is larger
+  than its `_master`/`_mid` derivative, assert the returned `bbox` equals `getBbox()` scaled by
+  `dst/src` and clamped — **not** the raw source-space bbox — and that `imageWidth`/`imageHeight` equal
+  the derivative's dimensions.
+- **Derivative selection (Codex High/Medium):** `_original`-only asset → omitted; `URLAssetStore`-backed
+  asset → omitted; `_master` absent but `_mid` present → resolves via `_mid` (asserts the no-fallback
+  `bestSafeAsset` bug is bypassed); unknown-label-only → omitted.
+- **Size guard (Codex Medium):** with > 10 visible IDs in one request, **all** of them resolve (proves
+  query `size` = ID count, not the default 10).
+- **Null-safety omission:** annotation with no MediaAsset, null bbox, or missing dimensions is omitted, not blank.
+- **Validation:** empty list, non-array, and >100 IDs each → `400`; missing/expired token or
+  non-`TOKEN_AUTH_ATTR` request → `401`.
+- **De-dup:** duplicate IDs collapse to one entry.
+- **Multi-parent:** a >1-parent annotation is admin-only — non-admin token omits it; admin path returns
+  first-parent `encounterId`/`individualId`. Malformed/garbage IDs on the admin path are omitted (not 500).
+
+**Live smoke test** (append to `docs/superpowers/runbooks/childindex-acl-reindex.md`):
+with claudio's admin token on flakebook, resolve the two salamander candidate annotations
+(BGBI_22-168 ↔ BGBI_23-2716); confirm `200` with both `imageUrl`s fetchable + bboxes present. With a
+non-admin token, confirm a private annotation resolves empty.
+
+**No index/mapping changes → no reindex required** for this feature (unlike Spec A).
+
+---
+
+## Components / file boundary (anticipated)
+
+- `MediaResolveApi.java` (new) — the servlet/endpoint: token-path enforcement (`TOKEN_AUTH_ATTR` +
+  verified context), validation, visibility gate (sized to ID count), per-ID resolution, response.
+- A small **derivative-selection + bbox-scaling helper** (in `MediaResolveApi`, or a static helper on
+  `Annotation`/`MediaAsset` if cleaner): selects `_master`→`_mid`, rejects `_original`/`URLAssetStore`/
+  unknown, reads source + derivative dimensions, scales + clamps the bbox. This is the one piece of
+  genuinely new logic; **do not** route it through `safeURL`/`bestSafeAsset` (which the review showed
+  can return originals and won't fall back).
+- Reuse: `OpenSearch.applyAclFilter` (annotation gate), `WildbookTokenAuthenticationFilter`,
+  `Annotation.getBbox()`/`getTheta()`/`findEncounter()`, `MediaAsset.findChildrenByLabel`/`webURL`/
+  dimensions, `Shepherd`.
+- `web.xml` — register the new endpoint mapping (if not covered by an existing `/api/v3/*` dispatch).
+- Tests: `MediaResolveApiTest.java` (new).
+- Runbook: smoke-test addendum to `childindex-acl-reindex.md`.
+
+This is a self-contained increment off the Spec A branch; it adds one endpoint plus a derivative/bbox
+helper and one test class, and changes no existing ACL or index code paths.

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <testcontainers.version>2.0.3</testcontainers.version>
     <rest-assured.version>5.4.0</rest-assured.version>
     <wiremock.version>3.3.1</wiremock.version>
+    <jjwt.version>0.12.6</jjwt.version>
   </properties>
 
   <repositories>
@@ -616,6 +617,25 @@
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
       <version>2.3.0.1</version>
+    </dependency>
+
+    <!-- JWT signing / verification for scoped-access tokens -->
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>${jjwt.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>${jjwt.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>${jjwt.version}</version>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -180,6 +180,10 @@ public class Annotation extends Base implements java.io.Serializable {
         map.put("encounterTaxonomy", keywordType);
         map.put("encounterProjectIds", keywordType);
 
+        // ACL fields (viewUsers is inherited from Base.opensearchMapping())
+        map.put("publiclyReadable", new JSONObject("{\"type\": \"boolean\"}"));
+        map.put("submitterUserIds", keywordType);
+
         // all case-insensitive keyword-ish types
         // map.put("fubar", keywordNormalType);
 
@@ -238,6 +242,7 @@ public class Annotation extends Base implements java.io.Serializable {
                 if (tod > 0) jgen.writeNumberField("encounterIndividualTimeOfDeath", tod);
             }
         }
+        this.writeAclFields(jgen, myShepherd);
         jgen.writeArrayFieldStart("embeddings");
         if (this.embeddings != null)
             for (Embedding emb : this.embeddings) {
@@ -1329,6 +1334,43 @@ public class Annotation extends Base implements java.io.Serializable {
     // convenience!
     public Encounter findEncounter(Shepherd myShepherd) {
         return Encounter.findByAnnotation(this, myShepherd);
+    }
+
+    /** All parent encounters of this annotation (0 = orphan; >1 = anomalous). */
+    public java.util.List<Encounter> parentEncounters(Shepherd myShepherd) {
+        return Encounter.findAllByAnnotation(this, myShepherd);
+    }
+
+    /**
+     * Write the denormalized ACL from this annotation's SINGLE parent encounter.
+     * 0 parents (orphan) or >1 parents (anomalous) -> fail closed (admin-only), because the doc's
+     * encounter* metadata fields come from only the first parent and must not be exposed to a user
+     * authorized via a different parent.
+     */
+    public void writeAclFields(com.fasterxml.jackson.core.JsonGenerator jgen, Shepherd myShepherd)
+    throws java.io.IOException {
+        boolean pub = false;
+        java.util.Set<String> submitters = new java.util.LinkedHashSet<String>();
+        java.util.Set<String> viewers = new java.util.LinkedHashSet<String>();
+        java.util.List<Encounter> parents = this.parentEncounters(myShepherd);
+        if (parents.size() == 1) { // exactly one parent: use its ACL
+            org.json.JSONObject acl = parents.get(0).opensearchAclFields(myShepherd);
+            if (acl.optBoolean("publiclyReadable", false)) pub = true;
+            String sid = acl.optString("submitterUserId", null);
+            if (sid != null) submitters.add(sid);
+            org.json.JSONArray vu = acl.optJSONArray("viewUsers");
+            if (vu != null) for (int i = 0; i < vu.length(); i++) viewers.add(vu.optString(i));
+        } else if (parents.size() > 1) {
+            System.out.println("Annotation.writeAclFields: " + this.getId() + " has " + parents.size()
+                + " parent encounters -> indexing admin-only (fail closed)");
+        }
+        jgen.writeBooleanField("publiclyReadable", pub); // false for 0/many parents
+        jgen.writeArrayFieldStart("submitterUserIds");
+        for (String s : submitters) jgen.writeString(s);
+        jgen.writeEndArray();
+        jgen.writeArrayFieldStart("viewUsers");
+        for (String v : viewers) jgen.writeString(v);
+        jgen.writeEndArray();
     }
 
     // this is a little tricky. the idea is the end result will get us an Encounter, which *may* be new

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -3712,14 +3712,13 @@ public class Encounter extends Base implements java.io.Serializable {
 
     /** All encounters whose annotations contain this annotation (usually 0 or 1; >1 is anomalous). */
     public static java.util.List<Encounter> findAllByAnnotation(Annotation annot, Shepherd myShepherd) {
-        String queryString =
-            "SELECT FROM org.ecocean.Encounter WHERE annotations.contains(ann) && ann.id == '"
-            + annot.getId() + "'";
-        javax.jdo.Query query = myShepherd.getPM().newQuery(queryString);
+        javax.jdo.Query query = myShepherd.getPM().newQuery(
+            "SELECT FROM org.ecocean.Encounter WHERE annotations.contains(ann) && ann.id == annId");
+        query.declareParameters("String annId");
         java.util.List<Encounter> out = new java.util.ArrayList<Encounter>();
         try {
-            java.util.List results = (java.util.List) query.execute();
-            if (results != null) for (Object o : results) out.add((Encounter) o);
+            java.util.List results = (java.util.List)query.execute(annot.getId());
+            if (results != null) for (Object o : results) out.add((Encounter)o);
         } finally {
             query.closeAll();
         }

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -1259,8 +1259,11 @@ public class Encounter extends Base implements java.io.Serializable {
         this.refreshAnnotationLiteIndividual();
         // membership change: refresh this encounter (deep -> its new individual + annotations)
         // and the OLD individual it left (so the departed encounter is dropped from its ACL).
-        this.enqueueAclReindex();
-        if (old != null && old != indiv) old.enqueueAclReindex();
+        // Only enqueue when membership actually changed; a no-op set (old == indiv) changes nothing.
+        if (old != indiv) {
+            this.enqueueAclReindex();
+            if (old != null) old.enqueueAclReindex();
+        }
     }
 
     public MarkedIndividual getIndividual() {
@@ -4337,11 +4340,17 @@ public class Encounter extends Base implements java.io.Serializable {
                     }
                 }
                 updateData.put("viewUsers", viewUsers); // always write, incl [] so revocation propagates
-                // Change-detection: compare freshly computed viewUsers (as a set) to what is
-                // CURRENTLY indexed. On a real difference (or if the current value can't be read),
-                // deep-reindex THIS encounter so its individual + annotations get the new ACL.
-                // Best-effort: a missed propagation is recovered by the reconciler / corrective reindex.
-                boolean viewUsersChanged = true; // default to "changed" when current state is unknown
+                // Child-reindex change-detection: compare freshly computed viewUsers (as a set) to
+                // what is CURRENTLY indexed. Enqueue the deep child reindex ONLY when the currently
+                // indexed value was READABLE (non-null) and genuinely DIFFERS.
+                // When getIndexedViewUsers returns null (missing doc / unreadable / degraded read) we
+                // do NOT enqueue: the encounter isn't reliably indexed yet, and on a degraded pass a
+                // null-means-changed default would storm child reindexes for every encounter. The
+                // tradeoff is a rare miss for a genuinely-fresh-but-not-yet-readable encounter, which
+                // is recovered by the normal indexing-queue / opensearchIndexDeep path plus the
+                // periodic reconciler / corrective reindex. The encounter's own indexUpdate below is
+                // unconditional, so its viewUsers stays current regardless.
+                boolean childReindexNeeded = false; // only true on a confirmed, readable difference
                 try {
                     org.json.JSONArray current = os.getIndexedViewUsers("encounter", id);
                     if (current != null) {
@@ -4351,17 +4360,17 @@ public class Encounter extends Base implements java.io.Serializable {
                         Set<String> newSet = new java.util.HashSet<String>();
                         for (int ni = 0; ni < viewUsers.length(); ni++) newSet.add(viewUsers.optString(ni, null));
                         newSet.remove(null);
-                        viewUsersChanged = !currentSet.equals(newSet);
+                        childReindexNeeded = !currentSet.equals(newSet);
                     }
                 } catch (Exception ex) {
-                    viewUsersChanged = true; // unknown -> propagate to be safe
+                    childReindexNeeded = false; // unreadable -> don't storm; recoverable via reconciler
                 }
                 try {
                     os.indexUpdate("encounter", id, updateData);
                 } catch (Exception ex) {
                     viewUsersWriteFailures++; // aggregate only — no per-doc noise during index build
                 }
-                if (viewUsersChanged) {
+                if (childReindexNeeded) {
                     try {
                         Encounter enc = myShepherd.getEncounter(id);
                         if (enc != null) enc.enqueueAclReindex(); // refresh individual + annotations

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -3395,6 +3395,32 @@ public class Encounter extends Base implements java.io.Serializable {
         return computeViewUsers(myShepherd);
     }
 
+    /**
+     * Single source of this encounter's OpenSearch ACL fields, reused by the encounter,
+     * annotation, and individual indexing so all three agree. publiclyReadable mirrors
+     * isPubliclyReadable() (security-disabled OR anonymous owner). For a non-public encounter:
+     * submitterUserId is the resolved owner's UUID (absent if the owner is invalid/deleted ->
+     * admin-only/fail-closed), and viewUsers is computeViewUsers() (approved/edit collaborators +
+     * submitter-org orgAdmins). Anonymous-owned -> public; invalid/deleted non-anonymous owner -> closed.
+     * Semantically equivalent to (not byte-identical with) the encounter index's own serialization
+     * (e.g. for a public encounter we omit submitterUserId since publiclyReadable=true already grants);
+     * the ACCESS DECISION is identical, only the stored field set differs harmlessly.
+     */
+    public org.json.JSONObject opensearchAclFields(Shepherd myShepherd) {
+        org.json.JSONObject acl = new org.json.JSONObject();
+        boolean pub = this.isPubliclyReadable();
+        acl.put("publiclyReadable", pub);
+        org.json.JSONArray vu = new org.json.JSONArray();
+        if (!pub) {
+            User submitter = this.getSubmitterUser(myShepherd);
+            if ((submitter != null) && (submitter.getId() != null))
+                acl.put("submitterUserId", submitter.getId());
+            for (String id : this.computeViewUsers(myShepherd)) vu.put(id);
+        }
+        acl.put("viewUsers", vu);
+        return acl;
+    }
+
 /*
     public List<String> userIdsWithEditAccess(Shepherd myShepherd) {
         List<String> ids = new ArrayList<String>();

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -3691,6 +3691,22 @@ public class Encounter extends Base implements java.io.Serializable {
         return returnEnc;
     }
 
+    /** All encounters whose annotations contain this annotation (usually 0 or 1; >1 is anomalous). */
+    public static java.util.List<Encounter> findAllByAnnotation(Annotation annot, Shepherd myShepherd) {
+        String queryString =
+            "SELECT FROM org.ecocean.Encounter WHERE annotations.contains(ann) && ann.id == '"
+            + annot.getId() + "'";
+        javax.jdo.Query query = myShepherd.getPM().newQuery(queryString);
+        java.util.List<Encounter> out = new java.util.ArrayList<Encounter>();
+        try {
+            java.util.List results = (java.util.List) query.execute();
+            if (results != null) for (Object o : results) out.add((Encounter) o);
+        } finally {
+            query.closeAll();
+        }
+        return out;
+    }
+
     public static Encounter findByAnnotationId(String annid, Shepherd myShepherd) {
         Annotation ann = ((Annotation)(myShepherd.getPM().getObjectById(
             myShepherd.getPM().newObjectIdInstance(Annotation.class, annid), true)));

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -1242,9 +1242,25 @@ public class Encounter extends Base implements java.io.Serializable {
         setIndividual(indiv);
     }
 
+    /** Enqueue a (deep) reindex of this encounter — refreshes its individual + annotations' ACL.
+     *  Honors skipAutoIndexing so bulk import / deserialization don't storm. */
+    public void enqueueAclReindex() {
+        if (this.getSkipAutoIndexing()) return;
+        try {
+            IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false);
+        } catch (Exception ex) {
+            System.out.println("Encounter.enqueueAclReindex failed for " + this.getId() + ": " + ex);
+        }
+    }
+
     public void setIndividual(MarkedIndividual indiv) {
+        MarkedIndividual old = this.individual;
         if (indiv == null) { this.individual = null; } else { this.individual = indiv; }
         this.refreshAnnotationLiteIndividual();
+        // membership change: refresh this encounter (deep -> its new individual + annotations)
+        // and the OLD individual it left (so the departed encounter is dropped from its ACL).
+        this.enqueueAclReindex();
+        if (old != null && old != indiv) old.enqueueAclReindex();
     }
 
     public MarkedIndividual getIndividual() {
@@ -4321,10 +4337,37 @@ public class Encounter extends Base implements java.io.Serializable {
                     }
                 }
                 updateData.put("viewUsers", viewUsers); // always write, incl [] so revocation propagates
+                // Change-detection: compare freshly computed viewUsers (as a set) to what is
+                // CURRENTLY indexed. On a real difference (or if the current value can't be read),
+                // deep-reindex THIS encounter so its individual + annotations get the new ACL.
+                // Best-effort: a missed propagation is recovered by the reconciler / corrective reindex.
+                boolean viewUsersChanged = true; // default to "changed" when current state is unknown
+                try {
+                    org.json.JSONArray current = os.getIndexedViewUsers("encounter", id);
+                    if (current != null) {
+                        Set<String> currentSet = new java.util.HashSet<String>();
+                        for (int ci = 0; ci < current.length(); ci++) currentSet.add(current.optString(ci, null));
+                        currentSet.remove(null);
+                        Set<String> newSet = new java.util.HashSet<String>();
+                        for (int ni = 0; ni < viewUsers.length(); ni++) newSet.add(viewUsers.optString(ni, null));
+                        newSet.remove(null);
+                        viewUsersChanged = !currentSet.equals(newSet);
+                    }
+                } catch (Exception ex) {
+                    viewUsersChanged = true; // unknown -> propagate to be safe
+                }
                 try {
                     os.indexUpdate("encounter", id, updateData);
                 } catch (Exception ex) {
                     viewUsersWriteFailures++; // aggregate only — no per-doc noise during index build
+                }
+                if (viewUsersChanged) {
+                    try {
+                        Encounter enc = myShepherd.getEncounter(id);
+                        if (enc != null) enc.enqueueAclReindex(); // refresh individual + annotations
+                    } catch (Exception ex) {
+                        // best-effort; reconciler / corrective reindex recovers a missed child refresh
+                    }
                 }
             }
         } catch (Exception ex) {

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -1245,7 +1245,7 @@ public class Encounter extends Base implements java.io.Serializable {
     /** Enqueue a (deep) reindex of this encounter — refreshes its individual + annotations' ACL.
      *  Honors skipAutoIndexing so bulk import / deserialization don't storm. */
     public void enqueueAclReindex() {
-        if (this.getSkipAutoIndexing()) return;
+        if (this.getSkipAutoIndexing() || OpenSearch.skipAutoIndexing()) return;
         try {
             IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false);
         } catch (Exception ex) {

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -2691,6 +2691,32 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         myShepherd.throwAwayMarkedIndividual(other);
     }
 
+    /** Denormalized ACL union over member encounters; 0 encounters -> world-readable (matches the live gate). */
+    public void writeAclFields(com.fasterxml.jackson.core.JsonGenerator jgen, Shepherd myShepherd)
+    throws java.io.IOException {
+        java.util.List<Encounter> encs = this.getEncounters();
+        boolean pub = (encs == null) || encs.isEmpty(); // encounterless -> visible to anyone
+        java.util.Set<String> submitters = new java.util.LinkedHashSet<String>();
+        java.util.Set<String> viewers = new java.util.LinkedHashSet<String>();
+        if (encs != null) {
+            for (Encounter enc : encs) {
+                org.json.JSONObject acl = enc.opensearchAclFields(myShepherd);
+                if (acl.optBoolean("publiclyReadable", false)) pub = true;
+                String sid = acl.optString("submitterUserId", null);
+                if (sid != null) submitters.add(sid);
+                org.json.JSONArray vu = acl.optJSONArray("viewUsers");
+                if (vu != null) for (int i = 0; i < vu.length(); i++) viewers.add(vu.optString(i));
+            }
+        }
+        jgen.writeBooleanField("publiclyReadable", pub);
+        jgen.writeArrayFieldStart("submitterUserIds");
+        for (String s : submitters) jgen.writeString(s);
+        jgen.writeEndArray();
+        jgen.writeArrayFieldStart("viewUsers");
+        for (String v : viewers) jgen.writeString(v);
+        jgen.writeEndArray();
+    }
+
     public org.json.JSONObject opensearchMapping() {
         org.json.JSONObject map = super.opensearchMapping();
         org.json.JSONObject keywordType = new org.json.JSONObject("{\"type\": \"keyword\"}");
@@ -2717,12 +2743,15 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         map.put("relationships", new org.json.JSONObject("{\"type\": \"nested\"}"));
         map.put("cooccurrenceIndividualMap",
             new org.json.JSONObject("{\"type\": \"nested\", \"dynamic\": false}"));
+        map.put("publiclyReadable", new org.json.JSONObject("{\"type\": \"boolean\"}"));
+        map.put("submitterUserIds", keywordType);
         return map;
     }
 
     public void opensearchDocumentSerializer(JsonGenerator jgen, Shepherd myShepherd)
     throws IOException, JsonProcessingException {
         super.opensearchDocumentSerializer(jgen, myShepherd);
+        this.writeAclFields(jgen, myShepherd);
 
         jgen.writeStringField("sex", this.getSex());
         jgen.writeStringField("displayName", this.getDisplayName());

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -493,12 +493,16 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
             numberEncounters++;
             refreshDependentProperties();
             setVersion();
+            // membership change: the joining encounter's ACL must reflect this individual.
+            // Deep-reindexing the encounter also refreshes this individual + its annotations.
+            // Also reindex THIS individual directly: callers (AnnotationEdit, IBEISIA) do not set
+            // newEncounter.individual = this, so newEncounter.opensearchIndexDeep() would refresh a
+            // different (or null) individual, leaving this individual's ACL stale.
+            this.enqueueAclReindex();
+            if (newEncounter != null) newEncounter.enqueueAclReindex();
         }
         setTaxonomyFromEncounters(); // will only set if has no value
         setSexFromEncounters(); // likewise
-        // membership change: the joining encounter's ACL must reflect this individual.
-        // Deep-reindexing the encounter also refreshes this individual + its annotations.
-        if (newEncounter != null) newEncounter.enqueueAclReindex();
         return isNew;
     }
 

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -468,7 +468,7 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
     /** Enqueue a (deep) reindex of this individual — refreshes the individual + its member
      *  encounters. Honors skipAutoIndexing so bulk import / deserialization don't storm. */
     public void enqueueAclReindex() {
-        if (this.getSkipAutoIndexing()) return;
+        if (this.getSkipAutoIndexing() || OpenSearch.skipAutoIndexing()) return;
         try {
             IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false);
         } catch (Exception ex) {

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -465,6 +465,17 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
     }
 
     // Adds a new encounter to this MarkedIndividual.
+    /** Enqueue a (deep) reindex of this individual — refreshes the individual + its member
+     *  encounters. Honors skipAutoIndexing so bulk import / deserialization don't storm. */
+    public void enqueueAclReindex() {
+        if (this.getSkipAutoIndexing()) return;
+        try {
+            IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false);
+        } catch (Exception ex) {
+            System.out.println("MarkedIndividual.enqueueAclReindex failed for " + this.getId() + ": " + ex);
+        }
+    }
+
     public boolean addEncounter(Encounter newEncounter) {
         // get and therefore set the haplotype if necessary
         getHaplotype();
@@ -485,6 +496,9 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         }
         setTaxonomyFromEncounters(); // will only set if has no value
         setSexFromEncounters(); // likewise
+        // membership change: the joining encounter's ACL must reflect this individual.
+        // Deep-reindexing the encounter also refreshes this individual + its annotations.
+        if (newEncounter != null) newEncounter.enqueueAclReindex();
         return isNew;
     }
 
@@ -528,6 +542,10 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         getHaplotype();
 
         setVersion();
+        // membership change: refresh this individual (drops the departed encounter from its ACL)
+        // and the departed encounter itself (its individual link is now gone).
+        this.enqueueAclReindex();
+        if (getRidOfMe != null) getRidOfMe.enqueueAclReindex();
         return changed;
     }
 
@@ -2653,6 +2671,11 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
             myShepherd.updateDBTransaction();
         }
         refreshDependentProperties();
+        // merge moved every encounter from other -> this (per-encounter hooks already fired via
+        // removeEncounter/setIndividual). Enqueue both individuals as a safety net; the indexing
+        // queue dedups by id so this does not multiply work.
+        this.enqueueAclReindex();
+        if (other != null) other.enqueueAclReindex();
     }
 
     public String getMergedComments(MarkedIndividual other, HttpServletRequest request,

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -1013,8 +1013,10 @@ public class OpenSearch {
         "term","terms","match","match_phrase","match_phrase_prefix","range",
         "prefix","wildcard","regexp","fuzzy","ids","exists"));
     // Leaf-operator keys whose CHILD OBJECT's keys ARE field names (e.g. term/range/match -> {field:...}).
+    // NOTE: "terms" is intentionally absent — it is handled separately in nodeAllowed because the
+    // terms-lookup form (object value) must be rejected while the plain-array form is allowed.
     private static final java.util.Set<String> FIELD_BEARING = new java.util.HashSet<>(java.util.Arrays.asList(
-        "term","terms","match","match_phrase","match_phrase_prefix","range","prefix","wildcard","regexp","fuzzy"));
+        "term","match","match_phrase","match_phrase_prefix","range","prefix","wildcard","regexp","fuzzy"));
     // Keys that are DISALLOWED outright (can reference arbitrary fields / execute code).
     private static final java.util.Set<String> DENY_FEATURES = new java.util.HashSet<>(java.util.Arrays.asList(
         "script","script_score","aggs","aggregations","sort","_source","fields","docvalue_fields",
@@ -1063,6 +1065,18 @@ public class OpenSearch {
                 // current level keys are FIELD NAMES
                 if (!allowed.contains(rootField(key))) return false;
                 // values under a field (e.g. range bounds) are leaf params; don't recurse for fields
+            } else if ("terms".equals(key)) {
+                // Special-case: the terms operator has two legal forms:
+                //   plain:  {"terms": {"field": ["v1","v2"]}}   -> array/scalar value  -> allowed (if field allowlisted)
+                //   lookup: {"terms": {"field": {"index":"...","path":"..."}}} -> object value -> REJECT
+                // The lookup form lets a caller probe hidden nested fields via "path"; reject it fail-closed.
+                Object tv = obj.opt(key);
+                if (!(tv instanceof JSONObject)) return false; // terms body must be a JSONObject
+                JSONObject to = (JSONObject) tv;
+                for (String f : to.keySet()) {
+                    if (!allowed.contains(rootField(f))) return false; // field must be allowlisted
+                    if (to.opt(f) instanceof JSONObject) return false;  // object value = terms-lookup -> reject
+                }
             } else if (FIELD_BEARING.contains(key)) {
                 // the child object's keys are field names
                 if (!nodeAllowed(obj.opt(key), allowed, true)) return false;

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -776,8 +776,9 @@ public class OpenSearch {
 
     // Reads the CURRENT indexed viewUsers array for a single doc. Returns the array
     // (possibly empty) on success, or null if the doc/field cannot be read (missing doc,
-    // index not present, parse failure). Callers should treat null as "unknown" — i.e.
-    // assume a change so propagation is not silently skipped.
+    // index not present, parse failure). null means "unknown": the caller decides the
+    // policy (opensearchIndexPermissions treats unknown as no-change to avoid storming
+    // child reindexes on a degraded read; the reconciler recovers a missed refresh).
     public org.json.JSONArray getIndexedViewUsers(String index, String id) {
         if ((index == null) || (id == null)) return null;
         try {

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -536,9 +536,9 @@ public class OpenSearch {
         }
     }
 
-    // Package-visible for testing. Returns the _count-shaped query body that
-    // filters on _id ∈ ids, using OpenSearch's idiomatic `ids` query.
-    static JSONObject buildIdEligibilityQuery(Set<String> ids) {
+    // Returns a query body that filters on _id ∈ ids, using OpenSearch's idiomatic `ids` query.
+    // Public so the media-resolve endpoint (org.ecocean.api) can reuse the exact id-eligibility shape.
+    public static JSONObject buildIdEligibilityQuery(Set<String> ids) {
         JSONArray idArr = new JSONArray();
         for (String id : ids) idArr.put(id);
         JSONObject query = new JSONObject();

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -1011,7 +1011,7 @@ public class OpenSearch {
         "query","bool","must","should","filter","must_not","minimum_should_match","boost",
         "match_all","match_none","constant_score","dis_max","queries","tie_breaker",
         "term","terms","match","match_phrase","match_phrase_prefix","range",
-        "prefix","wildcard","regexp","fuzzy","ids","exists","nested","path"));
+        "prefix","wildcard","regexp","fuzzy","ids","exists"));
     // Leaf-operator keys whose CHILD OBJECT's keys ARE field names (e.g. term/range/match -> {field:...}).
     private static final java.util.Set<String> FIELD_BEARING = new java.util.HashSet<>(java.util.Arrays.asList(
         "term","terms","match","match_phrase","match_phrase_prefix","range","prefix","wildcard","regexp","fuzzy"));
@@ -1019,8 +1019,16 @@ public class OpenSearch {
     private static final java.util.Set<String> DENY_FEATURES = new java.util.HashSet<>(java.util.Arrays.asList(
         "script","script_score","aggs","aggregations","sort","_source","fields","docvalue_fields",
         "runtime_mappings","function_score","more_like_this","percolate","field",
+        // nested/path let a caller probe nested aggregate fields (socialUnits/relationships) -> deny
+        "nested","path",
         // free-text/Lucene operators carry field references the validator can't parse -> fail-closed
         "query_string","simple_query_string","multi_match"));
+
+    // The ONLY top-level body keys a non-admin token individual search may carry.
+    // Anything else (post_filter, collapse, rescore, suggest, highlight, aggs, sort, _source,
+    // fields, script_fields, search_after, pit, runtime_mappings, ...) is rejected fail-closed.
+    private static final java.util.Set<String> ALLOWED_TOP_LEVEL_KEYS =
+        new java.util.HashSet<>(java.util.Arrays.asList("query", "from", "size"));
 
     /**
      * Fail-closed: returns true ONLY if every field the query/sort/aggs could reference is in `allowed`.
@@ -1029,8 +1037,13 @@ public class OpenSearch {
      */
     public static boolean queryReferencesOnlyAllowedFields(JSONObject body, java.util.Set<String> allowed) {
         if (body == null) return true;
-        // reject disallowed top-level features outright
-        for (String f : DENY_FEATURES) if (body.has(f)) return false;
+        // Strict top-level allowlist (fail-closed): ONLY query/from/size are permitted. Any other
+        // top-level key (post_filter, collapse, rescore, suggest, highlight, aggs, sort, _source,
+        // fields, script_fields, search_after, pit, ...) is an unvetted field-bearing/feature key.
+        for (String key : body.keySet()) {
+            if (!ALLOWED_TOP_LEVEL_KEYS.contains(key)) return false;
+        }
+        // from/size are pagination scalars; only `query` needs recursive field validation.
         return nodeAllowed(body.opt("query"), allowed, false);
     }
 

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -967,20 +967,59 @@ public class OpenSearch {
         return out;
     }
 
-    // takes raw search result doc and presents only data user should see
+    private static final String[] ACL_FIELDS = {
+        "publiclyReadable", "submitterUserId", "submitterUserIds", "viewUsers", "editUsers"
+    };
+    // identity fields kept for a non-admin token individual hit; everything else dropped (allowlist).
+    // NOTE: socialUnits/relationships/cooccurrence*/users/encounterIds/number* and all other
+    // cross-encounter aggregates are DELIBERATELY excluded — they reveal data from encounters the
+    // viewer may not see. Out of scope for v1 (agent gets per-viewer detail via the scoped encounter index).
+    private static final String[] INDIVIDUAL_TOKEN_KEEP = {
+        "id", "version", "indexTimestamp", "displayName", "names", "nameMap",
+        "sex", "taxonomy", "timeOfBirth", "timeOfDeath"
+    };
+
+    private static void scrubAclFields(JSONObject doc) {
+        for (String f : ACL_FIELDS) doc.remove(f);
+    }
+
+    // 4-arg overload preserved for the existing caller (non-token path) until SearchApi passes tokenAuth.
     public static JSONObject sanitizeDoc(final JSONObject sourceDoc, String indexName,
         Shepherd myShepherd, User user)
     throws IOException {
+        return sanitizeDoc(sourceDoc, indexName, myShepherd, user, false);
+    }
+
+    // takes raw search result doc and presents only data user should see
+    public static JSONObject sanitizeDoc(final JSONObject sourceDoc, String indexName,
+        Shepherd myShepherd, User user, boolean tokenAuth)
+    throws IOException {
         if ((user == null) || (sourceDoc == null)) throw new IOException("null user or sourceDoc");
-        // these classes we let anyone see as-is
-        if ("annotation".equals(indexName) || "individual".equals(indexName)) return sourceDoc;
+        if ("annotation".equals(indexName)) {
+            JSONObject clean = new JSONObject(sourceDoc.toString());
+            scrubAclFields(clean);             // never leak the internal ACL fields
+            return clean;                      // content (incl. embeddings) returned as-is
+        }
+        if ("individual".equals(indexName)) {
+            boolean admin = user.isAdmin(myShepherd);
+            if (tokenAuth && !admin) {
+                JSONObject clean = new JSONObject();
+                for (String f : INDIVIDUAL_TOKEN_KEEP) {
+                    if (sourceDoc.has(f)) clean.put(f, sourceDoc.get(f));
+                }
+                return clean;                  // allowlist: identity only, aggregates dropped
+            }
+            JSONObject clean = new JSONObject(sourceDoc.toString());
+            scrubAclFields(clean);
+            return clean;
+        }
         // these we return some kinda cleaned value
         JSONObject clean = new JSONObject();
         if ("encounter".equals(indexName)) {
             boolean hasAccess = Encounter.opensearchAccess(sourceDoc, user, myShepherd);
             if (hasAccess) {
                 clean = new JSONObject(sourceDoc.toString());
-                clean.remove("viewUsers");
+                scrubAclFields(clean);
                 clean.put("access", "full");
                 return clean;
             }
@@ -1001,14 +1040,13 @@ public class OpenSearch {
             boolean hasAccess = user.isAdmin(myShepherd) || hasAccessOccurrence(user, sourceDoc);
             if (hasAccess) {
                 clean = new JSONObject(sourceDoc.toString());
+                scrubAclFields(clean);
                 clean.put("access", "full");
             } else {
                 clean = new JSONObject();
                 clean.put("id", sourceDoc.optString("id", "unknown"));
                 clean.put("access", "none");
             }
-            // clean.remove("viewUsers");
-            // clean.remove("editUsers");
         }
         // if we fall through (e.g. future classes) clean will just be empty
         return clean;

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -1010,15 +1010,17 @@ public class OpenSearch {
     private static final java.util.Set<String> DSL_STRUCTURAL = new java.util.HashSet<>(java.util.Arrays.asList(
         "query","bool","must","should","filter","must_not","minimum_should_match","boost",
         "match_all","match_none","constant_score","dis_max","queries","tie_breaker",
-        "term","terms","match","match_phrase","match_phrase_prefix","multi_match","range",
-        "prefix","wildcard","regexp","fuzzy","ids","exists","nested","path","query_string","simple_query_string"));
+        "term","terms","match","match_phrase","match_phrase_prefix","range",
+        "prefix","wildcard","regexp","fuzzy","ids","exists","nested","path"));
     // Leaf-operator keys whose CHILD OBJECT's keys ARE field names (e.g. term/range/match -> {field:...}).
     private static final java.util.Set<String> FIELD_BEARING = new java.util.HashSet<>(java.util.Arrays.asList(
         "term","terms","match","match_phrase","match_phrase_prefix","range","prefix","wildcard","regexp","fuzzy"));
     // Keys that are DISALLOWED outright (can reference arbitrary fields / execute code).
     private static final java.util.Set<String> DENY_FEATURES = new java.util.HashSet<>(java.util.Arrays.asList(
         "script","script_score","aggs","aggregations","sort","_source","fields","docvalue_fields",
-        "runtime_mappings","function_score","more_like_this","percolate","field"));
+        "runtime_mappings","function_score","more_like_this","percolate","field",
+        // free-text/Lucene operators carry field references the validator can't parse -> fail-closed
+        "query_string","simple_query_string","multi_match"));
 
     /**
      * Fail-closed: returns true ONLY if every field the query/sort/aggs could reference is in `allowed`.

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -935,11 +935,18 @@ public class OpenSearch {
      */
     public static JSONObject applyEncounterAclFilter(JSONObject query, String userId)
     throws IOException {
+        return applyAclFilter(query, userId, "encounter");
+    }
+
+    public static JSONObject applyAclFilter(JSONObject query, String userId, String indexName)
+    throws IOException {
         if ((query == null) || !Util.stringExists(userId))
-            throw new IOException("applyEncounterAclFilter: null query or userId");
+            throw new IOException("applyAclFilter: null query or userId");
+        // encounter docs carry a single submitterUserId; annotation/individual carry the union set submitterUserIds
+        String submitterField = "encounter".equals(indexName) ? "submitterUserId" : "submitterUserIds";
         JSONArray should = new JSONArray();
         should.put(new JSONObject().put("term", new JSONObject().put("publiclyReadable", true)));
-        should.put(new JSONObject().put("term", new JSONObject().put("submitterUserId", userId)));
+        should.put(new JSONObject().put("term", new JSONObject().put(submitterField, userId)));
         should.put(new JSONObject().put("term", new JSONObject().put("viewUsers", userId)));
         JSONObject aclBool = new JSONObject();
         aclBool.put("should", should);

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -774,6 +774,30 @@ public class OpenSearch {
         getRestResponse(updateRequest);
     }
 
+    // Reads the CURRENT indexed viewUsers array for a single doc. Returns the array
+    // (possibly empty) on success, or null if the doc/field cannot be read (missing doc,
+    // index not present, parse failure). Callers should treat null as "unknown" — i.e.
+    // assume a change so propagation is not silently skipped.
+    public org.json.JSONArray getIndexedViewUsers(String index, String id) {
+        if ((index == null) || (id == null)) return null;
+        try {
+            if (!existsIndex(index)) return null;
+            // _source filtered to just viewUsers keeps the response tiny.
+            Request getRequest = new Request("GET", index + "/_doc/" + id + "?_source=viewUsers");
+            String body = getRestResponse(getRequest);
+            if (body == null) return null;
+            org.json.JSONObject parsed = new org.json.JSONObject(body);
+            if (!parsed.optBoolean("found", false)) return null;
+            org.json.JSONObject source = parsed.optJSONObject("_source");
+            if (source == null) return new org.json.JSONArray(); // doc exists, no viewUsers yet -> empty
+            org.json.JSONArray arr = source.optJSONArray("viewUsers");
+            return (arr == null) ? new org.json.JSONArray() : arr;
+        } catch (Exception ex) {
+            // 404 (doc not found) surfaces as ResponseException here; treat as unknown.
+            return null;
+        }
+    }
+
     // returns 2 lists: (1) items needing (re-)indexing; (2) items needing removal
     public static List<List<String> > resolveVersions(Map<String, Long> objVersions,
         Map<String, Long> indexVersions) {

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -1002,6 +1002,70 @@ public class OpenSearch {
         "id", "version", "indexTimestamp", "displayName", "names", "nameMap",
         "sex", "taxonomy", "timeOfBirth", "timeOfDeath"
     };
+    // Set form of the individual identity allowlist, for query-side field validation.
+    public static final java.util.Set<String> INDIVIDUAL_TOKEN_KEEP_SET =
+        new java.util.HashSet<>(java.util.Arrays.asList(INDIVIDUAL_TOKEN_KEEP));
+
+    // Structural/operator keys in the OpenSearch query DSL whose CHILD object keys are NOT field names.
+    private static final java.util.Set<String> DSL_STRUCTURAL = new java.util.HashSet<>(java.util.Arrays.asList(
+        "query","bool","must","should","filter","must_not","minimum_should_match","boost",
+        "match_all","match_none","constant_score","dis_max","queries","tie_breaker",
+        "term","terms","match","match_phrase","match_phrase_prefix","multi_match","range",
+        "prefix","wildcard","regexp","fuzzy","ids","exists","nested","path","query_string","simple_query_string"));
+    // Leaf-operator keys whose CHILD OBJECT's keys ARE field names (e.g. term/range/match -> {field:...}).
+    private static final java.util.Set<String> FIELD_BEARING = new java.util.HashSet<>(java.util.Arrays.asList(
+        "term","terms","match","match_phrase","match_phrase_prefix","range","prefix","wildcard","regexp","fuzzy"));
+    // Keys that are DISALLOWED outright (can reference arbitrary fields / execute code).
+    private static final java.util.Set<String> DENY_FEATURES = new java.util.HashSet<>(java.util.Arrays.asList(
+        "script","script_score","aggs","aggregations","sort","_source","fields","docvalue_fields",
+        "runtime_mappings","function_score","more_like_this","percolate","field"));
+
+    /**
+     * Fail-closed: returns true ONLY if every field the query/sort/aggs could reference is in `allowed`.
+     * Used to constrain non-admin token individual searches to identity fields (so a caller can't
+     * probe hidden cross-encounter aggregates via range/sort/aggs/etc.).
+     */
+    public static boolean queryReferencesOnlyAllowedFields(JSONObject body, java.util.Set<String> allowed) {
+        if (body == null) return true;
+        // reject disallowed top-level features outright
+        for (String f : DENY_FEATURES) if (body.has(f)) return false;
+        return nodeAllowed(body.opt("query"), allowed, false);
+    }
+
+    // expectField=true means: the CURRENT object's KEYS are field names to check against the allowlist.
+    private static boolean nodeAllowed(Object node, java.util.Set<String> allowed, boolean expectField) {
+        if (node == null) return true;
+        if (node instanceof org.json.JSONArray) {
+            org.json.JSONArray arr = (org.json.JSONArray) node;
+            for (int i = 0; i < arr.length(); i++) if (!nodeAllowed(arr.opt(i), allowed, expectField)) return false;
+            return true;
+        }
+        if (!(node instanceof JSONObject)) return true; // scalar value
+        JSONObject obj = (JSONObject) node;
+        for (String key : obj.keySet()) {
+            if (DENY_FEATURES.contains(key)) return false; // script/field/etc. anywhere -> reject
+            if (expectField) {
+                // current level keys are FIELD NAMES
+                if (!allowed.contains(rootField(key))) return false;
+                // values under a field (e.g. range bounds) are leaf params; don't recurse for fields
+            } else if (FIELD_BEARING.contains(key)) {
+                // the child object's keys are field names
+                if (!nodeAllowed(obj.opt(key), allowed, true)) return false;
+            } else if (DSL_STRUCTURAL.contains(key)) {
+                if (!nodeAllowed(obj.opt(key), allowed, false)) return false;
+            } else {
+                // unknown key in a structural position -> fail closed
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // allow nested subfields under an allowlisted root (e.g. nameMap.foo, names.keyword)
+    private static String rootField(String field) {
+        int dot = field.indexOf('.');
+        return (dot >= 0) ? field.substring(0, dot) : field;
+    }
 
     private static void scrubAclFields(JSONObject doc) {
         for (String f : ACL_FIELDS) doc.remove(f);

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -922,6 +922,44 @@ public class OpenSearch {
         return query;
     }
 
+    /**
+     * Wrap a search query's top-level "query" clause in a bool whose filter enforces the
+     * encounter ACL (mirrors Encounter.opensearchAccess for a non-admin user). Applied on the
+     * token-authenticated path BEFORE execution so totals, pagination, and hits are all scoped.
+     * Admins are not passed through here (caller skips the call for admins).
+     *
+     * Decision (documented, safe): a request with no inner "query" yields a filter-only bool,
+     * i.e. "all encounters this user may see" — still fully scoped, never a bypass. A truly
+     * malformed (non-JSON) body fails earlier in ServletUtilities.jsonFromHttpServletRequest,
+     * before reaching this method, so the spec's "fail closed on malformed" is satisfied upstream.
+     */
+    public static JSONObject applyEncounterAclFilter(JSONObject query, String userId)
+    throws IOException {
+        if ((query == null) || !Util.stringExists(userId))
+            throw new IOException("applyEncounterAclFilter: null query or userId");
+        JSONArray should = new JSONArray();
+        should.put(new JSONObject().put("term", new JSONObject().put("publiclyReadable", true)));
+        should.put(new JSONObject().put("term", new JSONObject().put("submitterUserId", userId)));
+        should.put(new JSONObject().put("term", new JSONObject().put("viewUsers", userId)));
+        JSONObject aclBool = new JSONObject();
+        aclBool.put("should", should);
+        aclBool.put("minimum_should_match", 1);
+        JSONObject acl = new JSONObject().put("bool", aclBool);
+
+        JSONObject wrapBool = new JSONObject();
+        JSONObject inner = query.optJSONObject("query");
+        if (inner != null) {
+            JSONArray must = new JSONArray();
+            must.put(inner);
+            wrapBool.put("must", must);
+        }
+        wrapBool.put("filter", new JSONArray().put(acl));
+
+        JSONObject out = new JSONObject(query.toString()); // shallow copy via re-parse
+        out.put("query", new JSONObject().put("bool", wrapBool));
+        return out;
+    }
+
     // takes raw search result doc and presents only data user should see
     public static JSONObject sanitizeDoc(final JSONObject sourceDoc, String indexName,
         Shepherd myShepherd, User user)

--- a/src/main/java/org/ecocean/api/AuthToken.java
+++ b/src/main/java/org/ecocean/api/AuthToken.java
@@ -1,0 +1,84 @@
+package org.ecocean.api;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.User;
+import org.ecocean.Util;
+import org.ecocean.api.auth.JwtService;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+
+/**
+ * POST /api/v3/auth/token
+ * Gated by existing Shiro auth (authcBasicWildbook). Mints a short-lived
+ * RS256 token carrying only the caller's identity (uuid + context). The
+ * external scoped-access kernel validates it with the public key.
+ */
+public class AuthToken extends ApiBase {
+    private static final long DEFAULT_TTL_MILLIS = 30L * 60L * 1000L; // 30 min
+
+    @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+        String context = ServletUtilities.getContext(request);
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("api.AuthToken.doPost");
+        myShepherd.beginDBTransaction();
+        try {
+            User user = myShepherd.getUser(request);
+            if (user == null) {
+                writeError(response, 401, "unauthenticated");
+                return;
+            }
+            // SECURITY (Codex High #1): pin the token context SERVER-SIDE. Do NOT
+            // sign ServletUtilities.getContext(request) — it honors a caller's
+            // ?context=, while Basic auth authenticates only against context0, so a
+            // caller-influenced context claim would let a user mint a token for a
+            // context they didn't authenticate in. v1 is single-context.
+            String tokenContext = org.ecocean.CommonConfiguration.getProperty("jwtContext", context);
+            if (!Util.stringExists(tokenContext)) tokenContext = "context0";
+            JwtService jwt = JwtService.fromConfig(tokenContext);
+            if (!jwt.isEnabled()) {
+                writeError(response, 503, "token issuance not configured");
+                return;
+            }
+            long ttl = ttlFromConfig(tokenContext);
+            String token = jwt.sign(user.getId(), tokenContext, ttl);
+            JSONObject out = new JSONObject();
+            out.put("token", token);
+            out.put("tokenType", "Bearer");
+            out.put("expiresInSeconds", ttl / 1000L);
+            response.setStatus(200);
+            response.setContentType("application/json");
+            response.getWriter().write(out.toString());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            writeError(response, 500, "token issuance failed");
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private long ttlFromConfig(String context) {
+        String v = org.ecocean.CommonConfiguration.getProperty("jwtTtlSeconds", context);
+        if (Util.stringExists(v)) {
+            try {
+                long secs = Long.parseLong(v.trim());
+                // Codex Low: clamp to a sane range (1 min .. 24 h)
+                secs = Math.max(60L, Math.min(secs, 24L * 3600L));
+                return secs * 1000L;
+            } catch (NumberFormatException ignore) {}
+        }
+        return DEFAULT_TTL_MILLIS;
+    }
+
+    private void writeError(HttpServletResponse response, int code, String message)
+        throws IOException {
+        response.setStatus(code);
+        response.setContentType("application/json");
+        response.getWriter().write(new JSONObject().put("success", false)
+            .put("error", message).toString());
+    }
+}

--- a/src/main/java/org/ecocean/api/AuthToken.java
+++ b/src/main/java/org/ecocean/api/AuthToken.java
@@ -7,7 +7,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.ecocean.User;
 import org.ecocean.Util;
 import org.ecocean.api.auth.JwtService;
-import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
 import org.json.JSONObject;
 
@@ -22,7 +21,11 @@ public class AuthToken extends ApiBase {
 
     @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
-        String context = ServletUtilities.getContext(request);
+        // SECURITY (Codex High): pin to the fixed auth context. Basic auth authenticates
+        // against context0 (WildbookBasicHttpAuthenticationFilter), so the user lookup,
+        // signing key/config, and the token's context claim must ALL come from context0 —
+        // never from ServletUtilities.getContext(request), which honors ?context=.
+        final String context = "context0";
         Shepherd myShepherd = new Shepherd(context);
         myShepherd.setAction("api.AuthToken.doPost");
         myShepherd.beginDBTransaction();
@@ -32,11 +35,6 @@ public class AuthToken extends ApiBase {
                 writeError(response, 401, "unauthenticated");
                 return;
             }
-            // SECURITY (Codex High #1): pin the token context SERVER-SIDE. Do NOT
-            // sign ServletUtilities.getContext(request) — it honors a caller's
-            // ?context=, while Basic auth authenticates only against context0, so a
-            // caller-influenced context claim would let a user mint a token for a
-            // context they didn't authenticate in. v1 is single-context.
             String tokenContext = org.ecocean.CommonConfiguration.getProperty("jwtContext", context);
             if (!Util.stringExists(tokenContext)) tokenContext = "context0";
             JwtService jwt = JwtService.fromConfig(tokenContext);

--- a/src/main/java/org/ecocean/api/CanUserAccess.java
+++ b/src/main/java/org/ecocean/api/CanUserAccess.java
@@ -2,8 +2,6 @@ package org.ecocean.api;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -42,18 +40,33 @@ public class CanUserAccess extends ApiBase {
                 writeError(response, 403, "admin required");
                 return;
             }
-            // Codex Medium: validate content-type + cap body size BEFORE reading/parsing.
+            // Fix 3 (Low): parse media type before ';' for an exact match — reject
+            // types like "text/application/json" or "application/json-patch+json".
             String ctype = request.getContentType();
-            if (ctype == null || !ctype.toLowerCase().contains("application/json")) {
+            if (ctype == null) {
                 writeError(response, 415, "Content-Type must be application/json");
                 return;
             }
+            String mediaType = ctype.split(";")[0].trim().toLowerCase();
+            if (!mediaType.equals("application/json")) {
+                writeError(response, 415, "Content-Type must be application/json");
+                return;
+            }
+            // Fix 2 (Medium): pre-flight Content-Length guard.
             if (request.getContentLengthLong() > MAX_BODY_BYTES) {
                 writeError(response, 413, "request body too large");
                 return;
             }
-            JSONObject body = readBody(request);
-            if (body == null) { writeError(response, 400, "invalid JSON body"); return; }
+            JSONObject body;
+            try {
+                body = readBody(request);
+            } catch (BodyTooLargeException ex) {
+                writeError(response, 413, "request body too large");
+                return;
+            } catch (Exception ex) {
+                writeError(response, 400, "invalid JSON body");
+                return;
+            }
             String userUuid = body.optString("userUuid", null);
             JSONArray idsArr = body.optJSONArray("encounterIds");
             if (!Util.stringExists(userUuid) || idsArr == null) {
@@ -90,19 +103,28 @@ public class CanUserAccess extends ApiBase {
         }
     }
 
-    private JSONObject readBody(HttpServletRequest request) {
-        try {
-            StringBuilder sb = new StringBuilder();
-            BufferedReader r = request.getReader();
-            String line;
-            while ((line = r.readLine()) != null) {
-                sb.append(line);
-                if (sb.length() > MAX_BODY_BYTES) return null; // cap even if Content-Length lied
-            }
-            return new JSONObject(sb.toString());
-        } catch (Exception ex) {
-            return null;
+    /** Thrown by readBody when the request body exceeds MAX_BODY_BYTES. */
+    private static final class BodyTooLargeException extends Exception {
+        BodyTooLargeException() { super("request body too large"); }
+    }
+
+    /**
+     * Fix 2 (Medium): read body in chunks, counting ALL bytes read (not just
+     * newline-stripped line lengths). Throws BodyTooLargeException on overflow
+     * (maps to 413) and JSONException on bad JSON (maps to 400).
+     */
+    private JSONObject readBody(HttpServletRequest request) throws IOException, BodyTooLargeException {
+        StringBuilder sb = new StringBuilder();
+        BufferedReader r = request.getReader();
+        char[] buf = new char[8192];
+        long total = 0;
+        int n;
+        while ((n = r.read(buf)) != -1) {
+            total += n;
+            if (total > MAX_BODY_BYTES) throw new BodyTooLargeException();
+            sb.append(buf, 0, n);
         }
+        return new JSONObject(sb.toString()); // throws JSONException on invalid input
     }
 
     private void writeError(HttpServletResponse response, int code, String message)

--- a/src/main/java/org/ecocean/api/CanUserAccess.java
+++ b/src/main/java/org/ecocean/api/CanUserAccess.java
@@ -1,0 +1,115 @@
+package org.ecocean.api;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.Encounter;
+import org.ecocean.User;
+import org.ecocean.Util;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * POST /api/v3/can-user-access
+ * Admin/service-scoped. Body: {"userUuid": "...", "encounterIds": ["...", ...]}.
+ * Returns {"accessible": ["...", ...]} — the subset of encounterIds the target
+ * user may VIEW, computed from LIVE Collaboration/role objects (not the indexed
+ * viewUsers). Defense-in-depth backstop for the scoped-query kernel.
+ */
+public class CanUserAccess extends ApiBase {
+    private static final int MAX_IDS = 200;
+    private static final long MAX_BODY_BYTES = 64L * 1024L; // cap request body (Codex Medium)
+
+    @Override protected void doPost(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+        String context = ServletUtilities.getContext(request);
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("api.CanUserAccess.doPost");
+        myShepherd.beginDBTransaction();
+        try {
+            User caller = myShepherd.getUser(request);
+            if (caller == null) {
+                writeError(response, 401, "unauthenticated");
+                return;
+            }
+            if (!caller.isAdmin(myShepherd)) {
+                writeError(response, 403, "admin required");
+                return;
+            }
+            // Codex Medium: validate content-type + cap body size BEFORE reading/parsing.
+            String ctype = request.getContentType();
+            if (ctype == null || !ctype.toLowerCase().contains("application/json")) {
+                writeError(response, 415, "Content-Type must be application/json");
+                return;
+            }
+            if (request.getContentLengthLong() > MAX_BODY_BYTES) {
+                writeError(response, 413, "request body too large");
+                return;
+            }
+            JSONObject body = readBody(request);
+            if (body == null) { writeError(response, 400, "invalid JSON body"); return; }
+            String userUuid = body.optString("userUuid", null);
+            JSONArray idsArr = body.optJSONArray("encounterIds");
+            if (!Util.stringExists(userUuid) || idsArr == null) {
+                writeError(response, 400, "userUuid and encounterIds required");
+                return;
+            }
+            if (idsArr.length() > MAX_IDS) {
+                writeError(response, 400, "too many encounterIds (max " + MAX_IDS + ")");
+                return;
+            }
+            User target = myShepherd.getUserByUUID(userUuid);
+            JSONArray accessible = new JSONArray();
+            // target==null -> empty accessible set (unknown user sees nothing)
+            if (target != null) {
+                for (int i = 0; i < idsArr.length(); i++) {
+                    String encId = idsArr.optString(i, null);
+                    if (!Util.stringExists(encId)) continue;
+                    Encounter enc = myShepherd.getEncounter(encId);
+                    if (enc != null && enc.canUserView(target, myShepherd)) {
+                        accessible.put(encId);
+                    }
+                }
+            }
+            JSONObject out = new JSONObject();
+            out.put("accessible", accessible);
+            response.setStatus(200);
+            response.setContentType("application/json");
+            response.getWriter().write(out.toString());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            writeError(response, 500, "canUserAccess failed");
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private JSONObject readBody(HttpServletRequest request) {
+        try {
+            StringBuilder sb = new StringBuilder();
+            BufferedReader r = request.getReader();
+            String line;
+            while ((line = r.readLine()) != null) {
+                sb.append(line);
+                if (sb.length() > MAX_BODY_BYTES) return null; // cap even if Content-Length lied
+            }
+            return new JSONObject(sb.toString());
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    private void writeError(HttpServletResponse response, int code, String message)
+        throws IOException {
+        response.setStatus(code);
+        response.setContentType("application/json");
+        response.getWriter().write(new JSONObject().put("success", false)
+            .put("error", message).toString());
+    }
+}

--- a/src/main/java/org/ecocean/api/CanUserAccess.java
+++ b/src/main/java/org/ecocean/api/CanUserAccess.java
@@ -1,7 +1,8 @@
 package org.ecocean.api;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -63,7 +64,8 @@ public class CanUserAccess extends ApiBase {
             } catch (BodyTooLargeException ex) {
                 writeError(response, 413, "request body too large");
                 return;
-            } catch (Exception ex) {
+            }
+            if (body == null) {
                 writeError(response, 400, "invalid JSON body");
                 return;
             }
@@ -109,22 +111,29 @@ public class CanUserAccess extends ApiBase {
     }
 
     /**
-     * Fix 2 (Medium): read body in chunks, counting ALL bytes read (not just
-     * newline-stripped line lengths). Throws BodyTooLargeException on overflow
-     * (maps to 413) and JSONException on bad JSON (maps to 400).
+     * Fix 2 (Medium): read raw bytes from the input stream, counting actual bytes
+     * against MAX_BODY_BYTES so multibyte UTF-8 sequences cannot evade the cap.
+     * Throws BodyTooLargeException on overflow (maps to 413); returns null on any
+     * other read/parse error (maps to 400 in doPost).
      */
-    private JSONObject readBody(HttpServletRequest request) throws IOException, BodyTooLargeException {
-        StringBuilder sb = new StringBuilder();
-        BufferedReader r = request.getReader();
-        char[] buf = new char[8192];
-        long total = 0;
-        int n;
-        while ((n = r.read(buf)) != -1) {
-            total += n;
-            if (total > MAX_BODY_BYTES) throw new BodyTooLargeException();
-            sb.append(buf, 0, n);
+    private JSONObject readBody(HttpServletRequest request) throws BodyTooLargeException {
+        try {
+            InputStream in = request.getInputStream();
+            java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+            byte[] buf = new byte[8192];
+            long total = 0;
+            int n;
+            while ((n = in.read(buf)) != -1) {
+                total += n;
+                if (total > MAX_BODY_BYTES) throw new BodyTooLargeException();
+                bos.write(buf, 0, n);
+            }
+            return new JSONObject(new String(bos.toByteArray(), StandardCharsets.UTF_8));
+        } catch (BodyTooLargeException e) {
+            throw e;                 // -> 413 in doPost
+        } catch (Exception ex) {
+            return null;             // -> 400 invalid JSON in doPost
         }
-        return new JSONObject(sb.toString()); // throws JSONException on invalid input
     }
 
     private void writeError(HttpServletResponse response, int code, String message)

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -248,34 +248,51 @@ public class MediaResolveApi extends ApiBase {
     }
 
     /**
-     * Select the safe derivative to serve for an annotation's region: a child of the source asset
-     * labeled _master (preferred) or _mid. Both the source and the chosen derivative must be backed
-     * by a LocalAssetStore — an ALLOWLIST, not a denylist: this rejects URLAssetStore (external/public
-     * originals) AND YouTubeAssetStore (webURL is a watch page, not cropable image bytes). Also skips
-     * any child carrying _original. Returns null if none qualifies (caller omits).
-     * Deliberately does NOT use MediaAsset.safeURL/bestSafeAsset, which can return originals for
-     * URLAssetStore and does not fall back from a missing _master to _mid.
+     * Select the safe derivative whose pixels are a UNIFORM SCALE of the annotation's bbox frame, so
+     * the bbox (defined in {@code ann.getMediaAsset()} space) maps to it by a single dimension ratio.
+     *
+     * Two paths, in order:
+     *  1. A _master/_mid child of the annotation's OWN asset — always a uniform scale of that frame.
+     *  2. If the own asset has no such child, the derivatives hang off the _original ANCESTOR and the
+     *     annotation's asset is a sibling of them. Walk to the _original parent (mirroring
+     *     MediaAsset.bestSafeAsset) and use its derivative ONLY when it is a uniform scale of the
+     *     source frame (matching aspect ratio) — i.e. the source is a full-frame view, not a
+     *     crop/transform. Otherwise the bbox would be scaled against a different coordinate plane, so
+     *     we omit (fail-closed).
+     *
+     * Chosen assets must be LocalAssetStore-backed (allowlist: rejects URLAssetStore external
+     * originals AND YouTubeAssetStore watch pages) and never carry _original. Deliberately does NOT
+     * use MediaAsset.safeURL/bestSafeAsset (returns originals for URLAssetStore; no master->mid fallback).
      */
     static MediaAsset selectSafeDerivative(Annotation ann, Shepherd myShepherd) {
         if (ann == null) return null;
         MediaAsset src = ann.getMediaAsset();
         if (src == null) return null;
         if (!(src.getStore() instanceof LocalAssetStore)) return null;
-        // _master/_mid derivatives hang off the _original ANCESTOR. The annotation's asset is
-        // typically a non-original SIBLING of those derivatives, so walk to the _original parent
-        // before searching its children — mirroring MediaAsset.bestSafeAsset's traversal. Without
-        // this, findChildrenByLabel on a leaf sibling returns nothing and every annotation is omitted.
-        MediaAsset base = src;
+        // Path 1: a derivative of the annotation's own asset is a uniform scale of its frame -> safe.
+        MediaAsset own = findSafeDerivativeChild(src, myShepherd);
+        if (own != null) return own;
+        // Path 2: derivatives live on the _original ancestor; src is a sibling. Walk to the parent.
         Integer parentId = src.getParentId();
-        if (parentId != null) {
-            try {
-                MediaAsset parent = MediaAssetFactory.load(parentId, myShepherd);
-                if ((parent != null) && parent.hasLabel("_original")) base = parent;
-            } catch (RuntimeException ex) {
-                // parent lookup unavailable -> fall back to searching this asset directly (fail-soft;
-                // omit this one id rather than failing the whole batch).
-            }
+        if (parentId == null) return null;
+        MediaAsset parent;
+        try {
+            parent = MediaAssetFactory.load(parentId, myShepherd);
+        } catch (RuntimeException ex) {
+            return null; // parent lookup unavailable -> omit this id (fail-soft, never 500 the batch)
         }
+        if ((parent == null) || !parent.hasLabel("_original")) return null;
+        MediaAsset cand = findSafeDerivativeChild(parent, myShepherd);
+        if (cand == null) return null;
+        // Only safe if the parent's derivative is a uniform scale of the source frame (full-frame
+        // sibling). A crop/transform source has a different aspect ratio -> omit (fail-closed).
+        if (!isUniformScale(src, cand)) return null;
+        return cand;
+    }
+
+    /** First _master (else _mid) child of {@code base} that is LocalAssetStore-backed and not _original. */
+    private static MediaAsset findSafeDerivativeChild(MediaAsset base, Shepherd myShepherd) {
+        if (base == null) return null;
         for (String label : new String[] {"_master", "_mid"}) {
             ArrayList<MediaAsset> kids = base.findChildrenByLabel(myShepherd, label);
             // findChildrenByLabel returns an EMPTY list (not null) when children exist but none
@@ -289,5 +306,21 @@ public class MediaResolveApi extends ApiBase {
             }
         }
         return null;
+    }
+
+    /**
+     * True iff {@code deriv} is (within ~1% rounding tolerance) a uniform scale of {@code src}'s pixel
+     * frame — the precondition for mapping an axis-aligned bbox by a single dimension ratio. Guards
+     * against cropped/transformed sources whose aspect ratio differs from a full-frame derivative.
+     */
+    private static boolean isUniformScale(MediaAsset src, MediaAsset deriv) {
+        double sw = src.getWidth();
+        double sh = src.getHeight();
+        double dw = deriv.getWidth();
+        double dh = deriv.getHeight();
+        if ((sw <= 0) || (sh <= 0) || (dw <= 0) || (dh <= 0)) return false;
+        double sx = dw / sw;
+        double sy = dh / sh;
+        return Math.abs(sx - sy) <= 0.01 * Math.max(sx, sy);
     }
 }

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -205,38 +205,49 @@ public class MediaResolveApi extends ApiBase {
     }
 
     /**
-     * The access-controlled URL to display for the annotation's asset, via Wildbook's own safeURL
-     * (walks to the _original ancestor and masks the raw upload internally). Tries _master then _mid;
-     * requires a LocalAssetStore-backed, non-_original result. Fail-soft: any lookup error -> omit.
+     * Servable URL in the SAME coordinate frame as the bbox (the annotation asset's frame), so the
+     * consumer's scale-only transform is valid (a scale cannot recover a crop offset). If the
+     * annotation asset is not the raw upload (`!hasLabel("_original")`) it IS the bbox frame -> serve
+     * its own webURL. If it is the `_original`, never serve it directly -> serve a _master/_mid child
+     * of it (an aspect-preserving scale of the same frame). LocalAssetStore/non-_original guards;
+     * fail-soft (any error or null URL -> omit, never 500 the batch).
      */
     private static URL safeServableUrl(MediaAsset src, Shepherd myShepherd) {
-        for (String type : new String[] {"master", "mid"}) {
-            try {
+        try {
+            if (!src.hasLabel("_original")) {
+                return src.webURL(); // the annotation asset is the bbox frame; null -> omit
+            }
+            for (String type : new String[] {"master", "mid"}) {
                 MediaAsset a = src.bestSafeAsset(myShepherd, null, type);
                 if (a == null) continue;
                 if (!(a.getStore() instanceof LocalAssetStore)) continue;
                 if (a.hasLabel("_original")) continue;
                 URL u = a.webURL();
                 if (u != null) return u;
-            } catch (RuntimeException ex) {
-                // corrupt asset params / lookup failure -> try next type, else omit (never 500 batch)
             }
+            return null;
+        } catch (RuntimeException ex) {
+            return null; // fail-soft
         }
-        return null;
     }
 
-    /** Clamp bbox [x,y,w,h] (in src pixel space) to [0,W]x[0,H]; null if invalid or empty. */
+    /** Clamp bbox [x,y,w,h] (source pixel space) to [0,W]x[0,H] by clamping both corners; null if
+        invalid or empty (incl. negative/inverted). */
     private static int[] clampBbox(int[] b, double W, double H) {
         if ((b == null) || (b.length < 4)) return null;
-        int maxW = (int) Math.floor(W);
-        int maxH = (int) Math.floor(H);
-        int x = Math.max(0, Math.min(b[0], maxW));
-        int y = Math.max(0, Math.min(b[1], maxH));
-        int w = b[2];
-        int h = b[3];
-        if (x + w > maxW) w = maxW - x;
-        if (y + h > maxH) h = maxH - y;
+        long maxW = (long) Math.floor(W);
+        long maxH = (long) Math.floor(H);
+        long x1 = clampLong((long) b[0], 0, maxW);
+        long y1 = clampLong((long) b[1], 0, maxH);
+        long x2 = clampLong((long) b[0] + b[2], 0, maxW);
+        long y2 = clampLong((long) b[1] + b[3], 0, maxH);
+        int w = (int) (x2 - x1);
+        int h = (int) (y2 - y1);
         if ((w < 1) || (h < 1)) return null;
-        return new int[] {x, y, w, h};
+        return new int[] {(int) x1, (int) y1, w, h};
+    }
+
+    private static long clampLong(long v, long lo, long hi) {
+        return (v < lo) ? lo : (v > hi ? hi : v);
     }
 }

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -1,6 +1,7 @@
 package org.ecocean.api;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -10,6 +11,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.ecocean.Annotation;
+import org.ecocean.Embedding;
+import org.ecocean.Encounter;
 import org.ecocean.OpenSearch;
 import org.ecocean.User;
 import org.ecocean.Util;
@@ -179,8 +182,56 @@ public class MediaResolveApi extends ApiBase {
         return visible;
     }
 
+    /**
+     * Resolve one visible annotation into a response entry, or null to omit (fail-closed) when any
+     * required piece is missing: annotation, source asset, dimensions, safe derivative, bbox, or url.
+     * encounterId/individualId use findEncounter's first parent (documented multi-parent behavior;
+     * multi-parent annotations are admin-only in the index so a non-admin never reaches here for them).
+     */
     private JSONObject resolveOne(String annotationId, Shepherd myShepherd) {
-        return null; // TEMP — replaced in Task 6
+        Annotation ann = myShepherd.getAnnotation(annotationId);
+        if (ann == null) return null;
+        MediaAsset src = ann.getMediaAsset();
+        if (src == null) return null;
+        double srcW = src.getWidth();
+        double srcH = src.getHeight();
+        if ((srcW <= 0) || (srcH <= 0)) return null;
+        MediaAsset deriv = selectSafeDerivative(ann, myShepherd);
+        if (deriv == null) return null;
+        double dstW = deriv.getWidth();
+        double dstH = deriv.getHeight();
+        if ((dstW <= 0) || (dstH <= 0)) return null;
+        int[] scaled = scaleBbox(ann.getBbox(), srcW, srcH, dstW, dstH);
+        if (scaled == null) return null;
+        URL url = deriv.webURL();
+        if (url == null) return null;
+
+        JSONObject e = new JSONObject();
+        e.put("id", ann.getId());
+        e.put("imageUrl", url.toString());
+        e.put("imageWidth", (int) dstW);
+        e.put("imageHeight", (int) dstH);
+        JSONArray bb = new JSONArray();
+        for (int v : scaled) bb.put(v);
+        e.put("bbox", bb);
+        e.put("theta", ann.getTheta());
+        String vp = ann.getViewpoint();
+        e.put("viewpoint", (vp != null) ? vp : JSONObject.NULL);
+        Encounter enc = ann.findEncounter(myShepherd);
+        e.put("encounterId", (enc != null) ? enc.getId() : JSONObject.NULL);
+        String indId = ann.findIndividualId(myShepherd);
+        e.put("individualId",
+            (Util.stringExists(indId) && !"None".equalsIgnoreCase(indId)) ? indId : JSONObject.NULL);
+        JSONArray mvs = new JSONArray();
+        LinkedHashSet<String> seen = new LinkedHashSet<>();
+        if (ann.getEmbeddings() != null) {
+            for (Embedding emb : ann.getEmbeddings()) {
+                String mv = (emb != null) ? emb.getMethodVersion() : null;
+                if (Util.stringExists(mv) && seen.add(mv)) mvs.put(mv);
+            }
+        }
+        e.put("methodVersion", mvs);
+        return e;
     }
 
     private static long clamp(long v, long lo, long hi) {

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -226,6 +226,7 @@ public class MediaResolveApi extends ApiBase {
                 if (a == null) continue;
                 if (!(a.getStore() instanceof LocalAssetStore)) continue;
                 if (a.hasLabel("_original")) continue;
+                if (a.getParentId() == null) continue; // must be a child derivative, never a self-returned root
                 URL u = a.webURL();
                 if (u != null) return u;
             }

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -201,7 +201,14 @@ public class MediaResolveApi extends ApiBase {
         if ((dstW <= 0) || (dstH <= 0)) return null;
         int[] scaled = scaleBbox(ann.getBbox(), srcW, srcH, dstW, dstH);
         if (scaled == null) return null;
-        URL url = deriv.webURL();
+        URL url;
+        try {
+            url = deriv.webURL();
+        } catch (RuntimeException ex) {
+            // corrupt asset params (e.g. LocalAssetStore.pathFromParameters throws IllegalArgumentException)
+            // -> omit this one annotation (fail-closed); never 500 the whole batch.
+            return null;
+        }
         if (url == null) return null;
 
         JSONObject e = new JSONObject();

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -1,0 +1,37 @@
+package org.ecocean.api;
+
+public class MediaResolveApi extends ApiBase {
+
+    /** Max annotation IDs accepted per request. */
+    static final int MAX_IDS = 100;
+
+    /**
+     * Scale an axis-aligned bbox from the source asset's pixel space into the returned
+     * derivative's pixel space, then clamp to the derivative bounds.
+     * Returns null if inputs are invalid or the scaled region is empty (<1px) — caller omits the entry.
+     *
+     * @param src  [x, y, width, height] in source-asset pixels
+     */
+    static int[] scaleBbox(int[] src, double srcW, double srcH, double dstW, double dstH) {
+        if ((src == null) || (src.length < 4)) return null;
+        if ((srcW <= 0) || (srcH <= 0) || (dstW <= 0) || (dstH <= 0)) return null;
+        double sx = dstW / srcW;
+        double sy = dstH / srcH;
+        int maxW = (int) Math.floor(dstW);
+        int maxH = (int) Math.floor(dstH);
+        // Scale BOTH corners, clamp each corner to the derivative bounds, THEN derive w/h.
+        // (Clamping only the origin and keeping the scaled w/h would mis-size a negative-origin box.)
+        long x1 = clamp(Math.round(src[0] * sx), 0, maxW);
+        long y1 = clamp(Math.round(src[1] * sy), 0, maxH);
+        long x2 = clamp(Math.round(((long) src[0] + src[2]) * sx), 0, maxW);
+        long y2 = clamp(Math.round(((long) src[1] + src[3]) * sy), 0, maxH);
+        int w = (int) (x2 - x1);
+        int h = (int) (y2 - y1);
+        if ((w < 1) || (h < 1)) return null;
+        return new int[] {(int) x1, (int) y1, w, h};
+    }
+
+    private static long clamp(long v, long lo, long hi) {
+        return (v < lo) ? lo : (v > hi ? hi : v);
+    }
+}

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -17,6 +17,7 @@ import org.ecocean.OpenSearch;
 import org.ecocean.User;
 import org.ecocean.Util;
 import org.ecocean.media.MediaAsset;
+import org.ecocean.media.MediaAssetFactory;
 import org.ecocean.media.LocalAssetStore;
 import org.ecocean.security.WildbookTokenAuthenticationFilter;
 import org.ecocean.servlet.ServletUtilities;
@@ -260,8 +261,23 @@ public class MediaResolveApi extends ApiBase {
         MediaAsset src = ann.getMediaAsset();
         if (src == null) return null;
         if (!(src.getStore() instanceof LocalAssetStore)) return null;
+        // _master/_mid derivatives hang off the _original ANCESTOR. The annotation's asset is
+        // typically a non-original SIBLING of those derivatives, so walk to the _original parent
+        // before searching its children — mirroring MediaAsset.bestSafeAsset's traversal. Without
+        // this, findChildrenByLabel on a leaf sibling returns nothing and every annotation is omitted.
+        MediaAsset base = src;
+        Integer parentId = src.getParentId();
+        if (parentId != null) {
+            try {
+                MediaAsset parent = MediaAssetFactory.load(parentId, myShepherd);
+                if ((parent != null) && parent.hasLabel("_original")) base = parent;
+            } catch (RuntimeException ex) {
+                // parent lookup unavailable -> fall back to searching this asset directly (fail-soft;
+                // omit this one id rather than failing the whole batch).
+            }
+        }
         for (String label : new String[] {"_master", "_mid"}) {
-            ArrayList<MediaAsset> kids = src.findChildrenByLabel(myShepherd, label);
+            ArrayList<MediaAsset> kids = base.findChildrenByLabel(myShepherd, label);
             // findChildrenByLabel returns an EMPTY list (not null) when children exist but none
             // match this label — treat that the same as "no match" and try the next label.
             if ((kids == null) || kids.isEmpty()) continue;

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -21,6 +21,8 @@ public class MediaResolveApi extends ApiBase {
         int maxH = (int) Math.floor(dstH);
         // Scale BOTH corners, clamp each corner to the derivative bounds, THEN derive w/h.
         // (Clamping only the origin and keeping the scaled w/h would mis-size a negative-origin box.)
+        // src[i] * sx is int*double -> promotes through double, no overflow; the (long) casts below
+        // matter because src[0]+src[2] (an int sum) could overflow before the multiply.
         long x1 = clamp(Math.round(src[0] * sx), 0, maxW);
         long y1 = clamp(Math.round(src[1] * sy), 0, maxH);
         long x2 = clamp(Math.round(((long) src[0] + src[2]) * sx), 0, maxW);

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -147,17 +147,22 @@ public class MediaResolveApi extends ApiBase {
         w.close();
     }
 
-    // ===== TEMP stubs — replaced in Task 5 (gatedVisibleIds) and Task 6 (resolveOne) =====
+    // ===== TEMP stub — replaced in Task 6 (resolveOne) =====
 
     /**
      * Visibility gate (non-admin): reuse Spec A's exact annotation ACL filter over an ids query.
      * Returns the subset of requested ids the token may see. Query size is set to the id count so
      * none are dropped by the default page size.
      */
-    private Set<String> gatedVisibleIds(Set<String> ids, String userId) throws IOException {
+    // package-visible for unit testing
+    Set<String> gatedVisibleIds(Set<String> ids, String userId) throws IOException {
         JSONObject query = OpenSearch.buildIdEligibilityQuery(ids);
         query = OpenSearch.applyAclFilter(query, userId, "annotation");
         OpenSearch os = new OpenSearch();
+        // deletePit-then-queryPit mirrors SearchApi (SearchApi.java:159): forces a FRESH point-in-time
+        // so the ACL gate reads current state (createPit reuses a cached PIT otherwise, which could be
+        // stale and miss a just-revoked viewUser). PIT_CACHE being process-static is a pre-existing,
+        // systemic property shared by all OpenSearch callers — not addressed here.
         os.deletePit("annotation");
         JSONObject res = os.queryPit("annotation", query, 0, ids.size(), null, null);
         Set<String> visible = new LinkedHashSet<>();

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -206,16 +206,20 @@ public class MediaResolveApi extends ApiBase {
 
     /**
      * Servable URL in the SAME coordinate frame as the bbox (the annotation asset's frame), so the
-     * consumer's scale-only transform is valid (a scale cannot recover a crop offset). If the
-     * annotation asset is not the raw upload (`!hasLabel("_original")`) it IS the bbox frame -> serve
-     * its own webURL. If it is the `_original`, never serve it directly -> serve a _master/_mid child
-     * of it (an aspect-preserving scale of the same frame). LocalAssetStore/non-_original guards;
+     * consumer's scale-only transform is valid (a scale cannot recover a crop offset).
+     *
+     * A child asset (has a parent) is a derivative — safe to serve directly, and it IS the bbox frame.
+     * A ROOT asset (no parent) is the raw upload and must NOT be served directly even if it lacks the
+     * `_original` label (some import paths create unlabeled raw roots) — instead serve a `_master`/
+     * `_mid` child of it (an aspect-preserving scale of the same frame; the consumer scales). The
+     * `_original` label is also honored as a raw-root signal. LocalAssetStore/non-`_original` guards;
      * fail-soft (any error or null URL -> omit, never 500 the batch).
      */
     private static URL safeServableUrl(MediaAsset src, Shepherd myShepherd) {
         try {
-            if (!src.hasLabel("_original")) {
-                return src.webURL(); // the annotation asset is the bbox frame; null -> omit
+            boolean rawRoot = src.hasLabel("_original") || (src.getParentId() == null);
+            if (!rawRoot) {
+                return src.webURL(); // a child derivative; this IS the bbox frame. null -> omit
             }
             for (String type : new String[] {"master", "mid"}) {
                 MediaAsset a = src.bestSafeAsset(myShepherd, null, type);

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -150,8 +150,6 @@ public class MediaResolveApi extends ApiBase {
         w.close();
     }
 
-    // ===== TEMP stub — replaced in Task 6 (resolveOne) =====
-
     /**
      * Visibility gate (non-admin): reuse Spec A's exact annotation ACL filter over an ids query.
      * Returns the subset of requested ids the token may see. Query size is set to the id count so
@@ -218,10 +216,13 @@ public class MediaResolveApi extends ApiBase {
         String vp = ann.getViewpoint();
         e.put("viewpoint", (vp != null) ? vp : JSONObject.NULL);
         Encounter enc = ann.findEncounter(myShepherd);
-        e.put("encounterId", (enc != null) ? enc.getId() : JSONObject.NULL);
-        String indId = ann.findIndividualId(myShepherd);
-        e.put("individualId",
-            (Util.stringExists(indId) && !"None".equalsIgnoreCase(indId)) ? indId : JSONObject.NULL);
+        e.put("encounterId",
+            (enc != null && Util.stringExists(enc.getId())) ? enc.getId() : JSONObject.NULL);
+        // Derive the individual from the already-loaded encounter. findIndividualId() would re-run
+        // findEncounter (a second DB query per annotation); mirror its guard here instead.
+        // Util.stringExists already rejects null/blank/"none"/"unknown", so no extra "None" check.
+        String indId = (enc != null && enc.hasMarkedIndividual()) ? enc.getIndividualID() : null;
+        e.put("individualId", Util.stringExists(indId) ? indId : JSONObject.NULL);
         JSONArray mvs = new JSONArray();
         LinkedHashSet<String> seen = new LinkedHashSet<>();
         if (ann.getEmbeddings() != null) {

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -1,11 +1,24 @@
 package org.ecocean.api;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.ecocean.Annotation;
+import org.ecocean.User;
+import org.ecocean.Util;
 import org.ecocean.media.MediaAsset;
 import org.ecocean.media.LocalAssetStore;
+import org.ecocean.security.WildbookTokenAuthenticationFilter;
+import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 public class MediaResolveApi extends ApiBase {
 
@@ -38,6 +51,106 @@ public class MediaResolveApi extends ApiBase {
         int h = (int) (y2 - y1);
         if ((w < 1) || (h < 1)) return null;
         return new int[] {(int) x1, (int) y1, w, h};
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+    throws ServletException, IOException {
+        handle(request, response);
+    }
+
+    // package-visible entry point for unit tests
+    void doPostForTest(HttpServletRequest request, HttpServletResponse response)
+    throws IOException {
+        handle(request, response);
+    }
+
+    private void handle(HttpServletRequest request, HttpServletResponse response)
+    throws IOException {
+        boolean tokenAuth = Boolean.TRUE.equals(
+            request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR));
+        if (!tokenAuth) {
+            writeError(response, 401, "token auth required");
+            return;
+        }
+        // Verified context ONLY — never fall back to ServletUtilities.getContext() (no session on
+        // this endpoint, so a caller must not be able to steer context via ?context=/cookie/host).
+        String context = (String) request.getAttribute(
+            WildbookTokenAuthenticationFilter.TOKEN_CONTEXT_ATTR);
+        if (!Util.stringExists(context)) {
+            writeError(response, 401, "unauthorized");
+            return;
+        }
+        // Parse + validate the body BEFORE constructing a Shepherd or touching the DB/OpenSearch.
+        // Malformed JSON throws here -> 400 (not the 500 a later broad catch would give).
+        Set<String> ids;
+        try {
+            JSONObject body = ServletUtilities.jsonFromHttpServletRequest(request);
+            JSONArray idArr = (body != null) ? body.optJSONArray("annotationIds") : null;
+            if ((idArr == null) || (idArr.length() == 0) || (idArr.length() > MAX_IDS)) {
+                writeError(response, 400, "annotationIds must be a non-empty array of <= " + MAX_IDS);
+                return;
+            }
+            ids = new LinkedHashSet<>();
+            for (int i = 0; i < idArr.length(); i++) {
+                String s = idArr.optString(i, null);
+                if (Util.stringExists(s)) ids.add(s);
+            }
+            if (ids.isEmpty()) {
+                writeError(response, 400, "annotationIds must contain at least one valid id");
+                return;
+            }
+        } catch (Exception ex) {
+            writeError(response, 400, "malformed request body");
+            return;
+        }
+
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("api.MediaResolveApi.POST");
+        myShepherd.beginDBTransaction();
+        try {
+            User currentUser = myShepherd.getUser(request);
+            if ((currentUser == null) || (currentUser.getId() == null)) {
+                writeError(response, 401, "unauthorized");
+                return;
+            }
+            boolean isAdmin = currentUser.isAdmin(myShepherd);
+            Set<String> visible = isAdmin ? ids : gatedVisibleIds(ids, currentUser.getId());
+            JSONArray results = new JSONArray();
+            for (String id : visible) {
+                JSONObject entry = resolveOne(id, myShepherd);
+                if (entry != null) results.put(entry);
+            }
+            response.setStatus(200);
+            writeBody(response, results.toString());
+        } catch (Exception ex) {
+            response.setStatus(500);
+            writeBody(response, new JSONObject().put("error", "resolve failed").toString());
+            ex.printStackTrace();
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private void writeError(HttpServletResponse response, int status, String msg) throws IOException {
+        response.setStatus(status);
+        writeBody(response, new JSONObject().put("error", msg).toString());
+    }
+
+    private void writeBody(HttpServletResponse response, String s) throws IOException {
+        response.setHeader("Content-Type", "application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(s);
+        response.getWriter().close();
+    }
+
+    // ===== TEMP stubs — replaced in Task 5 (gatedVisibleIds) and Task 6 (resolveOne) =====
+    private Set<String> gatedVisibleIds(Set<String> ids, String userId) throws IOException {
+        return ids; // TEMP — replaced in Task 5
+    }
+
+    private JSONObject resolveOne(String annotationId, Shepherd myShepherd) {
+        return null; // TEMP — replaced in Task 6
     }
 
     private static long clamp(long v, long lo, long hi) {

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.ecocean.Annotation;
+import org.ecocean.OpenSearch;
 import org.ecocean.User;
 import org.ecocean.Util;
 import org.ecocean.media.MediaAsset;
@@ -147,8 +148,30 @@ public class MediaResolveApi extends ApiBase {
     }
 
     // ===== TEMP stubs — replaced in Task 5 (gatedVisibleIds) and Task 6 (resolveOne) =====
+
+    /**
+     * Visibility gate (non-admin): reuse Spec A's exact annotation ACL filter over an ids query.
+     * Returns the subset of requested ids the token may see. Query size is set to the id count so
+     * none are dropped by the default page size.
+     */
     private Set<String> gatedVisibleIds(Set<String> ids, String userId) throws IOException {
-        return ids; // TEMP — replaced in Task 5
+        JSONObject query = OpenSearch.buildIdEligibilityQuery(ids);
+        query = OpenSearch.applyAclFilter(query, userId, "annotation");
+        OpenSearch os = new OpenSearch();
+        os.deletePit("annotation");
+        JSONObject res = os.queryPit("annotation", query, 0, ids.size(), null, null);
+        Set<String> visible = new LinkedHashSet<>();
+        JSONObject outer = (res != null) ? res.optJSONObject("hits") : null;
+        JSONArray hits = (outer != null) ? outer.optJSONArray("hits") : null;
+        if (hits != null) {
+            for (int i = 0; i < hits.length(); i++) {
+                JSONObject h = hits.optJSONObject(i);
+                if (h == null) continue;
+                String hid = h.optString("_id", null);
+                if (Util.stringExists(hid)) visible.add(hid);
+            }
+        }
+        return visible;
     }
 
     private JSONObject resolveOne(String annotationId, Shepherd myShepherd) {

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -60,7 +60,9 @@ public class MediaResolveApi extends ApiBase {
         if (!(src.getStore() instanceof LocalAssetStore)) return null;
         for (String label : new String[] {"_master", "_mid"}) {
             ArrayList<MediaAsset> kids = src.findChildrenByLabel(myShepherd, label);
-            if (kids == null) continue;
+            // findChildrenByLabel returns an EMPTY list (not null) when children exist but none
+            // match this label — treat that the same as "no match" and try the next label.
+            if ((kids == null) || kids.isEmpty()) continue;
             for (MediaAsset kid : kids) {
                 if (kid == null) continue;
                 if (!(kid.getStore() instanceof LocalAssetStore)) continue;

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -1,5 +1,12 @@
 package org.ecocean.api;
 
+import java.util.ArrayList;
+
+import org.ecocean.Annotation;
+import org.ecocean.media.MediaAsset;
+import org.ecocean.media.LocalAssetStore;
+import org.ecocean.shepherd.core.Shepherd;
+
 public class MediaResolveApi extends ApiBase {
 
     /** Max annotation IDs accepted per request. */
@@ -35,5 +42,32 @@ public class MediaResolveApi extends ApiBase {
 
     private static long clamp(long v, long lo, long hi) {
         return (v < lo) ? lo : (v > hi ? hi : v);
+    }
+
+    /**
+     * Select the safe derivative to serve for an annotation's region: a child of the source asset
+     * labeled _master (preferred) or _mid. Both the source and the chosen derivative must be backed
+     * by a LocalAssetStore — an ALLOWLIST, not a denylist: this rejects URLAssetStore (external/public
+     * originals) AND YouTubeAssetStore (webURL is a watch page, not cropable image bytes). Also skips
+     * any child carrying _original. Returns null if none qualifies (caller omits).
+     * Deliberately does NOT use MediaAsset.safeURL/bestSafeAsset, which can return originals for
+     * URLAssetStore and does not fall back from a missing _master to _mid.
+     */
+    static MediaAsset selectSafeDerivative(Annotation ann, Shepherd myShepherd) {
+        if (ann == null) return null;
+        MediaAsset src = ann.getMediaAsset();
+        if (src == null) return null;
+        if (!(src.getStore() instanceof LocalAssetStore)) return null;
+        for (String label : new String[] {"_master", "_mid"}) {
+            ArrayList<MediaAsset> kids = src.findChildrenByLabel(myShepherd, label);
+            if (kids == null) continue;
+            for (MediaAsset kid : kids) {
+                if (kid == null) continue;
+                if (!(kid.getStore() instanceof LocalAssetStore)) continue;
+                if (kid.hasLabel("_original")) continue;
+                return kid;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -286,6 +286,9 @@ public class MediaResolveApi extends ApiBase {
         if (cand == null) return null;
         // Only safe if the parent's derivative is a uniform scale of the source frame (full-frame
         // sibling). A crop/transform source has a different aspect ratio -> omit (fail-closed).
+        // Residual (acceptable): a same-aspect sub-region crop with no own derivative could still pass
+        // this dimension-only check; isUniformScale proves equal x/y scale, not shared origin. Path 1
+        // covers such a crop whenever it has its own _master/_mid, which is the common case.
         if (!isUniformScale(src, cand)) return null;
         return cand;
     }

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -2,7 +2,6 @@ package org.ecocean.api;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -17,7 +16,6 @@ import org.ecocean.OpenSearch;
 import org.ecocean.User;
 import org.ecocean.Util;
 import org.ecocean.media.MediaAsset;
-import org.ecocean.media.MediaAssetFactory;
 import org.ecocean.media.LocalAssetStore;
 import org.ecocean.security.WildbookTokenAuthenticationFilter;
 import org.ecocean.servlet.ServletUtilities;
@@ -29,34 +27,6 @@ public class MediaResolveApi extends ApiBase {
 
     /** Max annotation IDs accepted per request. */
     static final int MAX_IDS = 100;
-
-    /**
-     * Scale an axis-aligned bbox from the source asset's pixel space into the returned
-     * derivative's pixel space, then clamp to the derivative bounds.
-     * Returns null if inputs are invalid or the scaled region is empty (<1px) — caller omits the entry.
-     *
-     * @param src  [x, y, width, height] in source-asset pixels
-     */
-    static int[] scaleBbox(int[] src, double srcW, double srcH, double dstW, double dstH) {
-        if ((src == null) || (src.length < 4)) return null;
-        if ((srcW <= 0) || (srcH <= 0) || (dstW <= 0) || (dstH <= 0)) return null;
-        double sx = dstW / srcW;
-        double sy = dstH / srcH;
-        int maxW = (int) Math.floor(dstW);
-        int maxH = (int) Math.floor(dstH);
-        // Scale BOTH corners, clamp each corner to the derivative bounds, THEN derive w/h.
-        // (Clamping only the origin and keeping the scaled w/h would mis-size a negative-origin box.)
-        // src[i] * sx is int*double -> promotes through double, no overflow; the (long) casts below
-        // matter because src[0]+src[2] (an int sum) could overflow before the multiply.
-        long x1 = clamp(Math.round(src[0] * sx), 0, maxW);
-        long y1 = clamp(Math.round(src[1] * sy), 0, maxH);
-        long x2 = clamp(Math.round(((long) src[0] + src[2]) * sx), 0, maxW);
-        long y2 = clamp(Math.round(((long) src[1] + src[3]) * sy), 0, maxH);
-        int w = (int) (x2 - x1);
-        int h = (int) (y2 - y1);
-        if ((w < 1) || (h < 1)) return null;
-        return new int[] {(int) x1, (int) y1, w, h};
-    }
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
@@ -183,42 +153,36 @@ public class MediaResolveApi extends ApiBase {
 
     /**
      * Resolve one visible annotation into a response entry, or null to omit (fail-closed) when any
-     * required piece is missing: annotation, source asset, dimensions, safe derivative, bbox, or url.
-     * encounterId/individualId use findEncounter's first parent (documented multi-parent behavior;
-     * multi-parent annotations are admin-only in the index so a non-admin never reaches here for them).
+     * required piece is missing. The bbox is returned in the ANNOTATION ASSET's coordinate space
+     * (whose dimensions are reliably stored, unlike derivative children's) — NOT scaled into the
+     * served derivative. The consumer fetches imageUrl, reads its real pixel size, and scales bbox by
+     * realDim/reportedDim before cropping (usually a no-op since _master == source size).
+     * encounterId/individualId use the first parent (findEncounter); multi-parent annotations are
+     * admin-only in the index, so a non-admin never reaches here for them.
      */
     private JSONObject resolveOne(String annotationId, Shepherd myShepherd) {
         Annotation ann = myShepherd.getAnnotation(annotationId);
         if (ann == null) return null;
         MediaAsset src = ann.getMediaAsset();
         if (src == null) return null;
-        double srcW = src.getWidth();
-        double srcH = src.getHeight();
-        if ((srcW <= 0) || (srcH <= 0)) return null;
-        MediaAsset deriv = selectSafeDerivative(ann, myShepherd);
-        if (deriv == null) return null;
-        double dstW = deriv.getWidth();
-        double dstH = deriv.getHeight();
-        if ((dstW <= 0) || (dstH <= 0)) return null;
-        int[] scaled = scaleBbox(ann.getBbox(), srcW, srcH, dstW, dstH);
-        if (scaled == null) return null;
-        URL url;
-        try {
-            url = deriv.webURL();
-        } catch (RuntimeException ex) {
-            // corrupt asset params (e.g. LocalAssetStore.pathFromParameters throws IllegalArgumentException)
-            // -> omit this one annotation (fail-closed); never 500 the whole batch.
-            return null;
-        }
+        // Only LocalAssetStore assets yield servable image bytes (rejects URLAssetStore externals and
+        // YouTubeAssetStore watch pages).
+        if (!(src.getStore() instanceof LocalAssetStore)) return null;
+        double w = src.getWidth();
+        double h = src.getHeight();
+        if ((w <= 0) || (h <= 0)) return null;
+        int[] bbox = clampBbox(ann.getBbox(), w, h);
+        if (bbox == null) return null;
+        URL url = safeServableUrl(src, myShepherd);
         if (url == null) return null;
 
         JSONObject e = new JSONObject();
         e.put("id", ann.getId());
         e.put("imageUrl", url.toString());
-        e.put("imageWidth", (int) dstW);
-        e.put("imageHeight", (int) dstH);
+        e.put("imageWidth", (int) w);
+        e.put("imageHeight", (int) h);
         JSONArray bb = new JSONArray();
-        for (int v : scaled) bb.put(v);
+        for (int v : bbox) bb.put(v);
         e.put("bbox", bb);
         e.put("theta", ann.getTheta());
         String vp = ann.getViewpoint();
@@ -226,9 +190,6 @@ public class MediaResolveApi extends ApiBase {
         Encounter enc = ann.findEncounter(myShepherd);
         e.put("encounterId",
             (enc != null && Util.stringExists(enc.getId())) ? enc.getId() : JSONObject.NULL);
-        // Derive the individual from the already-loaded encounter. findIndividualId() would re-run
-        // findEncounter (a second DB query per annotation); mirror its guard here instead.
-        // Util.stringExists already rejects null/blank/"none"/"unknown", so no extra "None" check.
         String indId = (enc != null && enc.hasMarkedIndividual()) ? enc.getIndividualID() : null;
         e.put("individualId", Util.stringExists(indId) ? indId : JSONObject.NULL);
         JSONArray mvs = new JSONArray();
@@ -243,87 +204,39 @@ public class MediaResolveApi extends ApiBase {
         return e;
     }
 
-    private static long clamp(long v, long lo, long hi) {
-        return (v < lo) ? lo : (v > hi ? hi : v);
-    }
-
     /**
-     * Select the safe derivative whose pixels are a UNIFORM SCALE of the annotation's bbox frame, so
-     * the bbox (defined in {@code ann.getMediaAsset()} space) maps to it by a single dimension ratio.
-     *
-     * Two paths, in order:
-     *  1. A _master/_mid child of the annotation's OWN asset — always a uniform scale of that frame.
-     *  2. If the own asset has no such child, the derivatives hang off the _original ANCESTOR and the
-     *     annotation's asset is a sibling of them. Walk to the _original parent (mirroring
-     *     MediaAsset.bestSafeAsset) and use its derivative ONLY when it is a uniform scale of the
-     *     source frame (matching aspect ratio) — i.e. the source is a full-frame view, not a
-     *     crop/transform. Otherwise the bbox would be scaled against a different coordinate plane, so
-     *     we omit (fail-closed).
-     *
-     * Chosen assets must be LocalAssetStore-backed (allowlist: rejects URLAssetStore external
-     * originals AND YouTubeAssetStore watch pages) and never carry _original. Deliberately does NOT
-     * use MediaAsset.safeURL/bestSafeAsset (returns originals for URLAssetStore; no master->mid fallback).
+     * The access-controlled URL to display for the annotation's asset, via Wildbook's own safeURL
+     * (walks to the _original ancestor and masks the raw upload internally). Tries _master then _mid;
+     * requires a LocalAssetStore-backed, non-_original result. Fail-soft: any lookup error -> omit.
      */
-    static MediaAsset selectSafeDerivative(Annotation ann, Shepherd myShepherd) {
-        if (ann == null) return null;
-        MediaAsset src = ann.getMediaAsset();
-        if (src == null) return null;
-        if (!(src.getStore() instanceof LocalAssetStore)) return null;
-        // Path 1: a derivative of the annotation's own asset is a uniform scale of its frame -> safe.
-        MediaAsset own = findSafeDerivativeChild(src, myShepherd);
-        if (own != null) return own;
-        // Path 2: derivatives live on the _original ancestor; src is a sibling. Walk to the parent.
-        Integer parentId = src.getParentId();
-        if (parentId == null) return null;
-        MediaAsset parent;
-        try {
-            parent = MediaAssetFactory.load(parentId, myShepherd);
-        } catch (RuntimeException ex) {
-            return null; // parent lookup unavailable -> omit this id (fail-soft, never 500 the batch)
-        }
-        if ((parent == null) || !parent.hasLabel("_original")) return null;
-        MediaAsset cand = findSafeDerivativeChild(parent, myShepherd);
-        if (cand == null) return null;
-        // Only safe if the parent's derivative is a uniform scale of the source frame (full-frame
-        // sibling). A crop/transform source has a different aspect ratio -> omit (fail-closed).
-        // Residual (acceptable): a same-aspect sub-region crop with no own derivative could still pass
-        // this dimension-only check; isUniformScale proves equal x/y scale, not shared origin. Path 1
-        // covers such a crop whenever it has its own _master/_mid, which is the common case.
-        if (!isUniformScale(src, cand)) return null;
-        return cand;
-    }
-
-    /** First _master (else _mid) child of {@code base} that is LocalAssetStore-backed and not _original. */
-    private static MediaAsset findSafeDerivativeChild(MediaAsset base, Shepherd myShepherd) {
-        if (base == null) return null;
-        for (String label : new String[] {"_master", "_mid"}) {
-            ArrayList<MediaAsset> kids = base.findChildrenByLabel(myShepherd, label);
-            // findChildrenByLabel returns an EMPTY list (not null) when children exist but none
-            // match this label — treat that the same as "no match" and try the next label.
-            if ((kids == null) || kids.isEmpty()) continue;
-            for (MediaAsset kid : kids) {
-                if (kid == null) continue;
-                if (!(kid.getStore() instanceof LocalAssetStore)) continue;
-                if (kid.hasLabel("_original")) continue;
-                return kid;
+    private static URL safeServableUrl(MediaAsset src, Shepherd myShepherd) {
+        for (String type : new String[] {"master", "mid"}) {
+            try {
+                MediaAsset a = src.bestSafeAsset(myShepherd, null, type);
+                if (a == null) continue;
+                if (!(a.getStore() instanceof LocalAssetStore)) continue;
+                if (a.hasLabel("_original")) continue;
+                URL u = a.webURL();
+                if (u != null) return u;
+            } catch (RuntimeException ex) {
+                // corrupt asset params / lookup failure -> try next type, else omit (never 500 batch)
             }
         }
         return null;
     }
 
-    /**
-     * True iff {@code deriv} is (within ~1% rounding tolerance) a uniform scale of {@code src}'s pixel
-     * frame — the precondition for mapping an axis-aligned bbox by a single dimension ratio. Guards
-     * against cropped/transformed sources whose aspect ratio differs from a full-frame derivative.
-     */
-    private static boolean isUniformScale(MediaAsset src, MediaAsset deriv) {
-        double sw = src.getWidth();
-        double sh = src.getHeight();
-        double dw = deriv.getWidth();
-        double dh = deriv.getHeight();
-        if ((sw <= 0) || (sh <= 0) || (dw <= 0) || (dh <= 0)) return false;
-        double sx = dw / sw;
-        double sy = dh / sh;
-        return Math.abs(sx - sy) <= 0.01 * Math.max(sx, sy);
+    /** Clamp bbox [x,y,w,h] (in src pixel space) to [0,W]x[0,H]; null if invalid or empty. */
+    private static int[] clampBbox(int[] b, double W, double H) {
+        if ((b == null) || (b.length < 4)) return null;
+        int maxW = (int) Math.floor(W);
+        int maxH = (int) Math.floor(H);
+        int x = Math.max(0, Math.min(b[0], maxW));
+        int y = Math.max(0, Math.min(b[1], maxH));
+        int w = b[2];
+        int h = b[3];
+        if (x + w > maxW) w = maxW - x;
+        if (y + h > maxH) h = maxH - y;
+        if ((w < 1) || (h < 1)) return null;
+        return new int[] {x, y, w, h};
     }
 }

--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -105,10 +105,11 @@ public class MediaResolveApi extends ApiBase {
             return;
         }
 
-        Shepherd myShepherd = new Shepherd(context);
-        myShepherd.setAction("api.MediaResolveApi.POST");
-        myShepherd.beginDBTransaction();
+        Shepherd myShepherd = null;
         try {
+            myShepherd = new Shepherd(context);
+            myShepherd.setAction("api.MediaResolveApi.POST");
+            myShepherd.beginDBTransaction();
             User currentUser = myShepherd.getUser(request);
             if ((currentUser == null) || (currentUser.getId() == null)) {
                 writeError(response, 401, "unauthorized");
@@ -123,12 +124,13 @@ public class MediaResolveApi extends ApiBase {
             }
             response.setStatus(200);
             writeBody(response, results.toString());
+        } catch (IOException ioEx) {
+            throw ioEx; // broken pipe / client gone — let the container handle; don't double-write
         } catch (Exception ex) {
-            response.setStatus(500);
-            writeBody(response, new JSONObject().put("error", "resolve failed").toString());
+            writeError(response, 500, "resolve failed");
             ex.printStackTrace();
         } finally {
-            myShepherd.rollbackAndClose();
+            if (myShepherd != null) myShepherd.rollbackAndClose();
         }
     }
 
@@ -138,10 +140,10 @@ public class MediaResolveApi extends ApiBase {
     }
 
     private void writeBody(HttpServletResponse response, String s) throws IOException {
-        response.setHeader("Content-Type", "application/json");
-        response.setCharacterEncoding("UTF-8");
-        response.getWriter().write(s);
-        response.getWriter().close();
+        response.setContentType("application/json; charset=UTF-8");
+        java.io.PrintWriter w = response.getWriter();
+        w.write(s);
+        w.close();
     }
 
     // ===== TEMP stubs — replaced in Task 5 (gatedVisibleIds) and Task 6 (resolveOne) =====

--- a/src/main/java/org/ecocean/api/SearchApi.java
+++ b/src/main/java/org/ecocean/api/SearchApi.java
@@ -130,6 +130,18 @@ public class SearchApi extends ApiBase {
                         query = OpenSearch.queryScrubStored(query);
                     }
                     query = OpenSearch.querySanitize(query, currentUser, myShepherd);
+                    // Non-admin token individual search may only QUERY/SORT identity fields.
+                    // Fail-closed: if we cannot prove the query touches only allowlisted fields,
+                    // reject (400) BEFORE execution so it can't probe hidden cross-encounter
+                    // aggregates (numberEncounters, users, encounterIds, ...) via range/sort/aggs.
+                    // Checked on the scrubbed query, so it covers BOTH a direct body and a stored
+                    // individual query replay.
+                    if (tokenAuth && !isAdmin && "individual".equals(indexName)
+                        && !OpenSearch.queryReferencesOnlyAllowedFields(query,
+                            OpenSearch.INDIVIDUAL_TOKEN_KEEP_SET)) {
+                        response.setStatus(400);
+                        res.put("error", "individual token search may only query identity fields");
+                    } else {
                     if (tokenAuth && !isAdmin) {
                         // Java is the hard boundary: scope totals + pagination + hits before execution
                         query = OpenSearch.applyAclFilter(query, currentUser.getId(), indexName);
@@ -175,6 +187,7 @@ public class SearchApi extends ApiBase {
                         res.put("error", "query failed");
                         ex.printStackTrace();
                     }
+                    } // end individual-token field-gate else
                 }
             }
         }

--- a/src/main/java/org/ecocean/api/SearchApi.java
+++ b/src/main/java/org/ecocean/api/SearchApi.java
@@ -180,7 +180,9 @@ public class SearchApi extends ApiBase {
                         res.put("success", true);
                         res.put("searchQueryId", searchQueryId);
                         res.put("hits", hitsArr);
-                        res.put("query", query);
+                        // On the token path `query` has been mutated by applyAclFilter to embed the
+                        // ACL filter (internal ACL field names + the caller's UUID). Don't echo it back.
+                        if (!tokenAuth) res.put("query", query);
                     } catch (IOException ex) {
                         response.setStatus(500);
                         res.put("success", false);

--- a/src/main/java/org/ecocean/api/SearchApi.java
+++ b/src/main/java/org/ecocean/api/SearchApi.java
@@ -136,11 +136,15 @@ public class SearchApi extends ApiBase {
                     // aggregates (numberEncounters, users, encounterIds, ...) via range/sort/aggs.
                     // Checked on the scrubbed query, so it covers BOTH a direct body and a stored
                     // individual query replay.
+                    // The URL `sort` param is applied by queryPit() (not present in the body),
+                    // so validate it here too: it may only sort on an allowlisted identity field.
+                    boolean badSort = (sort != null) && !sort.trim().isEmpty()
+                        && !OpenSearch.INDIVIDUAL_TOKEN_KEEP_SET.contains(sort.trim());
                     if (tokenAuth && !isAdmin && "individual".equals(indexName)
-                        && !OpenSearch.queryReferencesOnlyAllowedFields(query,
-                            OpenSearch.INDIVIDUAL_TOKEN_KEEP_SET)) {
+                        && (!OpenSearch.queryReferencesOnlyAllowedFields(query,
+                            OpenSearch.INDIVIDUAL_TOKEN_KEEP_SET) || badSort)) {
                         response.setStatus(400);
-                        res.put("error", "individual token search may only query identity fields");
+                        res.put("error", "individual token search may only query/sort identity fields");
                     } else {
                     if (tokenAuth && !isAdmin) {
                         // Java is the hard boundary: scope totals + pagination + hits before execution

--- a/src/main/java/org/ecocean/api/SearchApi.java
+++ b/src/main/java/org/ecocean/api/SearchApi.java
@@ -44,6 +44,7 @@ public class SearchApi extends ApiBase {
             response.setStatus(401);
             res.put("error", "token auth misconfiguration");
         } else {
+            boolean isAdmin = currentUser.isAdmin(myShepherd);
             String arg = request.getPathInfo();
             if ((arg == null) || arg.equals("/")) {
                 // for multisearch later maybe?
@@ -75,19 +76,18 @@ public class SearchApi extends ApiBase {
                 } else if ((searchQueryId == null) && !OpenSearch.isValidIndexName(indexName)) {
                     response.setStatus(404);
                     res.put("error", "unknown index");
-                } else if ("annotation".equals(indexName) && !currentUser.isAdmin(myShepherd)) {
+                } else if ("annotation".equals(indexName) && !isAdmin) {
                     // per discussion with jh today, api exposure of annotations admin-only currently
                     response.setStatus(403);
                     res.put("error", 403);
                 // --- token encounter-only index gate + stored-query owner check ---
                 } else if (tokenAuth && !"encounter".equals(
-                    (searchQueryId != null) ? (query != null ? query.optString("indexName", null) : null)
-                                            : indexName)) {
+                    (searchQueryId != null) ? query.optString("indexName", null) : indexName)) {
                     // covers stored queries whose real index is read from the stored doc, not the URL
                     response.setStatus(403);
                     res.put("error", "token search is limited to the encounter index");
                 } else if (tokenAuth && (searchQueryId != null) && (query != null)
-                    && !currentUser.isAdmin(myShepherd)
+                    && !isAdmin
                     && !currentUser.getId().equals(query.optString("creator", null))) {
                     // replaying someone else's stored query is not allowed (admin bypasses)
                     response.setStatus(403);
@@ -117,7 +117,7 @@ public class SearchApi extends ApiBase {
                         query = OpenSearch.queryScrubStored(query);
                     }
                     query = OpenSearch.querySanitize(query, currentUser, myShepherd);
-                    if (tokenAuth && !currentUser.isAdmin(myShepherd)) {
+                    if (tokenAuth && !isAdmin) {
                         // Java is the hard boundary: scope totals + pagination + hits before execution
                         query = OpenSearch.applyEncounterAclFilter(query, currentUser.getId());
                     }

--- a/src/main/java/org/ecocean/api/SearchApi.java
+++ b/src/main/java/org/ecocean/api/SearchApi.java
@@ -30,9 +30,19 @@ public class SearchApi extends ApiBase {
 
         User currentUser = myShepherd.getUser(request);
         JSONObject res = new JSONObject();
+        boolean tokenAuth = Boolean.TRUE.equals(
+            request.getAttribute(org.ecocean.security.WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR));
+        String authzHeader = request.getHeader("Authorization");
+        // case-insensitive scheme match (matches the filter); avoids fall-through on "bearer ..."
+        boolean bearerPresent = (authzHeader != null)
+            && authzHeader.regionMatches(true, 0, "Bearer ", 0, 7);
         if ((currentUser == null) || (currentUser.getId() == null)) {
             response.setStatus(401);
             res.put("error", 401);
+        } else if (bearerPresent && !tokenAuth) {
+            // a Bearer reached SearchApi without the token filter marking it -> filter misconfig
+            response.setStatus(401);
+            res.put("error", "token auth misconfiguration");
         } else {
             String arg = request.getPathInfo();
             if ((arg == null) || arg.equals("/")) {
@@ -47,7 +57,19 @@ public class SearchApi extends ApiBase {
                     searchQueryId = indexName;
                     query = OpenSearch.queryLoad(searchQueryId);
                 }
-                if ((searchQueryId != null) && (query == null)) {
+                // --- token method allowlist FIRST (no existence/ownership leak via 403/404) ---
+                if (tokenAuth && (searchQueryId != null)
+                    && !"GET".equals(request.getMethod())) {
+                    // stored-query replay is GET-only on the token path
+                    response.setStatus(405);
+                    res.put("error", "method not allowed");
+                } else if (tokenAuth && (searchQueryId == null)
+                    && !"POST".equals(request.getMethod())) {
+                    // direct index search is POST-only on the token path
+                    response.setStatus(405);
+                    res.put("error", "method not allowed");
+                // --- existing validity checks ---
+                } else if ((searchQueryId != null) && (query == null)) {
                     response.setStatus(404);
                     res.put("error", "invalid searchQueryId " + searchQueryId);
                 } else if ((searchQueryId == null) && !OpenSearch.isValidIndexName(indexName)) {
@@ -57,6 +79,19 @@ public class SearchApi extends ApiBase {
                     // per discussion with jh today, api exposure of annotations admin-only currently
                     response.setStatus(403);
                     res.put("error", 403);
+                // --- token encounter-only index gate + stored-query owner check ---
+                } else if (tokenAuth && !"encounter".equals(
+                    (searchQueryId != null) ? (query != null ? query.optString("indexName", null) : null)
+                                            : indexName)) {
+                    // covers stored queries whose real index is read from the stored doc, not the URL
+                    response.setStatus(403);
+                    res.put("error", "token search is limited to the encounter index");
+                } else if (tokenAuth && (searchQueryId != null) && (query != null)
+                    && !currentUser.isAdmin(myShepherd)
+                    && !currentUser.getId().equals(query.optString("creator", null))) {
+                    // replaying someone else's stored query is not allowed (admin bypasses)
+                    response.setStatus(403);
+                    res.put("error", "not the owner of this stored query");
                 } else if ((query == null) && !"POST".equals(request.getMethod())) {
                     response.setStatus(405);
                     res.put("error", "method not allowed");
@@ -82,6 +117,10 @@ public class SearchApi extends ApiBase {
                         query = OpenSearch.queryScrubStored(query);
                     }
                     query = OpenSearch.querySanitize(query, currentUser, myShepherd);
+                    if (tokenAuth && !currentUser.isAdmin(myShepherd)) {
+                        // Java is the hard boundary: scope totals + pagination + hits before execution
+                        query = OpenSearch.applyEncounterAclFilter(query, currentUser.getId());
+                    }
                     System.out.println("SearchApi (sanitized) indexName=" + indexName + "; query=" +
                         query);
 

--- a/src/main/java/org/ecocean/api/SearchApi.java
+++ b/src/main/java/org/ecocean/api/SearchApi.java
@@ -64,6 +64,11 @@ public class SearchApi extends ApiBase {
                     searchQueryId = indexName;
                     query = OpenSearch.queryLoad(searchQueryId);
                 }
+                // effective index: a stored query's real index comes from the loaded doc, not the {uuid} URL.
+                // null-safe: null when a stored query failed to load (handled by the missing-stored-query branch).
+                String effectiveIndex = (searchQueryId != null)
+                    ? (query != null ? query.optString("indexName", null) : null)
+                    : indexName;
                 // --- token method allowlist FIRST (no existence/ownership leak via 403/404) ---
                 if (tokenAuth && (searchQueryId != null)
                     && !"GET".equals(request.getMethod())) {
@@ -75,30 +80,31 @@ public class SearchApi extends ApiBase {
                     // direct index search is POST-only on the token path
                     response.setStatus(405);
                     res.put("error", "method not allowed");
-                // --- existing validity checks ---
+                // --- missing stored query (failed load): before index validity ---
                 } else if ((searchQueryId != null) && (query == null)) {
                     response.setStatus(404);
                     res.put("error", "invalid searchQueryId " + searchQueryId);
-                } else if ((searchQueryId == null) && !OpenSearch.isValidIndexName(indexName)) {
-                    response.setStatus(404);
-                    res.put("error", "unknown index");
-                } else if ("annotation".equals(indexName) && !isAdmin) {
-                    // per discussion with jh today, api exposure of annotations admin-only currently
-                    response.setStatus(403);
-                    res.put("error", 403);
-                // --- token stored-query OWNER check FIRST: a non-owner must not learn the
-                // index/existence of someone else's stored query (admin bypasses) ---
+                // --- token stored-query OWNER check: before index validity so a non-owner can't probe it ---
                 } else if (tokenAuth && (searchQueryId != null) && (query != null)
                     && !isAdmin
                     && !currentUser.getId().equals(query.optString("creator", null))) {
                     response.setStatus(403);
                     res.put("error", "not the owner of this stored query");
-                // --- token encounter-only index gate (own stored queries / direct index) ---
-                } else if (tokenAuth && !"encounter".equals(
-                    (searchQueryId != null) ? query.optString("indexName", null) : indexName)) {
-                    // covers stored queries whose real index is read from the stored doc, not the URL
+                // --- effective-index validity (subsumes the old direct unknown-index check) ---
+                } else if (!OpenSearch.isValidIndexName(effectiveIndex)) {
+                    response.setStatus(404);
+                    res.put("error", "unknown index");
+                // --- session-path annotation gate stays admin-only; token path uses the ACL filter instead ---
+                } else if (!tokenAuth && "annotation".equals(effectiveIndex) && !isAdmin) {
+                    // per discussion with jh: api exposure of annotations admin-only on the session path
                     response.setStatus(403);
-                    res.put("error", "token search is limited to the encounter index");
+                    res.put("error", 403);
+                // --- token index allowlist: encounter, annotation, individual (others 403) ---
+                } else if (tokenAuth && !"encounter".equals(effectiveIndex)
+                    && !"annotation".equals(effectiveIndex)
+                    && !"individual".equals(effectiveIndex)) {
+                    response.setStatus(403);
+                    res.put("error", "token search is limited to encounter, annotation, individual");
                 } else if ((query == null) && !"POST".equals(request.getMethod())) {
                     response.setStatus(405);
                     res.put("error", "method not allowed");
@@ -126,7 +132,7 @@ public class SearchApi extends ApiBase {
                     query = OpenSearch.querySanitize(query, currentUser, myShepherd);
                     if (tokenAuth && !isAdmin) {
                         // Java is the hard boundary: scope totals + pagination + hits before execution
-                        query = OpenSearch.applyEncounterAclFilter(query, currentUser.getId());
+                        query = OpenSearch.applyAclFilter(query, currentUser.getId(), indexName);
                     }
                     // do not log the full (possibly ACL-scoped) query body / user identifiers
                     System.out.println("SearchApi search indexName=" + indexName
@@ -153,7 +159,7 @@ public class SearchApi extends ApiBase {
                             if (doc == null)
                                 throw new IOException("failed to parse doc in hits[" + i + "]");
                             hitsArr.put(OpenSearch.sanitizeDoc(doc, indexName, myShepherd,
-                                currentUser));
+                                currentUser, tokenAuth));
                         }
                         response.setHeader("X-Wildbook-Total-Hits", Integer.toString(totalHits));
                         response.setHeader("X-Wildbook-Search-Query-Id", searchQueryId);

--- a/src/main/java/org/ecocean/api/SearchApi.java
+++ b/src/main/java/org/ecocean/api/SearchApi.java
@@ -22,16 +22,22 @@ public class SearchApi extends ApiBase {
 
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
     throws ServletException, IOException {
-        String context = ServletUtilities.getContext(request);
+        boolean tokenAuth = Boolean.TRUE.equals(
+            request.getAttribute(org.ecocean.security.WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR));
+        String tokenContext = (String) request.getAttribute(
+            org.ecocean.security.WildbookTokenAuthenticationFilter.TOKEN_CONTEXT_ATTR);
+        // On the token path use the filter-VERIFIED context, not request-derived context (which a
+        // caller can steer via ?context=/cookie/host). Session path resolves context as before.
+        String context = (tokenAuth && (tokenContext != null))
+            ? tokenContext : ServletUtilities.getContext(request);
         Shepherd myShepherd = new Shepherd(context);
 
         myShepherd.setAction("api.SearchApi.POST");
         myShepherd.beginDBTransaction();
 
+        try {
         User currentUser = myShepherd.getUser(request);
         JSONObject res = new JSONObject();
-        boolean tokenAuth = Boolean.TRUE.equals(
-            request.getAttribute(org.ecocean.security.WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR));
         String authzHeader = request.getHeader("Authorization");
         // case-insensitive scheme match (matches the filter); avoids fall-through on "bearer ..."
         boolean bearerPresent = (authzHeader != null)
@@ -80,18 +86,19 @@ public class SearchApi extends ApiBase {
                     // per discussion with jh today, api exposure of annotations admin-only currently
                     response.setStatus(403);
                     res.put("error", 403);
-                // --- token encounter-only index gate + stored-query owner check ---
+                // --- token stored-query OWNER check FIRST: a non-owner must not learn the
+                // index/existence of someone else's stored query (admin bypasses) ---
+                } else if (tokenAuth && (searchQueryId != null) && (query != null)
+                    && !isAdmin
+                    && !currentUser.getId().equals(query.optString("creator", null))) {
+                    response.setStatus(403);
+                    res.put("error", "not the owner of this stored query");
+                // --- token encounter-only index gate (own stored queries / direct index) ---
                 } else if (tokenAuth && !"encounter".equals(
                     (searchQueryId != null) ? query.optString("indexName", null) : indexName)) {
                     // covers stored queries whose real index is read from the stored doc, not the URL
                     response.setStatus(403);
                     res.put("error", "token search is limited to the encounter index");
-                } else if (tokenAuth && (searchQueryId != null) && (query != null)
-                    && !isAdmin
-                    && !currentUser.getId().equals(query.optString("creator", null))) {
-                    // replaying someone else's stored query is not allowed (admin bypasses)
-                    response.setStatus(403);
-                    res.put("error", "not the owner of this stored query");
                 } else if ((query == null) && !"POST".equals(request.getMethod())) {
                     response.setStatus(405);
                     res.put("error", "method not allowed");
@@ -121,8 +128,9 @@ public class SearchApi extends ApiBase {
                         // Java is the hard boundary: scope totals + pagination + hits before execution
                         query = OpenSearch.applyEncounterAclFilter(query, currentUser.getId());
                     }
-                    System.out.println("SearchApi (sanitized) indexName=" + indexName + "; query=" +
-                        query);
+                    // do not log the full (possibly ACL-scoped) query body / user identifiers
+                    System.out.println("SearchApi search indexName=" + indexName
+                        + " tokenAuth=" + tokenAuth);
 
                     OpenSearch os = new OpenSearch();
                     try {
@@ -168,6 +176,8 @@ public class SearchApi extends ApiBase {
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(res.toString());
         response.getWriter().close();
-        myShepherd.rollbackAndClose();
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
     }
 }

--- a/src/main/java/org/ecocean/api/auth/JwtService.java
+++ b/src/main/java/org/ecocean/api/auth/JwtService.java
@@ -10,6 +10,7 @@ import java.util.Date;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 
 import org.ecocean.CommonConfiguration;
@@ -107,11 +108,19 @@ public class JwtService {
 
     public Jws<Claims> verify(String token) {
         if (publicKey == null) throw new IllegalStateException("JwtService cannot verify (no public key)");
-        return Jwts.parser()
+        Jws<Claims> jws = Jwts.parser()
             .requireIssuer(issuer)
             .requireAudience(audience)
             .verifyWith(publicKey)
             .build()
             .parseSignedClaims(token);
+        // Pin to RS256: reject same-key tokens signed with a different RSA/PSS variant.
+        // jjwt 0.12.6's sig().clear().add() API throws IAE before build(), so we check
+        // the algorithm header explicitly after a successful signature verification.
+        String alg = jws.getHeader().getAlgorithm();
+        if (!Jwts.SIG.RS256.getId().equals(alg)) {
+            throw new JwtException("JWT algorithm '" + alg + "' is not accepted; only RS256 is allowed");
+        }
+        return jws;
     }
 }

--- a/src/main/java/org/ecocean/api/auth/JwtService.java
+++ b/src/main/java/org/ecocean/api/auth/JwtService.java
@@ -91,6 +91,10 @@ public class JwtService {
         return privateKey != null;
     }
 
+    public boolean canVerify() {
+        return publicKey != null;
+    }
+
     public String sign(String userUuid, String context, long ttlMillis) {
         if (!isEnabled()) throw new IllegalStateException("JwtService not enabled (no private key)");
         long now = System.currentTimeMillis();

--- a/src/main/java/org/ecocean/api/auth/JwtService.java
+++ b/src/main/java/org/ecocean/api/auth/JwtService.java
@@ -1,0 +1,117 @@
+package org.ecocean.api.auth;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+
+import org.ecocean.CommonConfiguration;
+import org.ecocean.Util;
+
+/**
+ * Issues and verifies short-lived RS256 JWTs that carry ONLY identity
+ * (subject = user UUID, context). No admin/role claims — the consumer
+ * resolves privileges fresh. Wildbook holds the private (signing) key;
+ * the external scoped-access kernel holds the public key.
+ *
+ * Keys are RSA, supplied as Base64 of the encoded key bytes (private = PKCS8,
+ * public = X.509), via commonConfiguration.properties:
+ *   jwtPrivateKeyBase64=...   (signing; required to mint tokens)
+ *   jwtPublicKeyBase64=...    (verify; optional Wildbook-side)
+ *   jwtIssuer=wildbook
+ *   jwtAudience=wildbook-scoped-api
+ * If the private key is absent, the service is "disabled" and the token
+ * endpoint returns 503.
+ */
+public class JwtService {
+    private final PrivateKey privateKey;
+    private final PublicKey publicKey;
+    private final String issuer;
+    private final String audience;
+    private final String keyId; // JWT header 'kid' for key rotation (Codex Medium); may be null
+
+    private JwtService(PrivateKey priv, PublicKey pub, String issuer, String audience,
+        String keyId) {
+        this.privateKey = priv;
+        this.publicKey = pub;
+        this.issuer = issuer;
+        this.audience = audience;
+        this.keyId = keyId;
+    }
+
+    // test/explicit overload without a keyId
+    public static JwtService fromBase64Keys(String privB64, String pubB64, String issuer,
+        String audience) {
+        return fromBase64Keys(privB64, pubB64, issuer, audience, null);
+    }
+
+    public static JwtService fromBase64Keys(String privB64, String pubB64, String issuer,
+        String audience, String keyId) {
+        PrivateKey priv = null;
+        PublicKey pub = null;
+        try {
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            if (Util.stringExists(privB64)) {
+                priv = kf.generatePrivate(
+                    new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privB64.trim())));
+            }
+            if (Util.stringExists(pubB64)) {
+                pub = kf.generatePublic(
+                    new X509EncodedKeySpec(Base64.getDecoder().decode(pubB64.trim())));
+            }
+        } catch (Exception ex) {
+            System.out.println("JwtService: failed to load keys: " + ex);
+        }
+        return new JwtService(priv, pub, issuer, audience, keyId);
+    }
+
+    public static JwtService fromConfig(String context) {
+        return fromBase64Keys(
+            CommonConfiguration.getProperty("jwtPrivateKeyBase64", context),
+            CommonConfiguration.getProperty("jwtPublicKeyBase64", context),
+            orDefault(CommonConfiguration.getProperty("jwtIssuer", context), "wildbook"),
+            orDefault(CommonConfiguration.getProperty("jwtAudience", context),
+                "wildbook-scoped-api"),
+            CommonConfiguration.getProperty("jwtKeyId", context)); // may be null
+    }
+
+    private static String orDefault(String v, String d) {
+        return Util.stringExists(v) ? v : d;
+    }
+
+    public boolean isEnabled() {
+        return privateKey != null;
+    }
+
+    public String sign(String userUuid, String context, long ttlMillis) {
+        if (!isEnabled()) throw new IllegalStateException("JwtService not enabled (no private key)");
+        long now = System.currentTimeMillis();
+        io.jsonwebtoken.JwtBuilder b = Jwts.builder()
+            .issuer(issuer)
+            .audience().add(audience).and()
+            .subject(userUuid)
+            .claim("context", context)
+            .id(Util.generateUUID())
+            .issuedAt(new Date(now))
+            .expiration(new Date(now + ttlMillis));
+        if (Util.stringExists(keyId)) b.header().keyId(keyId).and(); // 'kid' for rotation
+        return b.signWith(privateKey, Jwts.SIG.RS256).compact();
+    }
+
+    public Jws<Claims> verify(String token) {
+        if (publicKey == null) throw new IllegalStateException("JwtService cannot verify (no public key)");
+        return Jwts.parser()
+            .requireIssuer(issuer)
+            .requireAudience(audience)
+            .verifyWith(publicKey)
+            .build()
+            .parseSignedClaims(token);
+    }
+}

--- a/src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java
+++ b/src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java
@@ -35,6 +35,8 @@ import org.json.JSONObject;
 public class WildbookTokenAuthenticationFilter extends OncePerRequestFilter {
 
     public static final String TOKEN_AUTH_ATTR = "org.ecocean.tokenAuth";
+    /** Filter-verified context, passed to SearchApi so it does not re-resolve from caller-controlled inputs. */
+    public static final String TOKEN_CONTEXT_ATTR = "org.ecocean.tokenAuthContext";
 
     @Override
     protected void doFilterInternal(ServletRequest req, ServletResponse resp, FilterChain chain)
@@ -62,22 +64,26 @@ public class WildbookTokenAuthenticationFilter extends OncePerRequestFilter {
             deny(response, 503, "token auth not configured");
             return;
         }
-        Claims claims;
+        // Extract claims INSIDE the catch: jjwt typed-claim access (get(..., String.class),
+        // getSubject) can throw JwtException subclasses for ill-typed claims -> treat as 401,
+        // never let it escape as a 500.
+        String tokenContext;
+        String uuid;
         try {
             Jws<Claims> jws = jwt.verify(token);
-            claims = jws.getPayload();
+            Claims claims = jws.getPayload();
+            tokenContext = claims.get("context", String.class);
+            uuid = claims.getSubject();
         } catch (JwtException | IllegalArgumentException ex) {
             deny(response, 401, "invalid token");
             return;
         }
         // context claim must equal server context, AND request-resolved context must not drift
-        String tokenContext = claims.get("context", String.class);
         String reqContext = requestContext(request);
         if (!expected.equals(tokenContext) || !expected.equals(reqContext)) {
             deny(response, 401, "context mismatch");
             return;
         }
-        String uuid = claims.getSubject();
         if (!Util.stringExists(uuid)) {
             deny(response, 401, "invalid token subject");
             return;
@@ -122,6 +128,7 @@ public class WildbookTokenAuthenticationFilter extends OncePerRequestFilter {
             }
         };
         wrapped.setAttribute(TOKEN_AUTH_ATTR, Boolean.TRUE);
+        wrapped.setAttribute(TOKEN_CONTEXT_ATTR, expected);
         chain.doFilter(wrapped, response);
     }
 

--- a/src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java
+++ b/src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java
@@ -1,0 +1,166 @@
+package org.ecocean.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jws;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.shiro.web.servlet.OncePerRequestFilter;
+import org.ecocean.CommonConfiguration;
+import org.ecocean.User;
+import org.ecocean.Util;
+import org.ecocean.api.auth.JwtService;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+
+/**
+ * Token-authenticated read path for /api/v3/search/* (encounter index only; gated in SearchApi).
+ *
+ * Verifies a B-issued RS256 JWT, enforces the context claim + rejects request-context drift,
+ * resolves the user by UUID, and WRAPS the request so Shepherd.getUser(request) returns the
+ * token user. It deliberately does NOT call subject.login: Wildbook is session-based, and a
+ * login on a bearer request could mint a session reusable on write endpoints. No Bearer => the
+ * chain proceeds unchanged (browser/session path intact).
+ */
+public class WildbookTokenAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String TOKEN_AUTH_ATTR = "org.ecocean.tokenAuth";
+
+    @Override
+    protected void doFilterInternal(ServletRequest req, ServletResponse resp, FilterChain chain)
+    throws ServletException, IOException {
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) resp;
+
+        String authz = request.getHeader("Authorization");
+        // HTTP auth scheme tokens are case-insensitive: accept "Bearer"/"bearer"/etc.
+        if ((authz == null) || !authz.regionMatches(true, 0, "Bearer ", 0, 7)) {
+            chain.doFilter(request, response); // no token: leave session/anon path intact
+            return;
+        }
+        // method allowlist (defence in depth): only safe read methods reach search
+        String method = request.getMethod();
+        if (!"GET".equals(method) && !"POST".equals(method)) {
+            deny(response, 405, "method not allowed");
+            return;
+        }
+        String token = authz.substring(7).trim();
+        String expected = expectedContext();
+
+        JwtService jwt = jwtService(expected);
+        if (!jwt.canVerify()) {
+            deny(response, 503, "token auth not configured");
+            return;
+        }
+        Claims claims;
+        try {
+            Jws<Claims> jws = jwt.verify(token);
+            claims = jws.getPayload();
+        } catch (JwtException | IllegalStateException ex) {
+            deny(response, 401, "invalid token");
+            return;
+        }
+        // context claim must equal server context, AND request-resolved context must not drift
+        String tokenContext = claims.get("context", String.class);
+        String reqContext = requestContext(request);
+        if (!expected.equals(tokenContext) || !expected.equals(reqContext)) {
+            deny(response, 401, "context mismatch");
+            return;
+        }
+        String uuid = claims.getSubject();
+        if (!Util.stringExists(uuid)) {
+            deny(response, 401, "invalid token subject");
+            return;
+        }
+        final String username = lookupUsername(expected, uuid);
+        if (username == null) {
+            deny(response, 401, "unknown user");
+            return;
+        }
+        // wrap so getUser(request) -> getUsername(request) -> getUserPrincipal().toString() == username
+        final Principal principal = new Principal() {
+            public String getName() {
+                return username;
+            }
+
+            public String toString() {
+                return username;
+            }
+        };
+        // Local attribute store: keeps wrapper-set attrs isolated from the underlying session
+        // request (important in tests and in production to avoid bleeding auth markers into
+        // the original request, and ensures getAttribute(TOKEN_AUTH_ATTR) is visible on the
+        // wrapped object passed downstream — HttpServletRequestWrapper.setAttribute delegates
+        // to the underlying request, which would be invisible to callers of the wrapper).
+        final Map<String, Object> localAttrs = new HashMap<>();
+        HttpServletRequestWrapper wrapped = new HttpServletRequestWrapper(request) {
+            @Override public Principal getUserPrincipal() {
+                return principal;
+            }
+
+            @Override public String getRemoteUser() {
+                return username;
+            }
+
+            @Override public void setAttribute(String name, Object value) {
+                localAttrs.put(name, value);
+            }
+
+            @Override public Object getAttribute(String name) {
+                if (localAttrs.containsKey(name)) return localAttrs.get(name);
+                return super.getAttribute(name);
+            }
+        };
+        wrapped.setAttribute(TOKEN_AUTH_ATTR, Boolean.TRUE);
+        chain.doFilter(wrapped, response);
+    }
+
+    // ----- protected seams (overridden in unit tests) -----
+
+    protected String expectedContext() {
+        String c = CommonConfiguration.getProperty("jwtContext", "context0");
+        return Util.stringExists(c) ? c : "context0";
+    }
+
+    protected String requestContext(HttpServletRequest request) {
+        return ServletUtilities.getContext(request);
+    }
+
+    protected JwtService jwtService(String context) {
+        return JwtService.fromConfig(context);
+    }
+
+    protected String lookupUsername(String context, String uuid) {
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("WildbookTokenAuthenticationFilter");
+        myShepherd.beginDBTransaction();
+        try {
+            User user = myShepherd.getUserByUUID(uuid);
+            return (user != null) ? user.getUsername() : null;
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
+    }
+
+    private void deny(HttpServletResponse response, int status, String message)
+    throws IOException {
+        response.setStatus(status);
+        response.setHeader("Content-Type", "application/json");
+        response.setCharacterEncoding("UTF-8");
+        JSONObject err = new JSONObject();
+        err.put("success", false);
+        err.put("error", message);
+        response.getWriter().write(err.toString());
+        response.getWriter().close();
+    }
+}

--- a/src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java
+++ b/src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java
@@ -66,7 +66,7 @@ public class WildbookTokenAuthenticationFilter extends OncePerRequestFilter {
         try {
             Jws<Claims> jws = jwt.verify(token);
             claims = jws.getPayload();
-        } catch (JwtException | IllegalStateException ex) {
+        } catch (JwtException | IllegalArgumentException ex) {
             deny(response, 401, "invalid token");
             return;
         }
@@ -155,12 +155,12 @@ public class WildbookTokenAuthenticationFilter extends OncePerRequestFilter {
     private void deny(HttpServletResponse response, int status, String message)
     throws IOException {
         response.setStatus(status);
-        response.setHeader("Content-Type", "application/json");
-        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json;charset=UTF-8");
         JSONObject err = new JSONObject();
         err.put("success", false);
         err.put("error", message);
-        response.getWriter().write(err.toString());
-        response.getWriter().close();
+        java.io.PrintWriter w = response.getWriter();
+        w.write(err.toString());
+        w.close();
     }
 }

--- a/src/main/java/org/ecocean/shepherd/core/ShepherdPMF.java
+++ b/src/main/java/org/ecocean/shepherd/core/ShepherdPMF.java
@@ -29,6 +29,27 @@ public class ShepherdPMF {
         return getPMF(context, null);
     }
 
+    /**
+     * Close and evict the cached PMF for a context (no-op if none). TEST SUPPORT ONLY
+     * (package-private; tests call it via TestPMFUtil): each Testcontainers test class binds the
+     * context's PMF to ITS OWN database container, so a class must evict the cached PMF (which may
+     * point at a previous class's now-stopped container) before seeding, and again after itself,
+     * or later classes fail with "An I/O error occurred while sending to the backend".
+     * NOT safe as a production API: another thread holding a PMF from getPMF would have it closed
+     * out from under it.
+     */
+    synchronized static void closePMF(String context) {
+        if (pmfs == null) return;
+        PersistenceManagerFactory pmf = pmfs.remove(context);
+        if ((pmf != null) && !pmf.isClosed()) {
+            try {
+                pmf.close();
+            } catch (Exception ex) {
+                System.out.println("ShepherdPMF.closePMF(" + context + ") failed: " + ex);
+            }
+        }
+    }
+
     public synchronized static PersistenceManagerFactory getPMF(String context,
         Properties overrideProps) {
         // public static PersistenceManagerFactory getPMF(String dbLocation) {

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -85,6 +85,7 @@
 				realmA = org.ecocean.security.ShepherdRealm
 				roles.unauthorizedUrl = /accessDenied.jsp
 				authcBasicWildbook = org.ecocean.security.WildbookBasicHttpAuthenticationFilter
+				tokenAuthSearch = org.ecocean.security.WildbookTokenAuthenticationFilter
 				authc.loginUrl = /react/login
 
 				[filters]
@@ -107,6 +108,9 @@
 				/api/v3/bulk-export = authc, roles[researcher]
 				/api/v3/bulk-export/** = authc, roles[researcher]
 				/api/v3/match-inspection/** = authc
+				# token-authenticated scoped search (Artifact D): token filter ONLY, no authc/roles chained.
+				# No Bearer => falls through to SearchApi (which self-401s if no session). Filter handles auth.
+				/api/v3/search/** = tokenAuthSearch
 
 
 				# ===== Appadmin =====

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -100,6 +100,7 @@
 
 				# ===== v3 API Security =====
 				/api/v3/auth/token = authcBasicWildbook
+				/api/v3/can-user-access = authcBasicWildbook, roles[admin]
 				/api/v3/bulk-import = authc
 				/api/v3/bulk-import/** = authc
 				/api/v3/bulk-export = authc
@@ -543,6 +544,16 @@
 	<servlet-mapping>
 		<servlet-name>AuthToken</servlet-name>
 		<url-pattern>/api/v3/auth/token</url-pattern>
+	</servlet-mapping>
+
+	<servlet>
+		<servlet-name>CanUserAccess</servlet-name>
+		<servlet-class>org.ecocean.api.CanUserAccess</servlet-class>
+	</servlet>
+
+	<servlet-mapping>
+		<servlet-name>CanUserAccess</servlet-name>
+		<url-pattern>/api/v3/can-user-access</url-pattern>
 	</servlet-mapping>
 
 	<servlet>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -111,6 +111,7 @@
 				# token-authenticated scoped search (Artifact D): token filter ONLY, no authc/roles chained.
 				# No Bearer => falls through to SearchApi (which self-401s if no session). Filter handles auth.
 				/api/v3/search/** = tokenAuthSearch
+				/api/v3/media/** = tokenAuthSearch
 
 
 				# ===== Appadmin =====
@@ -561,6 +562,15 @@
 	<servlet-mapping>
 		<servlet-name>CanUserAccess</servlet-name>
 		<url-pattern>/api/v3/can-user-access</url-pattern>
+	</servlet-mapping>
+
+	<servlet>
+		<servlet-name>MediaResolveApi</servlet-name>
+		<servlet-class>org.ecocean.api.MediaResolveApi</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>MediaResolveApi</servlet-name>
+		<url-pattern>/api/v3/media/resolve</url-pattern>
 	</servlet-mapping>
 
 	<servlet>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -99,6 +99,7 @@
 				/LightRest/** = authcBasicWildbook,roles[researcher]
 
 				# ===== v3 API Security =====
+				/api/v3/auth/token = authcBasicWildbook
 				/api/v3/bulk-import = authc
 				/api/v3/bulk-import/** = authc
 				/api/v3/bulk-export = authc
@@ -532,6 +533,16 @@
 	<servlet-mapping>
 		<servlet-name>MatchInspection</servlet-name>
 		<url-pattern>/api/v3/match-inspection/*</url-pattern>
+	</servlet-mapping>
+
+	<servlet>
+		<servlet-name>AuthToken</servlet-name>
+		<servlet-class>org.ecocean.api.AuthToken</servlet-class>
+	</servlet>
+
+	<servlet-mapping>
+		<servlet-name>AuthToken</servlet-name>
+		<url-pattern>/api/v3/auth/token</url-pattern>
 	</servlet-mapping>
 
 	<servlet>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -111,7 +111,7 @@
 				# token-authenticated scoped search (Artifact D): token filter ONLY, no authc/roles chained.
 				# No Bearer => falls through to SearchApi (which self-401s if no session). Filter handles auth.
 				/api/v3/search/** = tokenAuthSearch
-				/api/v3/media/** = tokenAuthSearch
+				/api/v3/media/resolve = tokenAuthSearch
 
 
 				# ===== Appadmin =====

--- a/src/test/java/org/ecocean/AnnotationAclSerializerTest.java
+++ b/src/test/java/org/ecocean/AnnotationAclSerializerTest.java
@@ -1,0 +1,61 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.StringWriter;
+import java.util.Arrays;
+import org.json.JSONObject;
+import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.Test;
+
+class AnnotationAclSerializerTest {
+
+    private JSONObject serialize(Annotation ann, Shepherd sh) throws Exception {
+        StringWriter sw = new StringWriter();
+        JsonGenerator jg = new JsonFactory().createGenerator(sw);
+        jg.writeStartObject();
+        ann.writeAclFields(jg, sh);
+        jg.writeEndObject();
+        jg.close();
+        return new JSONObject(sw.toString());
+    }
+
+    @Test void singleParent_usesItsAcl() throws Exception {
+        Annotation ann = spy(new Annotation());
+        Shepherd sh = mock(Shepherd.class);
+        Encounter parent = mock(Encounter.class);
+        when(parent.opensearchAclFields(sh)).thenReturn(new JSONObject(
+            "{\"publiclyReadable\":false,\"submitterUserId\":\"u1\",\"viewUsers\":[\"v1\"]}"));
+        doReturn(Arrays.asList(parent)).when(ann).parentEncounters(sh);
+
+        JSONObject out = serialize(ann, sh);
+        assertFalse(out.getBoolean("publiclyReadable"));
+        assertTrue(out.getJSONArray("submitterUserIds").toList().contains("u1"));
+        assertTrue(out.getJSONArray("viewUsers").toList().contains("v1"));
+    }
+
+    @Test void zeroParents_failsClosed() throws Exception {
+        Annotation ann = spy(new Annotation());
+        Shepherd sh = mock(Shepherd.class);
+        doReturn(java.util.Collections.emptyList()).when(ann).parentEncounters(sh);
+        JSONObject out = serialize(ann, sh);
+        assertFalse(out.getBoolean("publiclyReadable"), "no parent -> not public");
+        assertEquals(0, out.getJSONArray("submitterUserIds").length(), "no parent -> admin-only");
+        assertEquals(0, out.getJSONArray("viewUsers").length(), "no parent -> admin-only");
+    }
+
+    @Test void multipleParents_failsClosed() throws Exception {
+        Annotation ann = spy(new Annotation());
+        Shepherd sh = mock(Shepherd.class);
+        Encounter a = mock(Encounter.class);
+        Encounter b = mock(Encounter.class);
+        doReturn(Arrays.asList(a, b)).when(ann).parentEncounters(sh);
+        JSONObject out = serialize(ann, sh);
+        assertFalse(out.getBoolean("publiclyReadable"), ">1 parent -> not public");
+        assertEquals(0, out.getJSONArray("submitterUserIds").length(), ">1 parent -> admin-only");
+        assertEquals(0, out.getJSONArray("viewUsers").length(), ">1 parent -> admin-only");
+    }
+}

--- a/src/test/java/org/ecocean/ChildReindexTriggerTest.java
+++ b/src/test/java/org/ecocean/ChildReindexTriggerTest.java
@@ -1,0 +1,109 @@
+package org.ecocean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Model-level unit tests for the child-reindex membership hooks (Spec-A Task 7).
+ * Verifies that encounter<->individual membership changes enqueue a deep reindex of the
+ * affected encounter + old/new individuals via IndexingManager, and that skipAutoIndexing
+ * suppresses the enqueue (so bulk import / deserialization do not storm the queue).
+ *
+ * The ACL-propagation path inside Encounter.opensearchIndexPermissions() requires a live
+ * Shepherd + OpenSearch and is covered by the Task 9 integration test, not here.
+ */
+class ChildReindexTriggerTest {
+
+    // sets the private Encounter.individual field directly, so we can establish a
+    // pre-existing "old" individual without triggering the setIndividual() hook.
+    private static void setIndividualField(Encounter enc, MarkedIndividual indiv) throws Exception {
+        Field f = Encounter.class.getDeclaredField("individual");
+        f.setAccessible(true);
+        f.set(enc, indiv);
+    }
+
+    // setIndividual enqueues the encounter (covers new individual + annotations via deep index)
+    // AND the old individual it left.
+    @Test void setIndividual_enqueuesEncounterAndOldIndividual() throws Exception {
+        Encounter enc = spy(new Encounter());
+        enc.setSkipAutoIndexing(false);
+        MarkedIndividual oldInd = spy(new MarkedIndividual());
+        oldInd.setSkipAutoIndexing(false);
+        setIndividualField(enc, oldInd);
+        MarkedIndividual newInd = mock(MarkedIndividual.class);
+
+        IndexingManager im = mock(IndexingManager.class);
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            enc.setIndividual(newInd);
+        }
+        // enc (its new individual + annotations refresh via deep index)
+        verify(im).addIndexingQueueEntry(eq(enc), eq(false));
+        // old individual the encounter left
+        verify(im).addIndexingQueueEntry(eq(oldInd), eq(false));
+    }
+
+    // skipAutoIndexing on the encounter (and old individual) suppresses all enqueues.
+    @Test void setIndividual_skipAutoIndexing_noEnqueue() throws Exception {
+        Encounter enc = spy(new Encounter());
+        enc.setSkipAutoIndexing(true);
+        MarkedIndividual oldInd = spy(new MarkedIndividual());
+        oldInd.setSkipAutoIndexing(true); // both skip => assert NO enqueue at all
+        setIndividualField(enc, oldInd);
+        MarkedIndividual newInd = mock(MarkedIndividual.class);
+
+        IndexingManager im = mock(IndexingManager.class);
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            enc.setIndividual(newInd);
+        }
+        verify(im, never()).addIndexingQueueEntry(any(), anyBoolean());
+    }
+
+    // MarkedIndividual.removeEncounter enqueues the individual AND the departed encounter.
+    @Test void removeEncounter_enqueuesIndividualAndEncounter() throws Exception {
+        MarkedIndividual ind = spy(new MarkedIndividual());
+        ind.setSkipAutoIndexing(false);
+        Encounter enc = spy(new Encounter());
+        enc.setSkipAutoIndexing(false);
+        enc.setCatalogNumber("enc-1");
+        // addEncounterNoCommit avoids firing the addEncounter hook so we isolate removeEncounter.
+        ind.addEncounterNoCommit(enc);
+
+        IndexingManager im = mock(IndexingManager.class);
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            ind.removeEncounter(enc);
+        }
+        verify(im).addIndexingQueueEntry(eq(ind), eq(false));
+        verify(im).addIndexingQueueEntry(eq(enc), eq(false));
+    }
+
+    // MarkedIndividual.addEncounter enqueues the joining encounter.
+    @Test void addEncounter_enqueuesEncounter() throws Exception {
+        MarkedIndividual ind = spy(new MarkedIndividual());
+        ind.setSkipAutoIndexing(false);
+        Encounter enc = spy(new Encounter());
+        enc.setSkipAutoIndexing(false);
+        enc.setCatalogNumber("enc-2");
+
+        IndexingManager im = mock(IndexingManager.class);
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            ind.addEncounter(enc);
+        }
+        verify(im).addIndexingQueueEntry(eq(enc), eq(false));
+    }
+}

--- a/src/test/java/org/ecocean/ChildReindexTriggerTest.java
+++ b/src/test/java/org/ecocean/ChildReindexTriggerTest.java
@@ -26,6 +26,17 @@ import org.mockito.MockedStatic;
  */
 class ChildReindexTriggerTest {
 
+    // The triggers honor the global /tmp/skipAutoIndexing kill-switch (OpenSearch.skipAutoIndexing
+    // reads the host filesystem). Another test in the suite (EncounterExportImagesTest) creates
+    // that file and only removes it at JVM exit, so these tests MUST stub the static to false —
+    // otherwise they fail with "zero interactions" whenever they run after it (or on a dev
+    // machine with a leftover /tmp/skipAutoIndexing).
+    private static MockedStatic<OpenSearch> mockNoGlobalSkip() {
+        MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class);
+        os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+        return os;
+    }
+
     // sets the private Encounter.individual field directly, so we can establish a
     // pre-existing "old" individual without triggering the setIndividual() hook.
     private static void setIndividualField(Encounter enc, MarkedIndividual indiv) throws Exception {
@@ -45,7 +56,8 @@ class ChildReindexTriggerTest {
         MarkedIndividual newInd = mock(MarkedIndividual.class);
 
         IndexingManager im = mock(IndexingManager.class);
-        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockNoGlobalSkip()) {
             factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
             enc.setIndividual(newInd);
         }
@@ -65,7 +77,8 @@ class ChildReindexTriggerTest {
         MarkedIndividual newInd = mock(MarkedIndividual.class);
 
         IndexingManager im = mock(IndexingManager.class);
-        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockNoGlobalSkip()) { // global off: proves the ENTITY flag suppresses
             factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
             enc.setIndividual(newInd);
         }
@@ -83,7 +96,8 @@ class ChildReindexTriggerTest {
         ind.addEncounterNoCommit(enc);
 
         IndexingManager im = mock(IndexingManager.class);
-        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockNoGlobalSkip()) {
             factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
             ind.removeEncounter(enc);
         }
@@ -100,7 +114,8 @@ class ChildReindexTriggerTest {
         enc.setCatalogNumber("enc-2");
 
         IndexingManager im = mock(IndexingManager.class);
-        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockNoGlobalSkip()) {
             factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
             ind.addEncounter(enc);
         }

--- a/src/test/java/org/ecocean/EncounterAclFieldsTest.java
+++ b/src/test/java/org/ecocean/EncounterAclFieldsTest.java
@@ -1,0 +1,50 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import org.json.JSONObject;
+import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.Test;
+
+class EncounterAclFieldsTest {
+
+    @Test void privateEncounter_emitsSubmitterAndViewUsers() {
+        Encounter enc = spy(new Encounter());
+        Shepherd sh = mock(Shepherd.class);
+        User submitter = mock(User.class);
+        when(submitter.getId()).thenReturn("owner-uuid");
+        doReturn(false).when(enc).isPubliclyReadable();
+        doReturn(submitter).when(enc).getSubmitterUser(sh);
+        doReturn(Arrays.asList("collab-uuid")).when(enc).computeViewUsers(sh);
+
+        JSONObject acl = enc.opensearchAclFields(sh);
+        assertFalse(acl.getBoolean("publiclyReadable"), "private -> not public");
+        assertEquals("owner-uuid", acl.getString("submitterUserId"), "submitter uuid");
+        assertEquals(1, acl.getJSONArray("viewUsers").length(), "one viewUser");
+        assertEquals("collab-uuid", acl.getJSONArray("viewUsers").getString(0));
+    }
+
+    @Test void publicEncounter_isWorldReadable() {
+        Encounter enc = spy(new Encounter());
+        Shepherd sh = mock(Shepherd.class);
+        doReturn(true).when(enc).isPubliclyReadable();
+        JSONObject acl = enc.opensearchAclFields(sh);
+        assertTrue(acl.getBoolean("publiclyReadable"), "anonymous -> world readable");
+        assertFalse(acl.has("submitterUserId"), "no submitter on public");
+        assertEquals(0, acl.getJSONArray("viewUsers").length(), "no viewUsers on public");
+    }
+
+    @Test void invalidOwner_failsClosed() {
+        Encounter enc = spy(new Encounter());
+        Shepherd sh = mock(Shepherd.class);
+        doReturn(false).when(enc).isPubliclyReadable();
+        doReturn(null).when(enc).getSubmitterUser(sh);
+        doReturn(java.util.Collections.emptyList()).when(enc).computeViewUsers(sh);
+        JSONObject acl = enc.opensearchAclFields(sh);
+        assertFalse(acl.getBoolean("publiclyReadable"), "not public");
+        assertFalse(acl.has("submitterUserId"), "no resolvable submitter -> admin-only");
+        assertEquals(0, acl.getJSONArray("viewUsers").length(), "no viewUsers -> admin-only");
+    }
+}

--- a/src/test/java/org/ecocean/MarkedIndividualAclSerializerTest.java
+++ b/src/test/java/org/ecocean/MarkedIndividualAclSerializerTest.java
@@ -1,0 +1,51 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.StringWriter;
+import org.json.JSONObject;
+import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.Test;
+
+class MarkedIndividualAclSerializerTest {
+
+    private JSONObject serialize(MarkedIndividual mi, Shepherd sh) throws Exception {
+        StringWriter sw = new StringWriter();
+        JsonGenerator jg = new JsonFactory().createGenerator(sw);
+        jg.writeStartObject();
+        mi.writeAclFields(jg, sh);
+        jg.writeEndObject();
+        jg.close();
+        return new JSONObject(sw.toString());
+    }
+
+    @Test void unionOverMembers() throws Exception {
+        MarkedIndividual mi = spy(new MarkedIndividual());
+        Shepherd sh = mock(Shepherd.class);
+        Encounter e1 = mock(Encounter.class);
+        Encounter e2 = mock(Encounter.class);
+        when(e1.opensearchAclFields(sh)).thenReturn(new JSONObject(
+            "{\"publiclyReadable\":false,\"submitterUserId\":\"u1\",\"viewUsers\":[\"v1\"]}"));
+        when(e2.opensearchAclFields(sh)).thenReturn(new JSONObject(
+            "{\"publiclyReadable\":false,\"submitterUserId\":\"u2\",\"viewUsers\":[\"v2\"]}"));
+        // getEncounters() returns Vector<Encounter>, not List — stub with a Vector
+        doReturn(new java.util.Vector<Encounter>(java.util.Arrays.asList(e1, e2))).when(mi).getEncounters();
+
+        JSONObject out = serialize(mi, sh);
+        assertFalse(out.getBoolean("publiclyReadable"));
+        assertTrue(out.getJSONArray("submitterUserIds").toList().containsAll(java.util.Arrays.asList("u1","u2")));
+        assertTrue(out.getJSONArray("viewUsers").toList().containsAll(java.util.Arrays.asList("v1","v2")));
+    }
+
+    @Test void zeroEncounters_worldReadable() throws Exception {
+        MarkedIndividual mi = spy(new MarkedIndividual());
+        Shepherd sh = mock(Shepherd.class);
+        doReturn(new java.util.Vector<Encounter>()).when(mi).getEncounters();
+        JSONObject out = serialize(mi, sh);
+        assertTrue(out.getBoolean("publiclyReadable"),
+            "encounterless individual -> visible to anyone (matches canUserAccessMarkedIndividual)");
+    }
+}

--- a/src/test/java/org/ecocean/OpenSearchAclFilterIndexAwareTest.java
+++ b/src/test/java/org/ecocean/OpenSearchAclFilterIndexAwareTest.java
@@ -1,0 +1,38 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchAclFilterIndexAwareTest {
+
+    private JSONArray shoulds(JSONObject out) {
+        return out.getJSONObject("query").getJSONObject("bool")
+            .getJSONArray("filter").getJSONObject(0).getJSONObject("bool").getJSONArray("should");
+    }
+
+    @Test void encounterUsesSubmitterUserId() throws Exception {
+        JSONObject out = OpenSearch.applyAclFilter(
+            new JSONObject("{\"query\":{\"match_all\":{}}}"), "u1", "encounter");
+        assertEquals("u1", shoulds(out).getJSONObject(1).getJSONObject("term").getString("submitterUserId"));
+    }
+
+    @Test void individualUsesSubmitterUserIds() throws Exception {
+        JSONObject out = OpenSearch.applyAclFilter(
+            new JSONObject("{\"query\":{\"match_all\":{}}}"), "u1", "individual");
+        assertEquals("u1", shoulds(out).getJSONObject(1).getJSONObject("term").getString("submitterUserIds"));
+    }
+
+    @Test void annotationUsesSubmitterUserIds() throws Exception {
+        JSONObject out = OpenSearch.applyAclFilter(
+            new JSONObject("{\"query\":{\"match_all\":{}}}"), "u1", "annotation");
+        assertEquals("u1", shoulds(out).getJSONObject(1).getJSONObject("term").getString("submitterUserIds"));
+    }
+
+    @Test void rejectsNullUser() {
+        assertThrows(java.io.IOException.class,
+            () -> OpenSearch.applyAclFilter(new JSONObject("{\"query\":{\"match_all\":{}}}"), null, "encounter"));
+    }
+}

--- a/src/test/java/org/ecocean/OpenSearchAclFilterTest.java
+++ b/src/test/java/org/ecocean/OpenSearchAclFilterTest.java
@@ -1,0 +1,51 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchAclFilterTest {
+
+    @Test void wrapsInnerQueryWithAclFilter() throws Exception {
+        JSONObject original = new JSONObject("{\"query\":{\"match\":{\"name\":\"x\"}}}");
+        JSONObject out = OpenSearch.applyEncounterAclFilter(original, "user-uuid-1");
+
+        JSONObject bool = out.getJSONObject("query").getJSONObject("bool");
+        // original inner query preserved as a must clause
+        JSONArray must = bool.getJSONArray("must");
+        assertEquals(1, must.length(), "one must clause (the original query)");
+        assertTrue(must.getJSONObject(0).has("match"), "original match preserved");
+
+        // ACL is a filter clause: should[publiclyReadable, submitterUserId, viewUsers], msm=1
+        JSONArray filter = bool.getJSONArray("filter");
+        JSONObject aclBool = filter.getJSONObject(0).getJSONObject("bool");
+        assertEquals(1, aclBool.getInt("minimum_should_match"), "minimum_should_match=1");
+        JSONArray should = aclBool.getJSONArray("should");
+        assertEquals(3, should.length(), "three should clauses");
+        assertTrue(should.getJSONObject(0).getJSONObject("term").getBoolean("publiclyReadable"),
+            "publiclyReadable term");
+        assertEquals("user-uuid-1",
+            should.getJSONObject(1).getJSONObject("term").getString("submitterUserId"),
+            "submitterUserId term = uuid");
+        assertEquals("user-uuid-1",
+            should.getJSONObject(2).getJSONObject("term").getString("viewUsers"),
+            "viewUsers term = uuid");
+    }
+
+    @Test void filterOnlyWhenNoInnerQuery() throws Exception {
+        JSONObject original = new JSONObject("{}"); // no "query" field
+        JSONObject out = OpenSearch.applyEncounterAclFilter(original, "user-uuid-1");
+        JSONObject bool = out.getJSONObject("query").getJSONObject("bool");
+        assertFalse(bool.has("must"), "no must clause when there was no inner query");
+        assertTrue(bool.has("filter"), "ACL filter still applied (fail-closed scope)");
+    }
+
+    @Test void rejectsNullUser() {
+        JSONObject original = new JSONObject("{\"query\":{\"match_all\":{}}}");
+        assertThrows(java.io.IOException.class,
+            () -> OpenSearch.applyEncounterAclFilter(original, null),
+            "null/empty userId must throw (fail closed)");
+    }
+}

--- a/src/test/java/org/ecocean/OpenSearchQueryFieldsTest.java
+++ b/src/test/java/org/ecocean/OpenSearchQueryFieldsTest.java
@@ -96,4 +96,19 @@ class OpenSearchQueryFieldsTest {
         assertTrue(OpenSearch.queryReferencesOnlyAllowedFields(
             new JSONObject("{\"query\":{\"match_all\":{}}}"), ALLOW));
     }
+    @Test void termsLookupForm_isRejected() {
+        // terms lookup: field key "id" is allowlisted but the lookup object references hidden "path"
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(new JSONObject(
+            "{\"query\":{\"terms\":{\"id\":{\"index\":\"individual\",\"id\":\"x\",\"path\":\"cooccurrenceIndividualIds\"}}}}"),
+            ALLOW));
+    }
+    @Test void termsPlainArray_onAllowedField_isAllowed() {
+        assertTrue(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"terms\":{\"sex\":[\"f\",\"m\"]}}}"), ALLOW));
+    }
+    @Test void termsLookup_evenOnAllowedFieldName_isRejected() {
+        // any object-valued terms entry is the lookup form -> reject regardless of field name
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"terms\":{\"names\":{\"index\":\"x\",\"path\":\"y\"}}}}"), ALLOW));
+    }
 }

--- a/src/test/java/org/ecocean/OpenSearchQueryFieldsTest.java
+++ b/src/test/java/org/ecocean/OpenSearchQueryFieldsTest.java
@@ -64,4 +64,36 @@ class OpenSearchQueryFieldsTest {
         assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
             new JSONObject("{\"query\":{\"multi_match\":{\"query\":\"x\",\"fields\":[\"users\"]}}}"), ALLOW));
     }
+    @Test void postFilterIsRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"match_all\":{}},\"post_filter\":{\"range\":{\"numberEncounters\":{\"gte\":1}}}}"), ALLOW));
+    }
+    @Test void collapseIsRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"match_all\":{}},\"collapse\":{\"field\":\"users\"}}"), ALLOW));
+    }
+    @Test void rescoreIsRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"match_all\":{}},\"rescore\":{}}"), ALLOW));
+    }
+    @Test void aggsTopLevelRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"match_all\":{}},\"aggs\":{\"a\":{\"max\":{\"field\":\"numberEncounters\"}}}}"), ALLOW));
+    }
+    @Test void sortInBodyRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"match_all\":{}},\"sort\":[{\"numberEncounters\":\"asc\"}]}"), ALLOW));
+    }
+    @Test void nestedIsRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"nested\":{\"path\":\"socialUnits\",\"query\":{\"match_all\":{}}}}}"), ALLOW));
+    }
+    @Test void fromSizeAreAllowed() {
+        assertTrue(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"term\":{\"sex\":\"f\"}},\"from\":0,\"size\":10}"), ALLOW));
+    }
+    @Test void matchAllAlone_stillAllowed() {
+        assertTrue(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"match_all\":{}}}"), ALLOW));
+    }
 }

--- a/src/test/java/org/ecocean/OpenSearchQueryFieldsTest.java
+++ b/src/test/java/org/ecocean/OpenSearchQueryFieldsTest.java
@@ -1,0 +1,55 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchQueryFieldsTest {
+    private static final Set<String> ALLOW = new HashSet<>(Arrays.asList(
+        "id","version","indexTimestamp","displayName","names","nameMap","sex","taxonomy",
+        "timeOfBirth","timeOfDeath"));
+
+    @Test void matchAll_isAllowed() {
+        assertTrue(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"match_all\":{}}}"), ALLOW));
+    }
+    @Test void termOnAllowedField_isAllowed() {
+        assertTrue(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"term\":{\"sex\":\"female\"}}}"), ALLOW));
+    }
+    @Test void boolMatchOnNames_isAllowed() {
+        assertTrue(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"bool\":{\"must\":[{\"match\":{\"names\":\"Fluke\"}}]}}}"), ALLOW));
+    }
+    @Test void rangeOnNumberEncounters_isRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"range\":{\"numberEncounters\":{\"gte\":100}}}}"), ALLOW));
+    }
+    @Test void termOnUsers_isRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"term\":{\"users\":\"bob\"}}}"), ALLOW));
+    }
+    @Test void existsOnEncounterIds_isRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"exists\":{\"field\":\"encounterIds\"}}}"), ALLOW));
+    }
+    @Test void sortOnLocationGeoPoints_isRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"match_all\":{}},\"sort\":[{\"locationGeoPoints\":\"asc\"}]}"), ALLOW));
+    }
+    @Test void aggsAreRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"match_all\":{}},\"aggs\":{\"x\":{\"terms\":{\"field\":\"numberEncounters\"}}}}"), ALLOW));
+    }
+    @Test void nestedBoolWithDisallowed_isRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"bool\":{\"should\":[{\"term\":{\"sex\":\"f\"}},{\"range\":{\"numberEncounters\":{\"gt\":1}}}]}}}"), ALLOW));
+    }
+    @Test void scriptIsRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"script\":{\"script\":\"doc['numberEncounters'].value\"}}}"), ALLOW));
+    }
+}

--- a/src/test/java/org/ecocean/OpenSearchQueryFieldsTest.java
+++ b/src/test/java/org/ecocean/OpenSearchQueryFieldsTest.java
@@ -52,4 +52,16 @@ class OpenSearchQueryFieldsTest {
         assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
             new JSONObject("{\"query\":{\"script\":{\"script\":\"doc['numberEncounters'].value\"}}}"), ALLOW));
     }
+    @Test void queryStringIsRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"query_string\":{\"query\":\"numberEncounters:>100\"}}}"), ALLOW));
+    }
+    @Test void simpleQueryStringIsRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"simple_query_string\":{\"query\":\"users:bob\"}}}"), ALLOW));
+    }
+    @Test void multiMatchIsRejected() {
+        assertFalse(OpenSearch.queryReferencesOnlyAllowedFields(
+            new JSONObject("{\"query\":{\"multi_match\":{\"query\":\"x\",\"fields\":[\"users\"]}}}"), ALLOW));
+    }
 }

--- a/src/test/java/org/ecocean/OpenSearchSanitizeDocTest.java
+++ b/src/test/java/org/ecocean/OpenSearchSanitizeDocTest.java
@@ -1,0 +1,81 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.json.JSONObject;
+import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchSanitizeDocTest {
+
+    private User user(boolean admin) {
+        User u = mock(User.class);
+        when(u.getId()).thenReturn("u1");
+        return u;
+    }
+
+    @Test void annotation_stripsAclFields_keepsContent() throws Exception {
+        JSONObject doc = new JSONObject("{\"id\":\"a1\",\"viewpoint\":\"left\",\"embeddings\":[{}],"
+            + "\"publiclyReadable\":true,\"submitterUserIds\":[\"x\"],\"viewUsers\":[\"y\"]}");
+        Shepherd sh = mock(Shepherd.class);
+        JSONObject out = OpenSearch.sanitizeDoc(doc, "annotation", sh, user(false), true);
+        assertEquals("left", out.getString("viewpoint"), "content kept");
+        assertTrue(out.has("embeddings"), "embeddings kept (not precious)");
+        assertFalse(out.has("viewUsers"), "ACL fields scrubbed");
+        assertFalse(out.has("submitterUserIds"), "ACL fields scrubbed");
+        assertFalse(out.has("publiclyReadable"), "ACL fields scrubbed");
+    }
+
+    @Test void individualToken_allowlistOnly() throws Exception {
+        JSONObject doc = new JSONObject("{\"id\":\"i1\",\"displayName\":\"Fluke\",\"sex\":\"female\","
+            + "\"taxonomy\":\"x\",\"numberEncounters\":42,\"users\":[\"owner\"],"
+            + "\"encounterIds\":[\"e1\"],\"locationGeoPoints\":[{}],\"viewUsers\":[\"y\"]}");
+        Shepherd sh = mock(Shepherd.class);
+        User u = user(false);
+        when(u.isAdmin(sh)).thenReturn(false);
+        JSONObject out = OpenSearch.sanitizeDoc(doc, "individual", sh, u, true);
+        assertEquals("Fluke", out.getString("displayName"), "identity kept");
+        assertEquals("female", out.getString("sex"), "identity kept");
+        assertFalse(out.has("numberEncounters"), "aggregate dropped");
+        assertFalse(out.has("users"), "aggregate dropped (would leak hidden submitters)");
+        assertFalse(out.has("encounterIds"), "aggregate dropped");
+        assertFalse(out.has("locationGeoPoints"), "aggregate dropped");
+        assertFalse(out.has("viewUsers"), "ACL field scrubbed");
+    }
+
+    @Test void individualAdminToken_fullDocMinusAcl() throws Exception {
+        JSONObject doc = new JSONObject("{\"id\":\"i1\",\"numberEncounters\":42,\"viewUsers\":[\"y\"]}");
+        Shepherd sh = mock(Shepherd.class);
+        User u = user(true);
+        when(u.isAdmin(sh)).thenReturn(true);
+        JSONObject out = OpenSearch.sanitizeDoc(doc, "individual", sh, u, true);
+        assertEquals(42, out.getInt("numberEncounters"), "admin keeps aggregates");
+        assertFalse(out.has("viewUsers"), "ACL still scrubbed even for admin");
+    }
+
+    // Allowlist completeness: a doc with EVERY field the individual serializer emits must, for a
+    // non-admin token, retain ONLY the keep-list and drop everything else.
+    @Test void individualToken_allowlistDropsAllSerializerAggregates() throws Exception {
+        JSONObject doc = new JSONObject("{"
+            + "\"id\":\"i1\",\"version\":1,\"indexTimestamp\":1,\"displayName\":\"F\",\"names\":[\"F\"],"
+            + "\"nameMap\":{},\"sex\":\"female\",\"taxonomy\":\"t\",\"timeOfBirth\":\"x\",\"timeOfDeath\":\"y\","
+            + "\"numberEncounters\":5,\"encounterIds\":[\"e\"],\"users\":[\"u\"],\"numberOccurrences\":2,"
+            + "\"cooccurrenceIndividualIds\":[\"c\"],\"cooccurrenceIndividualMap\":{},\"locationGeoPoints\":[{}],"
+            + "\"numberMediaAssets\":3,\"socialUnits\":[{}],\"relationships\":[{}],"
+            + "\"publiclyReadable\":false,\"submitterUserIds\":[\"s\"],\"viewUsers\":[\"v\"]}");
+        Shepherd sh = mock(Shepherd.class);
+        User u = user(false);
+        when(u.isAdmin(sh)).thenReturn(false);
+        JSONObject out = OpenSearch.sanitizeDoc(doc, "individual", sh, u, true);
+        java.util.Set<String> keep = new java.util.HashSet<>(java.util.Arrays.asList(
+            "id","version","indexTimestamp","displayName","names","nameMap","sex","taxonomy",
+            "timeOfBirth","timeOfDeath"));
+        for (String k : out.keySet()) assertTrue(keep.contains(k), "leaked non-allowlisted field: " + k);
+        for (String dropped : new String[]{"numberEncounters","encounterIds","users","numberOccurrences",
+            "cooccurrenceIndividualIds","cooccurrenceIndividualMap","locationGeoPoints","numberMediaAssets",
+            "socialUnits","relationships","publiclyReadable","submitterUserIds","viewUsers"}) {
+            assertFalse(out.has(dropped), "must drop " + dropped);
+        }
+    }
+}

--- a/src/test/java/org/ecocean/api/AuthTokenTest.java
+++ b/src/test/java/org/ecocean/api/AuthTokenTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -63,6 +64,46 @@ class AuthTokenTest {
             JSONObject json = new JSONObject(body);
             assertFalse(json.optBoolean("success", true), "success must be false");
             assertEquals("unauthenticated", json.optString("error"), "error message");
+        }
+    }
+
+    /**
+     * SECURITY regression: the Shepherd must always be constructed with "context0",
+     * regardless of ?context= or any other request parameter.
+     * A caller supplying context=evilcontext must not shift user lookup or key config
+     * to another context. We capture the first constructor arg via MockedConstruction
+     * and assert it equals "context0".
+     * The request is also unauthenticated (getUser→null) so we get a 401, confirming
+     * the servlet completed the pinned construction path before returning.
+     */
+    @Test
+    void requestContextParamIgnored() throws Exception {
+        // Make the request look like it carries a context override
+        when(mockRequest.getParameter("context")).thenReturn("evilcontext");
+
+        AtomicReference<String> capturedCtorArg = new AtomicReference<>();
+
+        try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    // ctx.arguments() holds the constructor args; first arg is the context String
+                    if (!ctx.arguments().isEmpty()) {
+                        capturedCtorArg.set(String.valueOf(ctx.arguments().get(0)));
+                    }
+                    doNothing().when(mock).beginDBTransaction();
+                    doNothing().when(mock).setAction(anyString());
+                    doNothing().when(mock).rollbackAndClose();
+                    // unauthenticated → servlet returns 401 without attempting to sign
+                    when(mock.getUser(any(HttpServletRequest.class))).thenReturn(null);
+                })) {
+            AuthToken servlet = new AuthToken();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            // Shepherd must have been constructed with the pinned context, not "evilcontext"
+            assertEquals("context0", capturedCtorArg.get(),
+                "Shepherd must be constructed with pinned context0, not a request-derived value");
+            // Unauthenticated → 401 (confirms the code path ran fully through construction)
+            verify(mockResponse).setStatus(401);
         }
     }
 

--- a/src/test/java/org/ecocean/api/AuthTokenTest.java
+++ b/src/test/java/org/ecocean/api/AuthTokenTest.java
@@ -1,0 +1,102 @@
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.User;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+class AuthTokenTest {
+
+    HttpServletRequest mockRequest;
+    HttpServletResponse mockResponse;
+    StringWriter responseOut;
+    PrintWriter writer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockRequest = mock(HttpServletRequest.class);
+        mockResponse = mock(HttpServletResponse.class);
+        responseOut = new StringWriter();
+        writer = new PrintWriter(responseOut);
+        when(mockResponse.getWriter()).thenReturn(writer);
+        // getContext(request) reads servletContext; return "context0" for tests
+        when(mockRequest.getServletContext()).thenReturn(null);
+        when(mockRequest.getContextPath()).thenReturn("");
+    }
+
+    /**
+     * Primary protection gate: unauthenticated caller (getUser returns null) → 401.
+     * This is the most important unit-testable gate: the endpoint must reject requests
+     * where Shiro passed but no User principal was resolved.
+     */
+    @Test
+    void unauthenticated_returns401() throws Exception {
+        try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    doNothing().when(mock).beginDBTransaction();
+                    doNothing().when(mock).setAction(anyString());
+                    doNothing().when(mock).rollbackAndClose();
+                    when(mock.getUser(any(HttpServletRequest.class))).thenReturn(null);
+                })) {
+            AuthToken servlet = new AuthToken();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            verify(mockResponse).setStatus(401);
+            String body = responseOut.toString();
+            assertFalse(body.isEmpty(), "response body must not be empty");
+            JSONObject json = new JSONObject(body);
+            assertFalse(json.optBoolean("success", true), "success must be false");
+            assertEquals("unauthenticated", json.optString("error"), "error message");
+        }
+    }
+
+    /**
+     * JwtService disabled (no private key configured) → 503.
+     * Exercises the second gate after successful auth.
+     */
+    @Test
+    void jwtDisabled_returns503() throws Exception {
+        User fakeUser = new User();
+        fakeUser.setUsername("test-user");
+
+        try (MockedStatic<org.ecocean.CommonConfiguration> mockConfig =
+                mockStatic(org.ecocean.CommonConfiguration.class);
+             MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                 (mock, ctx) -> {
+                     doNothing().when(mock).beginDBTransaction();
+                     doNothing().when(mock).setAction(anyString());
+                     doNothing().when(mock).rollbackAndClose();
+                     when(mock.getUser(any(HttpServletRequest.class))).thenReturn(fakeUser);
+                 })) {
+            // All CommonConfiguration.getProperty calls return null → JwtService disabled
+            mockConfig.when(() -> org.ecocean.CommonConfiguration.getProperty(
+                anyString(), anyString())).thenReturn(null);
+
+            AuthToken servlet = new AuthToken();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            verify(mockResponse).setStatus(503);
+            String body = responseOut.toString();
+            JSONObject json = new JSONObject(body);
+            assertFalse(json.optBoolean("success", true), "success must be false");
+            assertEquals("token issuance not configured", json.optString("error"));
+        }
+    }
+}

--- a/src/test/java/org/ecocean/api/CanUserAccessTest.java
+++ b/src/test/java/org/ecocean/api/CanUserAccessTest.java
@@ -5,12 +5,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -30,6 +32,17 @@ class CanUserAccessTest {
     HttpServletResponse mockResponse;
     StringWriter responseOut;
     PrintWriter writer;
+
+    /** Wraps a byte array as a ServletInputStream for mocking getInputStream(). */
+    private static ServletInputStream servletInputStreamOf(byte[] bytes) {
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        return new ServletInputStream() {
+            @Override public int read() throws IOException { return bais.read(); }
+            @Override public boolean isFinished() { return bais.available() == 0; }
+            @Override public boolean isReady() { return true; }
+            @Override public void setReadListener(ReadListener rl) {}
+        };
+    }
 
     @BeforeEach
     void setUp() throws IOException {
@@ -96,8 +109,8 @@ class CanUserAccessTest {
         reqBody.put("userUuid", targetUuid);
         reqBody.put("encounterIds", new JSONArray().put(enc1Id).put(enc2Id));
 
-        when(mockRequest.getReader()).thenReturn(
-            new BufferedReader(new StringReader(reqBody.toString())));
+        when(mockRequest.getInputStream()).thenReturn(
+            servletInputStreamOf(reqBody.toString().getBytes(StandardCharsets.UTF_8)));
 
         try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
                 (mock, ctx) -> {
@@ -138,8 +151,8 @@ class CanUserAccessTest {
         reqBody.put("userUuid", unknownUuid);
         reqBody.put("encounterIds", new JSONArray().put("enc-aaa").put("enc-bbb"));
 
-        when(mockRequest.getReader()).thenReturn(
-            new BufferedReader(new StringReader(reqBody.toString())));
+        when(mockRequest.getInputStream()).thenReturn(
+            servletInputStreamOf(reqBody.toString().getBytes(StandardCharsets.UTF_8)));
 
         try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
                 (mock, ctx) -> {

--- a/src/test/java/org/ecocean/api/CanUserAccessTest.java
+++ b/src/test/java/org/ecocean/api/CanUserAccessTest.java
@@ -1,0 +1,164 @@
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.Encounter;
+import org.ecocean.User;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+class CanUserAccessTest {
+
+    HttpServletRequest mockRequest;
+    HttpServletResponse mockResponse;
+    StringWriter responseOut;
+    PrintWriter writer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockRequest = mock(HttpServletRequest.class);
+        mockResponse = mock(HttpServletResponse.class);
+        responseOut = new StringWriter();
+        writer = new PrintWriter(responseOut);
+        when(mockResponse.getWriter()).thenReturn(writer);
+        // getContext(request) reads servletContext + contextPath
+        when(mockRequest.getServletContext()).thenReturn(null);
+        when(mockRequest.getContextPath()).thenReturn("");
+        // default: reasonable content-type and size for tests that reach parsing
+        when(mockRequest.getContentType()).thenReturn("application/json");
+        when(mockRequest.getContentLengthLong()).thenReturn(100L);
+    }
+
+    /**
+     * (a) Non-admin caller → 403.
+     * The PRIMARY admin gate must reject any authenticated user who is not admin.
+     */
+    @Test
+    void nonAdminCaller_returns403() throws Exception {
+        User callerUser = mock(User.class);
+
+        try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    doNothing().when(mock).beginDBTransaction();
+                    doNothing().when(mock).setAction(anyString());
+                    doNothing().when(mock).rollbackAndClose();
+                    when(mock.getUser(any(HttpServletRequest.class))).thenReturn(callerUser);
+                    when(callerUser.isAdmin(mock)).thenReturn(false);
+                })) {
+            CanUserAccess servlet = new CanUserAccess();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            verify(mockResponse).setStatus(403);
+            String body = responseOut.toString();
+            assertFalse(body.isEmpty(), "response body must not be empty");
+            JSONObject json = new JSONObject(body);
+            assertFalse(json.optBoolean("success", true), "success must be false");
+            assertEquals("admin required", json.optString("error"), "error message");
+        }
+    }
+
+    /**
+     * (b) Admin caller, target user, two encounters:
+     *   - enc1: canUserView → true  → must appear in accessible
+     *   - enc2: canUserView → false → must NOT appear
+     */
+    @Test
+    void adminCaller_filtersEncountersByCanUserView() throws Exception {
+        User callerUser = mock(User.class);
+        User targetUser = mock(User.class);
+
+        Encounter enc1 = mock(Encounter.class);
+        Encounter enc2 = mock(Encounter.class);
+
+        String enc1Id = "enc-visible-001";
+        String enc2Id = "enc-hidden-002";
+        String targetUuid = "target-uuid-abc";
+
+        JSONObject reqBody = new JSONObject();
+        reqBody.put("userUuid", targetUuid);
+        reqBody.put("encounterIds", new JSONArray().put(enc1Id).put(enc2Id));
+
+        when(mockRequest.getReader()).thenReturn(
+            new BufferedReader(new StringReader(reqBody.toString())));
+
+        try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    doNothing().when(mock).beginDBTransaction();
+                    doNothing().when(mock).setAction(anyString());
+                    doNothing().when(mock).rollbackAndClose();
+                    when(mock.getUser(any(HttpServletRequest.class))).thenReturn(callerUser);
+                    when(callerUser.isAdmin(mock)).thenReturn(true);
+                    when(mock.getUserByUUID(targetUuid)).thenReturn(targetUser);
+                    when(mock.getEncounter(enc1Id)).thenReturn(enc1);
+                    when(mock.getEncounter(enc2Id)).thenReturn(enc2);
+                    when(enc1.canUserView(targetUser, mock)).thenReturn(true);
+                    when(enc2.canUserView(targetUser, mock)).thenReturn(false);
+                })) {
+            CanUserAccess servlet = new CanUserAccess();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            verify(mockResponse).setStatus(200);
+            String body = responseOut.toString();
+            JSONObject json = new JSONObject(body);
+            JSONArray accessible = json.getJSONArray("accessible");
+            assertEquals(1, accessible.length(), "only one encounter should be accessible");
+            assertEquals(enc1Id, accessible.getString(0), "the visible encounter id");
+        }
+    }
+
+    /**
+     * (c) Admin caller, unknown target uuid (getUserByUUID → null) → empty accessible.
+     * Fail-closed: unknown users see nothing.
+     */
+    @Test
+    void unknownTargetUuid_returnsEmptyAccessible() throws Exception {
+        User callerUser = mock(User.class);
+
+        String unknownUuid = "no-such-user-uuid";
+        JSONObject reqBody = new JSONObject();
+        reqBody.put("userUuid", unknownUuid);
+        reqBody.put("encounterIds", new JSONArray().put("enc-aaa").put("enc-bbb"));
+
+        when(mockRequest.getReader()).thenReturn(
+            new BufferedReader(new StringReader(reqBody.toString())));
+
+        try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    doNothing().when(mock).beginDBTransaction();
+                    doNothing().when(mock).setAction(anyString());
+                    doNothing().when(mock).rollbackAndClose();
+                    when(mock.getUser(any(HttpServletRequest.class))).thenReturn(callerUser);
+                    when(callerUser.isAdmin(mock)).thenReturn(true);
+                    when(mock.getUserByUUID(unknownUuid)).thenReturn(null);
+                })) {
+            CanUserAccess servlet = new CanUserAccess();
+            servlet.doPost(mockRequest, mockResponse);
+
+            writer.flush();
+            verify(mockResponse).setStatus(200);
+            String body = responseOut.toString();
+            JSONObject json = new JSONObject(body);
+            JSONArray accessible = json.getJSONArray("accessible");
+            assertEquals(0, accessible.length(), "unknown user sees no encounters");
+        }
+    }
+}

--- a/src/test/java/org/ecocean/api/EncounterExportImagesTest.java
+++ b/src/test/java/org/ecocean/api/EncounterExportImagesTest.java
@@ -92,6 +92,7 @@ import static org.mockito.Mockito.when;
 
     private static String baseUrl;
     private static String authenticationCookie;
+    private static boolean createdSkipAutoIndexingFile = false;
 
     @BeforeAll static void setUp() {
         System.out.println("=== Starting EncounterExportImagesTest Setup ===");
@@ -146,17 +147,26 @@ import static org.mockito.Mockito.when;
 
         OpenSearch.initializeClient(new HttpHost(opensearch.getHost(),
             opensearch.getMappedPort(9200), "http"));
+        // The client now points at OUR fresh container; drop cluster-coupled static caches left by
+        // any earlier test class. A stale INDEX_EXISTS_CACHE makes ensureIndex skip real index
+        // creation, so docs would dynamic-map (text) and keyword/term queries silently mismatch.
+        OpenSearch.INDEX_EXISTS_CACHE.clear();
+        OpenSearch.PIT_CACHE.clear();
 
-        // disable auto indexing for the duration of the test, or leave it disabled if it is currently
+        // disable auto indexing for the duration of the test, or leave it disabled if it is currently.
+        // Removed in tearDown if WE created it: deleteOnExit only fires at JVM exit, which leaks the
+        // global kill-switch into every test class that runs after this one in the same JVM (e.g.
+        // ChildReindexTriggerTest's reindex triggers honor it and would see zero enqueues).
         try {
-            File file = new File("/tmp/skipAutoIndexing");
-            if (!file.exists()) {
-                file.createNewFile();
-                file.deleteOnExit();
-            }
+            // createNewFile() is atomic: true only if WE created it, so a file created by another
+            // process between an exists() check and the create can never be claimed (and deleted) by us.
+            createdSkipAutoIndexingFile = new File("/tmp/skipAutoIndexing").createNewFile();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+        // Evict any cached PMF for context0: it may be bound to ANOTHER test class's (now stopped)
+        // Postgres container. The first Shepherd below then creates a fresh PMF against OUR container.
+        org.ecocean.shepherd.core.TestPMFUtil.closePMF("context0");
         // Initialize test data via Shepherd
         // DataNucleus will auto-create tables on first access
         initializeTestData();
@@ -171,6 +181,14 @@ import static org.mockito.Mockito.when;
 
     @AfterAll static void tearDown() {
         System.out.println("\n=== Tearing Down Test Environment ===");
+        // only remove the kill-switch if WE created it (preserve a pre-existing operator file)
+        if (createdSkipAutoIndexingFile) {
+            new File("/tmp/skipAutoIndexing").delete();
+        }
+        // our containers stop with this class; don't leave dead PMF / cluster caches for later classes
+        org.ecocean.shepherd.core.TestPMFUtil.closePMF("context0");
+        OpenSearch.INDEX_EXISTS_CACHE.clear();
+        OpenSearch.PIT_CACHE.clear();
         System.out.println("PostgreSQL container will be stopped automatically");
         System.out.println("OpenSearch container will be stopped automatically");
         System.out.println("=== Teardown Complete ===");

--- a/src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
+++ b/src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
@@ -203,4 +203,37 @@ class EndpointAuthWiringTest {
             "search path must map to tokenAuthSearch ONLY (no authc/roles chained); was: '"
                 + value + "'");
     }
+
+    // -----------------------------------------------------------------------
+    // Assertion 7, 8, 9 — /api/v3/media/resolve wiring
+    // -----------------------------------------------------------------------
+
+    @Test
+    void mediaResolve_servletClassIsRegistered() {
+        assertTrue(fullText().contains("<servlet-class>org.ecocean.api.MediaResolveApi</servlet-class>"),
+                "web.xml must register the MediaResolveApi servlet");
+    }
+
+    @Test
+    void mediaResolve_urlPatternIsRegistered() {
+        assertTrue(fullText().contains("<url-pattern>/api/v3/media/resolve</url-pattern>"),
+                "web.xml must map /api/v3/media/resolve");
+    }
+
+    @Test
+    void mediaResolve_shiroRuleIsTokenFilterOnly() {
+        // Mirror searchPath_wiredToTokenFilterOnly: exact value equality, not a loose contains().
+        String ruleLine = lines.stream()
+                .filter(l -> {
+                    String t = l.stripLeading();
+                    return !t.startsWith("#") && t.contains("/api/v3/media/**");
+                })
+                .findFirst().orElse(null);
+        assertNotNull(ruleLine, "Shiro [urls] must contain a rule for /api/v3/media/**");
+        String value = ruleLine.substring(
+                ruleLine.indexOf("/api/v3/media/**") + "/api/v3/media/**".length()).trim();
+        if (value.startsWith("=")) value = value.substring(1).trim();
+        assertEquals("tokenAuthSearch", value,
+                "media path must map to tokenAuthSearch ONLY (no authc/roles chained); was: '" + value + "'");
+    }
 }

--- a/src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
+++ b/src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
@@ -1,0 +1,176 @@
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Asserts that the AuthToken and CanUserAccess endpoints are both registered in
+ * web.xml AND gated by the appropriate Shiro rules.  No DB, no containers.
+ *
+ * <p>Maven runs tests with CWD = module root, so relative File paths resolve
+ * against the project root.
+ */
+class EndpointAuthWiringTest {
+
+    private static List<String> lines;
+
+    @BeforeAll
+    static void loadWebXml() throws Exception {
+        File webXml = new File("src/main/webapp/WEB-INF/web.xml");
+        assertTrue(webXml.exists(),
+                "web.xml not found at expected path: " + webXml.getAbsolutePath());
+        lines = Files.readAllLines(webXml.toPath());
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static String fullText() {
+        return String.join("\n", lines);
+    }
+
+    /** Returns the 0-based index of the first line that contains {@code needle}, or -1. */
+    private static int lineIndexOf(String needle) {
+        for (int i = 0; i < lines.size(); i++) {
+            if (lines.get(i).contains(needle)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    // -----------------------------------------------------------------------
+    // Assertion 1 & 2 — servlet registrations present
+    // -----------------------------------------------------------------------
+
+    @Test
+    void authToken_servletClassIsRegistered() {
+        assertTrue(fullText().contains("<servlet-class>org.ecocean.api.AuthToken</servlet-class>"),
+                "web.xml must contain a <servlet-class> declaration for org.ecocean.api.AuthToken");
+    }
+
+    @Test
+    void authToken_urlPatternIsRegistered() {
+        assertTrue(fullText().contains("<url-pattern>/api/v3/auth/token</url-pattern>"),
+                "web.xml must contain a <url-pattern> mapping for /api/v3/auth/token");
+    }
+
+    @Test
+    void canUserAccess_servletClassIsRegistered() {
+        assertTrue(fullText().contains("<servlet-class>org.ecocean.api.CanUserAccess</servlet-class>"),
+                "web.xml must contain a <servlet-class> declaration for org.ecocean.api.CanUserAccess");
+    }
+
+    @Test
+    void canUserAccess_urlPatternIsRegistered() {
+        assertTrue(fullText().contains("<url-pattern>/api/v3/can-user-access</url-pattern>"),
+                "web.xml must contain a <url-pattern> mapping for /api/v3/can-user-access");
+    }
+
+    // -----------------------------------------------------------------------
+    // Assertion 3 — /api/v3/auth/token is auth-gated (not anon)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void authToken_shiroRuleIsAuthGated() {
+        // Find the Shiro [urls] rule line for the token endpoint (non-comment)
+        String ruleLine = lines.stream()
+                .filter(l -> {
+                    String t = l.stripLeading();
+                    return !t.startsWith("#") && t.contains("/api/v3/auth/token");
+                })
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(ruleLine,
+                "Shiro [urls] must contain a rule line for /api/v3/auth/token");
+
+        // The rule value must not be just "anon"
+        String value = ruleLine.substring(ruleLine.indexOf("/api/v3/auth/token")
+                + "/api/v3/auth/token".length()).trim();
+        if (value.startsWith("=")) {
+            value = value.substring(1).trim();
+        }
+        assertFalse("anon".equalsIgnoreCase(value.trim()),
+                "Shiro rule for /api/v3/auth/token must not be 'anon' (was: '" + value + "')");
+
+        assertTrue(ruleLine.contains("authc"),
+                "Shiro rule for /api/v3/auth/token must contain 'authc' (was: '" + ruleLine.strip() + "')");
+    }
+
+    // -----------------------------------------------------------------------
+    // Assertion 4 — /api/v3/can-user-access requires roles[admin]
+    // -----------------------------------------------------------------------
+
+    @Test
+    void canUserAccess_shiroRuleRequiresAdminRole() {
+        String ruleLine = lines.stream()
+                .filter(l -> {
+                    String t = l.stripLeading();
+                    return !t.startsWith("#") && t.contains("/api/v3/can-user-access");
+                })
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(ruleLine,
+                "Shiro [urls] must contain a rule line for /api/v3/can-user-access");
+
+        assertTrue(ruleLine.contains("roles[admin]"),
+                "Shiro rule for /api/v3/can-user-access must contain 'roles[admin]' (was: '"
+                        + ruleLine.strip() + "')");
+    }
+
+    // -----------------------------------------------------------------------
+    // Assertion 5 — ordering guard: both new rules appear before /** catch-all
+    // -----------------------------------------------------------------------
+
+    @Test
+    void shiroRules_newEndpointsBeforeCatchAll() {
+        // Find the catch-all line, if any (/** = ..., not commented out)
+        int catchAllIdx = -1;
+        for (int i = 0; i < lines.size(); i++) {
+            String t = lines.get(i).stripLeading();
+            if (!t.startsWith("#") && t.startsWith("/**")) {
+                catchAllIdx = i;
+                break;
+            }
+        }
+
+        if (catchAllIdx == -1) {
+            // No catch-all — nothing to check
+            return;
+        }
+
+        int tokenRuleIdx = -1;
+        int canAccessRuleIdx = -1;
+        for (int i = 0; i < lines.size(); i++) {
+            String t = lines.get(i).stripLeading();
+            if (t.startsWith("#")) continue;
+            if (t.contains("/api/v3/auth/token") && tokenRuleIdx == -1) {
+                tokenRuleIdx = i;
+            }
+            if (t.contains("/api/v3/can-user-access") && canAccessRuleIdx == -1) {
+                canAccessRuleIdx = i;
+            }
+        }
+
+        assertNotEquals(-1, tokenRuleIdx,
+                "Shiro [urls] must have a rule for /api/v3/auth/token before the /** catch-all");
+        assertTrue(tokenRuleIdx < catchAllIdx,
+                "Shiro rule for /api/v3/auth/token (line " + (tokenRuleIdx + 1)
+                        + ") must appear before the /** catch-all (line " + (catchAllIdx + 1) + ")");
+
+        assertNotEquals(-1, canAccessRuleIdx,
+                "Shiro [urls] must have a rule for /api/v3/can-user-access before the /** catch-all");
+        assertTrue(canAccessRuleIdx < catchAllIdx,
+                "Shiro rule for /api/v3/can-user-access (line " + (canAccessRuleIdx + 1)
+                        + ") must appear before the /** catch-all (line " + (catchAllIdx + 1) + ")");
+    }
+}

--- a/src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
+++ b/src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
@@ -173,4 +173,34 @@ class EndpointAuthWiringTest {
                 "Shiro rule for /api/v3/can-user-access (line " + (canAccessRuleIdx + 1)
                         + ") must appear before the /** catch-all (line " + (catchAllIdx + 1) + ")");
     }
+
+    // -----------------------------------------------------------------------
+    // Assertion 6 — /api/v3/search/** wired to tokenAuthSearch ONLY
+    // -----------------------------------------------------------------------
+
+    @Test
+    void searchPath_wiredToTokenFilterOnly() {
+        // token filter declared in [main]
+        assertTrue(fullText().contains(
+            "tokenAuthSearch = org.ecocean.security.WildbookTokenAuthenticationFilter"),
+            "web.xml [main] must declare tokenAuthSearch = WildbookTokenAuthenticationFilter");
+
+        // search path mapped to the token filter (find the non-comment rule line)
+        String ruleLine = lines.stream()
+            .filter(l -> {
+                String t = l.stripLeading();
+                return !t.startsWith("#") && t.contains("/api/v3/search/**");
+            })
+            .findFirst()
+            .orElse(null);
+        assertNotNull(ruleLine,
+            "Shiro [urls] must contain a rule for /api/v3/search/**");
+
+        String value = ruleLine.substring(
+            ruleLine.indexOf("/api/v3/search/**") + "/api/v3/search/**".length()).trim();
+        if (value.startsWith("=")) value = value.substring(1).trim();
+        assertEquals("tokenAuthSearch", value,
+            "search path must map to tokenAuthSearch ONLY (no authc/roles chained); was: '"
+                + value + "'");
+    }
 }

--- a/src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
+++ b/src/test/java/org/ecocean/api/EndpointAuthWiringTest.java
@@ -222,16 +222,15 @@ class EndpointAuthWiringTest {
 
     @Test
     void mediaResolve_shiroRuleIsTokenFilterOnly() {
-        // Mirror searchPath_wiredToTokenFilterOnly: exact value equality, not a loose contains().
         String ruleLine = lines.stream()
                 .filter(l -> {
                     String t = l.stripLeading();
-                    return !t.startsWith("#") && t.contains("/api/v3/media/**");
+                    return !t.startsWith("#") && t.contains("/api/v3/media/resolve") && t.contains("tokenAuthSearch");
                 })
                 .findFirst().orElse(null);
-        assertNotNull(ruleLine, "Shiro [urls] must contain a rule for /api/v3/media/**");
+        assertNotNull(ruleLine, "Shiro [urls] must contain a rule for /api/v3/media/resolve");
         String value = ruleLine.substring(
-                ruleLine.indexOf("/api/v3/media/**") + "/api/v3/media/**".length()).trim();
+                ruleLine.indexOf("/api/v3/media/resolve") + "/api/v3/media/resolve".length()).trim();
         if (value.startsWith("=")) value = value.substring(1).trim();
         assertEquals("tokenAuthSearch", value,
                 "media path must map to tokenAuthSearch ONLY (no authc/roles chained); was: '" + value + "'");

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -567,6 +567,7 @@ class MediaResolveApiTest {
         when(resp.getWriter()).thenReturn(new PrintWriter(out));
 
         final int[] capturedSize = {-1};
+        final org.json.JSONObject[] capturedQuery = {null};
         try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
              MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
                  doNothing().when(m).beginDBTransaction();
@@ -581,7 +582,7 @@ class MediaResolveApiTest {
                  (m, c) -> {
                      doNothing().when(m).deletePit(anyString());
                      when(m.queryPit(eq("annotation"), any(), eq(0), anyInt(), any(), any()))
-                         .thenAnswer(inv -> { capturedSize[0] = inv.getArgument(3); return hitsFor(all); });
+                         .thenAnswer(inv -> { capturedSize[0] = inv.getArgument(3); capturedQuery[0] = inv.getArgument(1); return hitsFor(all); });
                  })) {
             su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
               .thenReturn(new JSONObject().put("annotationIds", req));
@@ -589,6 +590,59 @@ class MediaResolveApiTest {
         }
         verify(resp).setStatus(200);
         assertEquals(12, capturedSize[0], "gate query size must equal the de-duplicated id count, not the default 10");
+        assertNotNull(capturedQuery[0], "queryPit must have been called with a query");
+        String q = capturedQuery[0].toString();
+        assertTrue(q.contains("ann-0"), "gate query must include the requested ids; was: " + q);
+        assertTrue(q.contains("publiclyReadable") && q.contains("submitterUserIds") && q.contains("viewUsers"),
+            "gate query must include the Spec A annotation ACL filter; was: " + q);
+    }
+
+    @Test void resolve_webUrlThrows_omitsEntryNot500() throws Exception {
+        // A visible annotation whose derivative webURL() throws (corrupt LocalAssetStore params)
+        // must be omitted (fail-closed), not turn the whole batch into a 500.
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.getWidth()).thenReturn(1000.0);
+        when(src.getHeight()).thenReturn(1000.0);
+        MediaAsset master = mock(MediaAsset.class);
+        when(master.getStore()).thenReturn(mock(LocalAssetStore.class));
+        ArrayList<String> labels = new ArrayList<>(); labels.add("_master");
+        when(master.getLabels()).thenReturn(labels);
+        when(master.hasLabel("_master")).thenReturn(true);
+        when(master.hasLabel("_original")).thenReturn(false);
+        when(master.getWidth()).thenReturn(500.0);
+        when(master.getHeight()).thenReturn(500.0);
+        when(master.webURL()).thenThrow(new IllegalArgumentException("corrupt path"));
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
+        Annotation ann = mock(Annotation.class);
+        when(ann.getId()).thenReturn("ann-x");
+        when(ann.getMediaAsset()).thenReturn(src);
+        when(src.findChildrenByLabel(any(Shepherd.class), eq("_master"))).thenReturn(masters);
+        when(ann.getBbox()).thenReturn(new int[] {100, 200, 300, 400});
+        when(ann.getTheta()).thenReturn(0.0);
+        when(ann.getViewpoint()).thenReturn("up");
+
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin");
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-x")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-x")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(200);
+        assertEquals(0, new JSONArray(out.toString()).length(),
+            "an annotation whose webURL() throws is omitted; the batch still returns 200");
     }
 
     @Test void resolve_emptyEncounterId_serializedAsNull() throws Exception {

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -284,6 +284,22 @@ class MediaResolveApiTest {
                             .put("hits", hits));
     }
 
+    @Test void gatedVisibleIds_returnsOnlyAclPassingSubset() throws Exception {
+        java.util.Set<String> requested = new java.util.LinkedHashSet<>(
+            java.util.Arrays.asList("ann-0", "ann-1", "ann-hidden"));
+        try (MockedConstruction<org.ecocean.OpenSearch> os = mockConstruction(org.ecocean.OpenSearch.class,
+                (m, c) -> {
+                    doNothing().when(m).deletePit(anyString());
+                    when(m.queryPit(eq("annotation"), any(), eq(0), anyInt(), any(), any()))
+                        .thenReturn(hitsFor("ann-0", "ann-1")); // only these pass the ACL gate
+                })) {
+            java.util.Set<String> visible = new MediaResolveApi().gatedVisibleIds(requested, "viewer");
+            assertEquals(new java.util.HashSet<>(java.util.Arrays.asList("ann-0", "ann-1")),
+                new java.util.HashSet<>(visible),
+                "gate returns only the ACL-passing subset; the hidden id is excluded");
+        }
+    }
+
     @Test void gate_returns_only_acl_passing_ids_and_sizes_to_id_count() throws Exception {
         // 12 requested ids; OpenSearch (mocked) returns all 12 as visible -> proves size>=12, not 10.
         JSONArray req = new JSONArray();

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -256,6 +256,7 @@ class MediaResolveApiTest {
             su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
               .thenReturn(new JSONObject().put("annotationIds", big));
             new MediaResolveApi().doPostForTest(req, resp);
+            assertTrue(sh.constructed().isEmpty(), "over-max body must be rejected before Shepherd construction");
         }
         verify(resp).setStatus(400);
     }

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -518,6 +518,7 @@ class MediaResolveApiTest {
         MediaAsset master = mock(MediaAsset.class);
         when(master.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
         when(master.hasLabel("_original")).thenReturn(false);
+        when(master.getParentId()).thenReturn(99); // a real child derivative
         when(master.webURL()).thenReturn(new java.net.URL("https://h/wildbook_data_dir/x/child-master.jpg"));
         when(src.bestSafeAsset(any(Shepherd.class), isNull(), eq("master"))).thenReturn(master);
         Annotation ann = mock(Annotation.class);
@@ -569,6 +570,7 @@ class MediaResolveApiTest {
         MediaAsset master = mock(MediaAsset.class);
         when(master.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
         when(master.hasLabel("_original")).thenReturn(false);
+        when(master.getParentId()).thenReturn(99); // a real child derivative
         when(master.webURL()).thenReturn(new java.net.URL("https://h/wildbook_data_dir/x/safe-master.jpg"));
         when(src.bestSafeAsset(any(Shepherd.class), isNull(), eq("master"))).thenReturn(master);
         Annotation ann = mock(Annotation.class);

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -2,15 +2,27 @@ package org.ecocean.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.*;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.ecocean.Annotation;
+import org.ecocean.User;
 import org.ecocean.media.MediaAsset;
 import org.ecocean.media.URLAssetStore;
 import org.ecocean.media.YouTubeAssetStore;
 import org.ecocean.media.LocalAssetStore;
+import org.ecocean.security.WildbookTokenAuthenticationFilter;
+import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 
 class MediaResolveApiTest {
 
@@ -174,5 +186,92 @@ class MediaResolveApiTest {
         when(src.findChildrenByLabel(sh, "_mid")).thenReturn(mids);
         assertSame(mid, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
             "a non-local _master is skipped; falls back to the local _mid");
+    }
+
+    /** Build a token-auth request mock; body comes from the ServletUtilities static mock. */
+    private HttpServletRequest tokenRequest() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getMethod()).thenReturn("POST");
+        when(req.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR)).thenReturn(Boolean.TRUE);
+        when(req.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_CONTEXT_ATTR)).thenReturn("context0");
+        return req;
+    }
+
+    private User mockUser(String id, boolean admin) {
+        User u = mock(User.class);
+        when(u.getId()).thenReturn(id);
+        return u;
+    }
+
+    @Test void doPost_non_token_request_401() throws Exception {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getMethod()).thenReturn("POST");
+        when(req.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR)).thenReturn(Boolean.FALSE);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        new MediaResolveApi().doPostForTest(req, resp);
+        verify(resp).setStatus(401);
+    }
+
+    @Test void doPost_token_but_missing_context_401_noShepherd() throws Exception {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getMethod()).thenReturn("POST");
+        when(req.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR)).thenReturn(Boolean.TRUE);
+        when(req.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_CONTEXT_ATTR)).thenReturn(null);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class)) {
+            new MediaResolveApi().doPostForTest(req, resp);
+            assertTrue(sh.constructed().isEmpty(), "no Shepherd may be constructed without a verified context");
+        }
+        verify(resp).setStatus(401);
+    }
+
+    @Test void doPost_empty_ids_400_noShepherd() throws Exception {
+        HttpServletRequest req = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class)) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject("{\"annotationIds\":[]}"));
+            new MediaResolveApi().doPostForTest(req, resp);
+            assertTrue(sh.constructed().isEmpty(), "body validation must happen before any Shepherd/DB work");
+        }
+        verify(resp).setStatus(400);
+    }
+
+    @Test void doPost_over_max_ids_400() throws Exception {
+        HttpServletRequest req = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        JSONArray big = new JSONArray();
+        for (int i = 0; i < MediaResolveApi.MAX_IDS + 1; i++) big.put("id-" + i);
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class)) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", big));
+            new MediaResolveApi().doPostForTest(req, resp);
+        }
+        verify(resp).setStatus(400);
+    }
+
+    @Test void doPost_malformed_body_400() throws Exception {
+        HttpServletRequest req = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class)) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenThrow(new org.json.JSONException("bad json"));
+            new MediaResolveApi().doPostForTest(req, resp);
+            assertTrue(sh.constructed().isEmpty(), "malformed body must be rejected before Shepherd construction");
+        }
+        verify(resp).setStatus(400);
     }
 }

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -39,6 +39,12 @@ class MediaResolveApiTest {
         assertNull(out, "a box entirely outside the image collapses to <1px -> null (omit)");
     }
 
+    @Test void scaleBbox_asymmetricScaleAppliedPerAxis() {
+        // sx=2 on X, sy=0.5 on Y — a single-factor bug would produce wrong Y values
+        int[] out = MediaResolveApi.scaleBbox(new int[] {10, 100, 50, 200}, 100, 1000, 200, 500);
+        assertArrayEquals(new int[] {20, 50, 100, 100}, out, "x and y must use their own scale factor");
+    }
+
     @Test void scaleBbox_nullWhenScaledRegionVanishes() {
         int[] out = MediaResolveApi.scaleBbox(new int[] {0, 0, 1, 1}, 10000, 10000, 5, 5);
         assertNull(out, "a region that rounds to <1px in the derivative -> null (omit)");

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -275,4 +275,48 @@ class MediaResolveApiTest {
         }
         verify(resp).setStatus(400);
     }
+
+    private JSONObject hitsFor(String... idsThatPass) {
+        JSONArray hits = new JSONArray();
+        for (String id : idsThatPass) hits.put(new JSONObject().put("_id", id));
+        return new JSONObject().put("hits",
+            new JSONObject().put("total", new JSONObject().put("value", idsThatPass.length))
+                            .put("hits", hits));
+    }
+
+    @Test void gate_returns_only_acl_passing_ids_and_sizes_to_id_count() throws Exception {
+        // 12 requested ids; OpenSearch (mocked) returns all 12 as visible -> proves size>=12, not 10.
+        JSONArray req = new JSONArray();
+        String[] all = new String[12];
+        for (int i = 0; i < 12; i++) { all[i] = "ann-" + i; req.put(all[i]); }
+
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+
+        final int[] capturedSize = {-1};
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("viewer", false);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(false);
+                 when(m.getAnnotation(anyString())).thenReturn(null); // resolveOne no-op here
+             });
+             MockedConstruction<org.ecocean.OpenSearch> os = mockConstruction(org.ecocean.OpenSearch.class,
+                 (m, c) -> {
+                     doNothing().when(m).deletePit(anyString());
+                     when(m.queryPit(eq("annotation"), any(), eq(0), anyInt(), any(), any()))
+                         .thenAnswer(inv -> { capturedSize[0] = inv.getArgument(3); return hitsFor(all); });
+                 })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", req));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(200);
+        assertEquals(12, capturedSize[0], "gate query size must equal the de-duplicated id count, not the default 10");
+    }
 }

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -1,0 +1,46 @@
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class MediaResolveApiTest {
+
+    @Test void scaleBbox_identityWhenSameDims() {
+        int[] out = MediaResolveApi.scaleBbox(new int[] {10, 20, 30, 40}, 100, 200, 100, 200);
+        assertArrayEquals(new int[] {10, 20, 30, 40}, out, "same src/dst dims must be identity");
+    }
+
+    @Test void scaleBbox_halfScaleDownscales() {
+        int[] out = MediaResolveApi.scaleBbox(new int[] {100, 200, 300, 400}, 1000, 1000, 500, 500);
+        assertArrayEquals(new int[] {50, 100, 150, 200}, out, "0.5x scale halves every component");
+    }
+
+    @Test void scaleBbox_clampsOverflowToDerivative() {
+        int[] out = MediaResolveApi.scaleBbox(new int[] {900, 0, 400, 100}, 1000, 1000, 500, 500);
+        assertArrayEquals(new int[] {450, 0, 50, 50}, out, "overflow width/height clamped to derivative bounds");
+    }
+
+    @Test void scaleBbox_nullOnBadInput() {
+        assertNull(MediaResolveApi.scaleBbox(null, 100, 100, 50, 50), "null src -> null");
+        assertNull(MediaResolveApi.scaleBbox(new int[] {1, 2, 3}, 100, 100, 50, 50), "short src -> null");
+        assertNull(MediaResolveApi.scaleBbox(new int[] {0, 0, 10, 10}, 0, 100, 50, 50), "zero src dim -> null");
+        assertNull(MediaResolveApi.scaleBbox(new int[] {0, 0, 10, 10}, 100, 100, 0, 50), "zero dst dim -> null");
+    }
+
+    @Test void scaleBbox_negativeOriginClampsCornerAndShrinksWidth() {
+        // src bbox starts at x=-10; clamping the LEFT corner to 0 must shrink width to 10, not keep 20.
+        int[] out = MediaResolveApi.scaleBbox(new int[] {-10, 0, 20, 20}, 100, 100, 100, 100);
+        assertArrayEquals(new int[] {0, 0, 10, 20}, out, "negative origin clamps corner and shrinks width");
+    }
+
+    @Test void scaleBbox_fullyOutsideReturnsNull() {
+        int[] out = MediaResolveApi.scaleBbox(new int[] {-50, -50, 20, 20}, 100, 100, 100, 100);
+        assertNull(out, "a box entirely outside the image collapses to <1px -> null (omit)");
+    }
+
+    @Test void scaleBbox_nullWhenScaledRegionVanishes() {
+        int[] out = MediaResolveApi.scaleBbox(new int[] {0, 0, 1, 1}, 10000, 10000, 5, 5);
+        assertNull(out, "a region that rounds to <1px in the derivative -> null (omit)");
+    }
+}

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -140,18 +140,15 @@ class MediaResolveApiTest {
         }
     }
 
-    /** A resolvable annotation: source asset is LocalAssetStore 1000x1000, bbox [100,200,300,400],
-        and bestSafeAsset("master") returns a local, non-_original derivative with a webURL. */
+    /** A resolvable annotation: source asset is a non-_original LocalAssetStore 1000x1000 whose own
+        webURL is servable; bbox [100,200,300,400]. */
     private Annotation fullAnnotation(String id, String encId, String indId) throws Exception {
         MediaAsset src = mock(MediaAsset.class);
         when(src.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
         when(src.getWidth()).thenReturn(1000.0);
         when(src.getHeight()).thenReturn(1000.0);
-        MediaAsset master = mock(MediaAsset.class);
-        when(master.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
-        when(master.hasLabel("_original")).thenReturn(false);
-        when(master.webURL()).thenReturn(new java.net.URL("https://h/wildbook_data_dir/x/" + id + "-master.jpg"));
-        when(src.bestSafeAsset(any(Shepherd.class), isNull(), eq("master"))).thenReturn(master);
+        when(src.hasLabel("_original")).thenReturn(false);
+        when(src.webURL()).thenReturn(new java.net.URL("https://h/wildbook_data_dir/x/" + id + "-master.jpg"));
         Annotation ann = mock(Annotation.class);
         when(ann.getId()).thenReturn(id);
         when(ann.getMediaAsset()).thenReturn(src);
@@ -192,11 +189,11 @@ class MediaResolveApiTest {
         assertEquals(1, arr.length(), "one entry resolved");
         JSONObject e = arr.getJSONObject(0);
         assertEquals("ann-A", e.getString("id"), "id echoed");
-        assertTrue(e.getString("imageUrl").endsWith("-master.jpg"), "serves the safeURL master derivative");
+        assertTrue(e.getString("imageUrl").endsWith("-master.jpg"), "serves the source asset's own webURL");
         assertEquals(1000, e.getInt("imageWidth"), "imageWidth is the annotation asset width");
         assertEquals(1000, e.getInt("imageHeight"), "imageHeight is the annotation asset height");
         assertEquals("[100,200,300,400]", e.getJSONArray("bbox").toString(),
-            "bbox is returned in the source coordinate space (no server-side scaling)");
+            "bbox returned in source coordinate space (no server-side scaling)");
         assertEquals("up", e.getString("viewpoint"), "viewpoint passed through");
         assertEquals("enc-A", e.getString("encounterId"), "first-parent encounter id");
         assertEquals("ind-A", e.getString("individualId"), "individual id");
@@ -429,8 +426,8 @@ class MediaResolveApiTest {
         when(src.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
         when(src.getWidth()).thenReturn(1000.0);
         when(src.getHeight()).thenReturn(1000.0);
-        when(src.bestSafeAsset(any(Shepherd.class), isNull(), anyString()))
-            .thenThrow(new IllegalArgumentException("corrupt path"));
+        when(src.hasLabel("_original")).thenReturn(false);
+        when(src.webURL()).thenThrow(new IllegalArgumentException("corrupt path"));
         Annotation ann = mock(Annotation.class);
         when(ann.getId()).thenReturn("ann-x");
         when(ann.getMediaAsset()).thenReturn(src);
@@ -455,7 +452,7 @@ class MediaResolveApiTest {
         }
         verify(resp).setStatus(200);
         assertEquals(0, new JSONArray(out.toString()).length(),
-            "an annotation whose safeURL lookup throws is omitted; batch still 200");
+            "source webURL throwing -> entry omitted, batch still 200");
     }
 
     @Test void resolve_emptyEncounterId_serializedAsNull() throws Exception {
@@ -508,5 +505,101 @@ class MediaResolveApiTest {
         }
         verify(resp).setStatus(200);
         assertEquals(0, new JSONArray(out.toString()).length(), "null bbox -> omit");
+    }
+
+    @Test void resolve_originalSource_servedViaMasterChild() throws Exception {
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
+        when(src.getWidth()).thenReturn(1000.0);
+        when(src.getHeight()).thenReturn(1000.0);
+        when(src.hasLabel("_original")).thenReturn(true); // raw upload -> must NOT serve directly
+        MediaAsset master = mock(MediaAsset.class);
+        when(master.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
+        when(master.hasLabel("_original")).thenReturn(false);
+        when(master.webURL()).thenReturn(new java.net.URL("https://h/wildbook_data_dir/x/child-master.jpg"));
+        when(src.bestSafeAsset(any(Shepherd.class), isNull(), eq("master"))).thenReturn(master);
+        Annotation ann = mock(Annotation.class);
+        when(ann.getId()).thenReturn("ann-o");
+        when(ann.getMediaAsset()).thenReturn(src);
+        when(ann.getBbox()).thenReturn(new int[] {0, 0, 500, 500});
+        when(ann.getTheta()).thenReturn(0.0);
+        when(ann.getViewpoint()).thenReturn("up");
+        Encounter enc = mock(Encounter.class);
+        when(enc.getId()).thenReturn("enc-o");
+        when(ann.findEncounter(any(Shepherd.class))).thenReturn(enc);
+        when(ann.getEmbeddings()).thenReturn(null);
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin");
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-o")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-o")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(1, arr.length(), "_original source resolves via its master child");
+        assertTrue(arr.getJSONObject(0).getString("imageUrl").endsWith("child-master.jpg"),
+            "_original is served via a _master child, not directly");
+        assertEquals(1000, arr.getJSONObject(0).getInt("imageWidth"),
+            "reported dims are the source (original) frame; consumer scales to the served master");
+    }
+
+    @Test void resolve_negativeOriginBbox_clampsCorner() throws Exception {
+        Annotation ann = fullAnnotation("ann-c", "enc-c", "ind-c");
+        when(ann.getBbox()).thenReturn(new int[] {-10, 0, 20, 20}); // x=-10 -> clamp corner, width 20->10
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin");
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-c")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-c")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        assertEquals("[0,0,10,20]", new JSONArray(out.toString()).getJSONObject(0).getJSONArray("bbox").toString(),
+            "negative origin clamps the corner and shrinks width (not kept at 20)");
+    }
+
+    @Test void resolve_bboxFullyOutOfBounds_omits() throws Exception {
+        Annotation ann = fullAnnotation("ann-oob", "enc-oob", "ind-oob");
+        when(ann.getBbox()).thenReturn(new int[] {-50, -50, 20, 20}); // entirely off-image -> omit
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin");
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-oob")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-oob")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        assertEquals(0, new JSONArray(out.toString()).length(), "fully out-of-bounds bbox -> omit");
     }
 }

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -236,6 +236,19 @@ class MediaResolveApiTest {
         }
     }
 
+    @Test void selectSafeDerivative_parentLoadThrows_omits() {
+        // A parent-load failure must omit this one id (fail-soft), never throw to fail the batch.
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.getParentId()).thenReturn(4242);
+        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
+            mf.when(() -> MediaAssetFactory.load(4242, sh)).thenThrow(new RuntimeException("pm down"));
+            assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+                "parent load failure -> omit (fail-soft)");
+        }
+    }
+
     @Test void selectSafeDerivative_parentDerivativeNonUniformScale_omits() {
         // src is a CROP (different aspect than the parent's full-frame derivative): 1000x1000 source vs
         // 500x250 derivative => sx=0.5, sy=0.25 (non-uniform) => omit, to avoid a mis-scaled bbox.

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -6,10 +6,15 @@ import static org.mockito.ArgumentMatchers.*;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URL;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.ecocean.Annotation;
+import org.ecocean.Embedding;
+import org.ecocean.Encounter;
 import org.ecocean.User;
 import org.ecocean.media.MediaAsset;
 import org.ecocean.media.URLAssetStore;
@@ -298,6 +303,255 @@ class MediaResolveApiTest {
                 new java.util.HashSet<>(visible),
                 "gate returns only the ACL-passing subset; the hidden id is excluded");
         }
+    }
+
+    /** A fully-populated annotation whose 1000x1000 source has a 500x500 _master derivative. */
+    private Annotation fullAnnotation(String id, String encId, String indId) throws Exception {
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.getWidth()).thenReturn(1000.0);
+        when(src.getHeight()).thenReturn(1000.0);
+
+        MediaAsset master = mock(MediaAsset.class);
+        when(master.getStore()).thenReturn(mock(LocalAssetStore.class));
+        ArrayList<String> labels = new ArrayList<>(); labels.add("_master");
+        when(master.getLabels()).thenReturn(labels);
+        when(master.hasLabel("_master")).thenReturn(true);
+        when(master.hasLabel("_original")).thenReturn(false);
+        when(master.getWidth()).thenReturn(500.0);
+        when(master.getHeight()).thenReturn(500.0);
+        when(master.webURL()).thenReturn(new URL("https://h/wildbook_data_dir/x/" + id + "-master.jpg"));
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
+
+        Annotation ann = mock(Annotation.class);
+        when(ann.getId()).thenReturn(id);
+        when(ann.getMediaAsset()).thenReturn(src);
+        when(src.findChildrenByLabel(any(Shepherd.class), eq("_master"))).thenReturn(masters);
+        when(ann.getBbox()).thenReturn(new int[] {100, 200, 300, 400});
+        when(ann.getTheta()).thenReturn(0.0);
+        when(ann.getViewpoint()).thenReturn("up");
+        Encounter enc = mock(Encounter.class);
+        when(enc.getId()).thenReturn(encId);
+        when(ann.findEncounter(any(Shepherd.class))).thenReturn(enc);
+        when(ann.findIndividualId(any(Shepherd.class))).thenReturn(indId);
+        when(ann.getEmbeddings()).thenReturn(null);
+        return ann;
+    }
+
+    @Test void resolve_payload_scaledBbox_and_derivativeUrl() throws Exception {
+        Annotation ann = fullAnnotation("ann-A", "enc-A", "ind-A");
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin", true);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true); // admin path: no OpenSearch gate
+                 when(m.getAnnotation("ann-A")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-A")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(200);
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(1, arr.length(), "one entry resolved");
+        JSONObject e = arr.getJSONObject(0);
+        assertEquals("ann-A", e.getString("id"), "id echoed");
+        assertTrue(e.getString("imageUrl").endsWith("-master.jpg"), "serves the _master derivative url");
+        assertEquals(500, e.getInt("imageWidth"), "imageWidth is the derivative width");
+        assertEquals(500, e.getInt("imageHeight"), "imageHeight is the derivative height");
+        // src 1000x1000 -> dst 500x500 is 0.5x: [100,200,300,400] -> [50,100,150,200]
+        assertEquals("[50,100,150,200]", e.getJSONArray("bbox").toString(),
+            "bbox scaled into derivative pixel space, not raw source coords");
+        assertEquals("up", e.getString("viewpoint"), "viewpoint passed through");
+        assertEquals("enc-A", e.getString("encounterId"), "first-parent encounter id");
+        assertEquals("ind-A", e.getString("individualId"), "individual id");
+    }
+
+    @Test void resolve_omits_unresolvable_and_is_not_an_existence_oracle() throws Exception {
+        Annotation good = fullAnnotation("ann-good", "enc-1", "ind-1");
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin", true);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-good")).thenReturn(good);
+                 when(m.getAnnotation("ann-garbage")).thenReturn(null); // nonexistent
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds",
+                  new JSONArray().put("ann-good").put("ann-garbage")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(200);
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(1, arr.length(), "garbage/nonexistent id is silently absent (no existence oracle)");
+        assertEquals("ann-good", arr.getJSONObject(0).getString("id"), "only the resolvable id returned");
+    }
+
+    @Test void resolve_dedups_repeated_ids() throws Exception {
+        Annotation good = fullAnnotation("ann-d", "enc-d", "ind-d");
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin", true);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-d")).thenReturn(good);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds",
+                  new JSONArray().put("ann-d").put("ann-d").put("ann-d")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(1, arr.length(), "duplicate ids collapse to a single entry");
+    }
+
+    @Test void resolve_nonAdmin_onlyGateVisibleResolved_noOracle_andNoLoadForHidden() throws Exception {
+        Annotation vis = fullAnnotation("ann-vis", "enc-v", "ind-v");
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("viewer", false);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(false);
+                 when(m.getAnnotation("ann-vis")).thenReturn(vis);
+             });
+             MockedConstruction<org.ecocean.OpenSearch> os = mockConstruction(org.ecocean.OpenSearch.class,
+                 (m, c) -> {
+                     doNothing().when(m).deletePit(anyString());
+                     when(m.queryPit(eq("annotation"), any(), eq(0), anyInt(), any(), any()))
+                         .thenReturn(hitsFor("ann-vis")); // only ann-vis passes the ACL gate
+                 })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds",
+                  new JSONArray().put("ann-vis").put("ann-hidden").put("ann-garbage")));
+            new MediaResolveApi().doPostForTest(request, resp);
+            Shepherd constructed = sh.constructed().get(0);
+            verify(constructed, never()).getAnnotation("ann-hidden");
+            verify(constructed, never()).getAnnotation("ann-garbage");
+        }
+        verify(resp).setStatus(200);
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(1, arr.length(), "non-admin sees only gate-passed ids; hidden/garbage absent (no oracle)");
+        assertEquals("ann-vis", arr.getJSONObject(0).getString("id"), "only the visible id resolved");
+    }
+
+    @Test void resolve_nonAdmin_moreThan10VisibleAllResolve() throws Exception {
+        JSONArray reqIds = new JSONArray();
+        String[] all = new String[12];
+        for (int i = 0; i < 12; i++) { all[i] = "ann-" + i; reqIds.put(all[i]); }
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("viewer", false);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(false);
+                 when(m.getAnnotation(anyString())).thenAnswer(inv -> {
+                     String id = inv.getArgument(0);
+                     return fullAnnotation(id, "enc-" + id, "ind-" + id);
+                 });
+             });
+             MockedConstruction<org.ecocean.OpenSearch> os = mockConstruction(org.ecocean.OpenSearch.class,
+                 (m, c) -> {
+                     doNothing().when(m).deletePit(anyString());
+                     when(m.queryPit(eq("annotation"), any(), eq(0), anyInt(), any(), any()))
+                         .thenReturn(hitsFor(all));
+                 })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", reqIds));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(200);
+        assertEquals(12, new JSONArray(out.toString()).length(), "all 12 visible ids resolve (no default-10 truncation)");
+    }
+
+    @Test void resolve_thetaDefault_and_nullViewpoint() throws Exception {
+        Annotation ann = fullAnnotation("ann-t", "enc-t", "ind-t");
+        when(ann.getViewpoint()).thenReturn(null);
+        when(ann.getTheta()).thenReturn(0.0);
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin", true);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-t")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-t")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        JSONObject e = new JSONArray(out.toString()).getJSONObject(0);
+        assertTrue(e.isNull("viewpoint"), "null viewpoint serialized as JSON null");
+        assertEquals(0.0, e.getDouble("theta"), 0.0001, "theta defaults to 0.0");
+    }
+
+    @Test void resolve_methodVersion_dedupAndOrder() throws Exception {
+        Annotation ann = fullAnnotation("ann-m", "enc-m", "ind-m");
+        Embedding e1 = mock(Embedding.class); when(e1.getMethodVersion()).thenReturn("msv4.1");
+        Embedding e2 = mock(Embedding.class); when(e2.getMethodVersion()).thenReturn("msv4.1");
+        Embedding e3 = mock(Embedding.class); when(e3.getMethodVersion()).thenReturn("msv3");
+        Set<Embedding> embs = new LinkedHashSet<>(); embs.add(e1); embs.add(e2); embs.add(e3);
+        when(ann.getEmbeddings()).thenReturn(embs);
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin", true);
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-m")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-m")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        JSONArray mvs = new JSONArray(out.toString()).getJSONObject(0).getJSONArray("methodVersion");
+        assertEquals("[\"msv4.1\",\"msv3\"]", mvs.toString(), "method versions de-duplicated, first-seen order");
     }
 
     @Test void gate_returns_only_acl_passing_ids_and_sizes_to_id_count() throws Exception {

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -169,22 +169,93 @@ class MediaResolveApiTest {
     }
 
     @Test void selectSafeDerivative_walksToOriginalParentForDerivatives() {
-        // Live-data shape (flakebook): the annotation's asset is a non-original SIBLING of the
-        // derivatives; _master/_mid hang off the _original PARENT. selectSafeDerivative must walk to
-        // the parent to find them — searching the leaf sibling's own children would find nothing.
+        // Live-data shape (flakebook): the annotation's asset is a full-frame, non-original SIBLING of
+        // the derivatives; _master/_mid hang off the _original PARENT. With no own derivative,
+        // selectSafeDerivative walks to the parent and uses its _master because it is a uniform scale
+        // of the source frame (1000x1000 -> 500x500).
         Shepherd sh = mock(Shepherd.class);
         MediaAsset src = mock(MediaAsset.class);
         when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
         when(src.getParentId()).thenReturn(4242);
+        when(src.getWidth()).thenReturn(1000.0);
+        when(src.getHeight()).thenReturn(1000.0);
         MediaAsset original = mock(MediaAsset.class);
         when(original.hasLabel("_original")).thenReturn(true);
         MediaAsset master = child("_master", false);
+        when(master.getWidth()).thenReturn(500.0);
+        when(master.getHeight()).thenReturn(500.0);
         ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
         when(original.findChildrenByLabel(sh, "_master")).thenReturn(masters);
         try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
             mf.when(() -> MediaAssetFactory.load(4242, sh)).thenReturn(original);
             assertSame(master, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-                "must walk to the _original parent to find the _master derivative");
+                "uses the _original parent's derivative when it's a uniform scale of the source");
+        }
+    }
+
+    @Test void selectSafeDerivative_ownDerivativePreferredOverParent() {
+        // When the annotation's OWN asset has a _master, use it directly — never load the parent.
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.getParentId()).thenReturn(4242);
+        MediaAsset own = child("_master", false);
+        ArrayList<MediaAsset> owns = new ArrayList<>(); owns.add(own);
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(owns);
+        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
+            assertSame(own, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+                "the annotation's own _master is used without walking to the parent");
+            mf.verifyNoInteractions();
+        }
+    }
+
+    @Test void selectSafeDerivative_parentNotOriginal_omits() {
+        // src has no own derivative and the parent is NOT an _original -> omit.
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.getParentId()).thenReturn(4242);
+        MediaAsset parent = mock(MediaAsset.class);
+        when(parent.hasLabel("_original")).thenReturn(false);
+        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
+            mf.when(() -> MediaAssetFactory.load(4242, sh)).thenReturn(parent);
+            assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+                "a non-_original parent yields no derivative -> omit");
+        }
+    }
+
+    @Test void selectSafeDerivative_parentLoadNull_omits() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.getParentId()).thenReturn(4242);
+        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
+            mf.when(() -> MediaAssetFactory.load(4242, sh)).thenReturn(null);
+            assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+                "parent load returns null -> omit");
+        }
+    }
+
+    @Test void selectSafeDerivative_parentDerivativeNonUniformScale_omits() {
+        // src is a CROP (different aspect than the parent's full-frame derivative): 1000x1000 source vs
+        // 500x250 derivative => sx=0.5, sy=0.25 (non-uniform) => omit, to avoid a mis-scaled bbox.
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.getParentId()).thenReturn(4242);
+        when(src.getWidth()).thenReturn(1000.0);
+        when(src.getHeight()).thenReturn(1000.0);
+        MediaAsset original = mock(MediaAsset.class);
+        when(original.hasLabel("_original")).thenReturn(true);
+        MediaAsset master = child("_master", false);
+        when(master.getWidth()).thenReturn(500.0);
+        when(master.getHeight()).thenReturn(250.0);
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
+        when(original.findChildrenByLabel(sh, "_master")).thenReturn(masters);
+        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
+            mf.when(() -> MediaAssetFactory.load(4242, sh)).thenReturn(original);
+            assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+                "non-uniform scale (cropped/transformed source) -> omit");
         }
     }
 

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -202,7 +202,7 @@ class MediaResolveApiTest {
         return req;
     }
 
-    private User mockUser(String id, boolean admin) {
+    private User mockUser(String id) {
         User u = mock(User.class);
         when(u.getId()).thenReturn(id);
         return u;
@@ -332,8 +332,9 @@ class MediaResolveApiTest {
         when(ann.getViewpoint()).thenReturn("up");
         Encounter enc = mock(Encounter.class);
         when(enc.getId()).thenReturn(encId);
+        when(enc.hasMarkedIndividual()).thenReturn(indId != null && !indId.isEmpty());
+        when(enc.getIndividualID()).thenReturn(indId);
         when(ann.findEncounter(any(Shepherd.class))).thenReturn(enc);
-        when(ann.findIndividualId(any(Shepherd.class))).thenReturn(indId);
         when(ann.getEmbeddings()).thenReturn(null);
         return ann;
     }
@@ -349,7 +350,7 @@ class MediaResolveApiTest {
                  doNothing().when(m).beginDBTransaction();
                  doNothing().when(m).setAction(anyString());
                  doNothing().when(m).rollbackAndClose();
-                 User u = mockUser("admin", true);
+                 User u = mockUser("admin");
                  when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
                  when(u.isAdmin(m)).thenReturn(true); // admin path: no OpenSearch gate
                  when(m.getAnnotation("ann-A")).thenReturn(ann);
@@ -385,7 +386,7 @@ class MediaResolveApiTest {
                  doNothing().when(m).beginDBTransaction();
                  doNothing().when(m).setAction(anyString());
                  doNothing().when(m).rollbackAndClose();
-                 User u = mockUser("admin", true);
+                 User u = mockUser("admin");
                  when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
                  when(u.isAdmin(m)).thenReturn(true);
                  when(m.getAnnotation("ann-good")).thenReturn(good);
@@ -413,7 +414,7 @@ class MediaResolveApiTest {
                  doNothing().when(m).beginDBTransaction();
                  doNothing().when(m).setAction(anyString());
                  doNothing().when(m).rollbackAndClose();
-                 User u = mockUser("admin", true);
+                 User u = mockUser("admin");
                  when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
                  when(u.isAdmin(m)).thenReturn(true);
                  when(m.getAnnotation("ann-d")).thenReturn(good);
@@ -438,7 +439,7 @@ class MediaResolveApiTest {
                  doNothing().when(m).beginDBTransaction();
                  doNothing().when(m).setAction(anyString());
                  doNothing().when(m).rollbackAndClose();
-                 User u = mockUser("viewer", false);
+                 User u = mockUser("viewer");
                  when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
                  when(u.isAdmin(m)).thenReturn(false);
                  when(m.getAnnotation("ann-vis")).thenReturn(vis);
@@ -476,7 +477,7 @@ class MediaResolveApiTest {
                  doNothing().when(m).beginDBTransaction();
                  doNothing().when(m).setAction(anyString());
                  doNothing().when(m).rollbackAndClose();
-                 User u = mockUser("viewer", false);
+                 User u = mockUser("viewer");
                  when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
                  when(u.isAdmin(m)).thenReturn(false);
                  when(m.getAnnotation(anyString())).thenAnswer(inv -> {
@@ -511,7 +512,7 @@ class MediaResolveApiTest {
                  doNothing().when(m).beginDBTransaction();
                  doNothing().when(m).setAction(anyString());
                  doNothing().when(m).rollbackAndClose();
-                 User u = mockUser("admin", true);
+                 User u = mockUser("admin");
                  when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
                  when(u.isAdmin(m)).thenReturn(true);
                  when(m.getAnnotation("ann-t")).thenReturn(ann);
@@ -541,7 +542,7 @@ class MediaResolveApiTest {
                  doNothing().when(m).beginDBTransaction();
                  doNothing().when(m).setAction(anyString());
                  doNothing().when(m).rollbackAndClose();
-                 User u = mockUser("admin", true);
+                 User u = mockUser("admin");
                  when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
                  when(u.isAdmin(m)).thenReturn(true);
                  when(m.getAnnotation("ann-m")).thenReturn(ann);
@@ -571,7 +572,7 @@ class MediaResolveApiTest {
                  doNothing().when(m).beginDBTransaction();
                  doNothing().when(m).setAction(anyString());
                  doNothing().when(m).rollbackAndClose();
-                 User u = mockUser("viewer", false);
+                 User u = mockUser("viewer");
                  when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
                  when(u.isAdmin(m)).thenReturn(false);
                  when(m.getAnnotation(anyString())).thenReturn(null); // resolveOne no-op here
@@ -588,5 +589,32 @@ class MediaResolveApiTest {
         }
         verify(resp).setStatus(200);
         assertEquals(12, capturedSize[0], "gate query size must equal the de-duplicated id count, not the default 10");
+    }
+
+    @Test void resolve_emptyEncounterId_serializedAsNull() throws Exception {
+        Annotation ann = fullAnnotation("ann-e", "enc-e", "ind-e");
+        Encounter blankEnc = mock(Encounter.class);
+        when(blankEnc.getId()).thenReturn("");
+        when(ann.findEncounter(any(Shepherd.class))).thenReturn(blankEnc);
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin");
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-e")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-e")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        JSONObject e = new JSONArray(out.toString()).getJSONObject(0);
+        assertTrue(e.isNull("encounterId"), "empty encounter id serialized as JSON null");
     }
 }

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -17,6 +17,7 @@ import org.ecocean.Embedding;
 import org.ecocean.Encounter;
 import org.ecocean.User;
 import org.ecocean.media.MediaAsset;
+import org.ecocean.media.MediaAssetFactory;
 import org.ecocean.media.URLAssetStore;
 import org.ecocean.media.YouTubeAssetStore;
 import org.ecocean.media.LocalAssetStore;
@@ -165,6 +166,26 @@ class MediaResolveApiTest {
         when(src.findChildrenByLabel(sh, "_mid")).thenReturn(mids);
         assertSame(mid, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
             "a _master child also labeled _original is skipped; falls back to _mid");
+    }
+
+    @Test void selectSafeDerivative_walksToOriginalParentForDerivatives() {
+        // Live-data shape (flakebook): the annotation's asset is a non-original SIBLING of the
+        // derivatives; _master/_mid hang off the _original PARENT. selectSafeDerivative must walk to
+        // the parent to find them — searching the leaf sibling's own children would find nothing.
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.getParentId()).thenReturn(4242);
+        MediaAsset original = mock(MediaAsset.class);
+        when(original.hasLabel("_original")).thenReturn(true);
+        MediaAsset master = child("_master", false);
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
+        when(original.findChildrenByLabel(sh, "_master")).thenReturn(masters);
+        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
+            mf.when(() -> MediaAssetFactory.load(4242, sh)).thenReturn(original);
+            assertSame(master, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+                "must walk to the _original parent to find the _master derivative");
+        }
     }
 
     @Test void selectSafeDerivative_nullWhenChildrenExistButNoneMatchLabel() {

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.*;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
@@ -17,9 +16,6 @@ import org.ecocean.Embedding;
 import org.ecocean.Encounter;
 import org.ecocean.User;
 import org.ecocean.media.MediaAsset;
-import org.ecocean.media.MediaAssetFactory;
-import org.ecocean.media.URLAssetStore;
-import org.ecocean.media.YouTubeAssetStore;
 import org.ecocean.media.LocalAssetStore;
 import org.ecocean.security.WildbookTokenAuthenticationFilter;
 import org.ecocean.servlet.ServletUtilities;
@@ -31,272 +27,6 @@ import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
 class MediaResolveApiTest {
-
-    @Test void scaleBbox_identityWhenSameDims() {
-        int[] out = MediaResolveApi.scaleBbox(new int[] {10, 20, 30, 40}, 100, 200, 100, 200);
-        assertArrayEquals(new int[] {10, 20, 30, 40}, out, "same src/dst dims must be identity");
-    }
-
-    @Test void scaleBbox_halfScaleDownscales() {
-        int[] out = MediaResolveApi.scaleBbox(new int[] {100, 200, 300, 400}, 1000, 1000, 500, 500);
-        assertArrayEquals(new int[] {50, 100, 150, 200}, out, "0.5x scale halves every component");
-    }
-
-    @Test void scaleBbox_clampsOverflowToDerivative() {
-        int[] out = MediaResolveApi.scaleBbox(new int[] {900, 0, 400, 100}, 1000, 1000, 500, 500);
-        assertArrayEquals(new int[] {450, 0, 50, 50}, out, "overflow width/height clamped to derivative bounds");
-    }
-
-    @Test void scaleBbox_nullOnBadInput() {
-        assertNull(MediaResolveApi.scaleBbox(null, 100, 100, 50, 50), "null src -> null");
-        assertNull(MediaResolveApi.scaleBbox(new int[] {1, 2, 3}, 100, 100, 50, 50), "short src -> null");
-        assertNull(MediaResolveApi.scaleBbox(new int[] {0, 0, 10, 10}, 0, 100, 50, 50), "zero src dim -> null");
-        assertNull(MediaResolveApi.scaleBbox(new int[] {0, 0, 10, 10}, 100, 100, 0, 50), "zero dst dim -> null");
-    }
-
-    @Test void scaleBbox_negativeOriginClampsCornerAndShrinksWidth() {
-        // src bbox starts at x=-10; clamping the LEFT corner to 0 must shrink width to 10, not keep 20.
-        int[] out = MediaResolveApi.scaleBbox(new int[] {-10, 0, 20, 20}, 100, 100, 100, 100);
-        assertArrayEquals(new int[] {0, 0, 10, 20}, out, "negative origin clamps corner and shrinks width");
-    }
-
-    @Test void scaleBbox_fullyOutsideReturnsNull() {
-        int[] out = MediaResolveApi.scaleBbox(new int[] {-50, -50, 20, 20}, 100, 100, 100, 100);
-        assertNull(out, "a box entirely outside the image collapses to <1px -> null (omit)");
-    }
-
-    @Test void scaleBbox_asymmetricScaleAppliedPerAxis() {
-        // sx=2 on X, sy=0.5 on Y — a single-factor bug would produce wrong Y values
-        int[] out = MediaResolveApi.scaleBbox(new int[] {10, 100, 50, 200}, 100, 1000, 200, 500);
-        assertArrayEquals(new int[] {20, 50, 100, 100}, out, "x and y must use their own scale factor");
-    }
-
-    @Test void scaleBbox_nullWhenScaledRegionVanishes() {
-        int[] out = MediaResolveApi.scaleBbox(new int[] {0, 0, 1, 1}, 10000, 10000, 5, 5);
-        assertNull(out, "a region that rounds to <1px in the derivative -> null (omit)");
-    }
-
-    private MediaAsset child(String label, boolean urlStore) {
-        MediaAsset ma = mock(MediaAsset.class);
-        ArrayList<String> labels = new ArrayList<>();
-        labels.add(label);
-        when(ma.getLabels()).thenReturn(labels);
-        when(ma.hasLabel(label)).thenReturn(true);
-        when(ma.getStore()).thenReturn(urlStore ? mock(URLAssetStore.class) : mock(LocalAssetStore.class));
-        return ma;
-    }
-
-    private Annotation annWithSource(MediaAsset src) {
-        Annotation ann = mock(Annotation.class);
-        when(ann.getMediaAsset()).thenReturn(src);
-        return ann;
-    }
-
-    @Test void selectSafeDerivative_prefersMaster() {
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        MediaAsset master = child("_master", false);
-        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
-        when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
-        MediaAsset out = MediaResolveApi.selectSafeDerivative(annWithSource(src), sh);
-        assertSame(master, out, "a _master child must be selected first");
-    }
-
-    @Test void selectSafeDerivative_fallsBackToMidWhenNoMaster() {
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        when(src.findChildrenByLabel(sh, "_master")).thenReturn(null);
-        MediaAsset mid = child("_mid", false);
-        ArrayList<MediaAsset> mids = new ArrayList<>(); mids.add(mid);
-        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(mids);
-        MediaAsset out = MediaResolveApi.selectSafeDerivative(annWithSource(src), sh);
-        assertSame(mid, out, "must fall back to _mid when _master is absent (bestSafeAsset bug bypassed)");
-    }
-
-    @Test void selectSafeDerivative_nullWhenNoSafeDerivative() {
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        when(src.findChildrenByLabel(sh, "_master")).thenReturn(null);
-        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(null);
-        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-            "no _master/_mid -> null (omit)");
-    }
-
-    @Test void selectSafeDerivative_rejectsUrlAssetStoreSource() {
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(URLAssetStore.class));
-        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-            "URLAssetStore source (external original) must be rejected");
-    }
-
-    @Test void selectSafeDerivative_skipsUrlStoreChildren() {
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        MediaAsset urlChild = child("_master", true); // _master label but URLAssetStore
-        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(urlChild);
-        when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
-        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(null);
-        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-            "a non-local (URLAssetStore) child must be skipped");
-    }
-
-    @Test void selectSafeDerivative_rejectsYouTubeStoreSource() {
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(YouTubeAssetStore.class));
-        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-            "YouTubeAssetStore source (webURL is a watch page, not image bytes) must be rejected");
-    }
-
-    @Test void selectSafeDerivative_skipsMasterAlsoLabeledOriginal_fallsBackToMid() {
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        MediaAsset masterButOriginal = child("_master", false);
-        when(masterButOriginal.hasLabel("_original")).thenReturn(true); // also carries _original
-        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(masterButOriginal);
-        when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
-        MediaAsset mid = child("_mid", false);
-        ArrayList<MediaAsset> mids = new ArrayList<>(); mids.add(mid);
-        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(mids);
-        assertSame(mid, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-            "a _master child also labeled _original is skipped; falls back to _mid");
-    }
-
-    @Test void selectSafeDerivative_walksToOriginalParentForDerivatives() {
-        // Live-data shape (flakebook): the annotation's asset is a full-frame, non-original SIBLING of
-        // the derivatives; _master/_mid hang off the _original PARENT. With no own derivative,
-        // selectSafeDerivative walks to the parent and uses its _master because it is a uniform scale
-        // of the source frame (1000x1000 -> 500x500).
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        when(src.getParentId()).thenReturn(4242);
-        when(src.getWidth()).thenReturn(1000.0);
-        when(src.getHeight()).thenReturn(1000.0);
-        MediaAsset original = mock(MediaAsset.class);
-        when(original.hasLabel("_original")).thenReturn(true);
-        MediaAsset master = child("_master", false);
-        when(master.getWidth()).thenReturn(500.0);
-        when(master.getHeight()).thenReturn(500.0);
-        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
-        when(original.findChildrenByLabel(sh, "_master")).thenReturn(masters);
-        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
-            mf.when(() -> MediaAssetFactory.load(4242, sh)).thenReturn(original);
-            assertSame(master, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-                "uses the _original parent's derivative when it's a uniform scale of the source");
-        }
-    }
-
-    @Test void selectSafeDerivative_ownDerivativePreferredOverParent() {
-        // When the annotation's OWN asset has a _master, use it directly — never load the parent.
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        when(src.getParentId()).thenReturn(4242);
-        MediaAsset own = child("_master", false);
-        ArrayList<MediaAsset> owns = new ArrayList<>(); owns.add(own);
-        when(src.findChildrenByLabel(sh, "_master")).thenReturn(owns);
-        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
-            assertSame(own, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-                "the annotation's own _master is used without walking to the parent");
-            mf.verifyNoInteractions();
-        }
-    }
-
-    @Test void selectSafeDerivative_parentNotOriginal_omits() {
-        // src has no own derivative and the parent is NOT an _original -> omit.
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        when(src.getParentId()).thenReturn(4242);
-        MediaAsset parent = mock(MediaAsset.class);
-        when(parent.hasLabel("_original")).thenReturn(false);
-        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
-            mf.when(() -> MediaAssetFactory.load(4242, sh)).thenReturn(parent);
-            assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-                "a non-_original parent yields no derivative -> omit");
-        }
-    }
-
-    @Test void selectSafeDerivative_parentLoadNull_omits() {
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        when(src.getParentId()).thenReturn(4242);
-        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
-            mf.when(() -> MediaAssetFactory.load(4242, sh)).thenReturn(null);
-            assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-                "parent load returns null -> omit");
-        }
-    }
-
-    @Test void selectSafeDerivative_parentLoadThrows_omits() {
-        // A parent-load failure must omit this one id (fail-soft), never throw to fail the batch.
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        when(src.getParentId()).thenReturn(4242);
-        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
-            mf.when(() -> MediaAssetFactory.load(4242, sh)).thenThrow(new RuntimeException("pm down"));
-            assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-                "parent load failure -> omit (fail-soft)");
-        }
-    }
-
-    @Test void selectSafeDerivative_parentDerivativeNonUniformScale_omits() {
-        // src is a CROP (different aspect than the parent's full-frame derivative): 1000x1000 source vs
-        // 500x250 derivative => sx=0.5, sy=0.25 (non-uniform) => omit, to avoid a mis-scaled bbox.
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        when(src.getParentId()).thenReturn(4242);
-        when(src.getWidth()).thenReturn(1000.0);
-        when(src.getHeight()).thenReturn(1000.0);
-        MediaAsset original = mock(MediaAsset.class);
-        when(original.hasLabel("_original")).thenReturn(true);
-        MediaAsset master = child("_master", false);
-        when(master.getWidth()).thenReturn(500.0);
-        when(master.getHeight()).thenReturn(250.0);
-        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
-        when(original.findChildrenByLabel(sh, "_master")).thenReturn(masters);
-        try (MockedStatic<MediaAssetFactory> mf = mockStatic(MediaAssetFactory.class)) {
-            mf.when(() -> MediaAssetFactory.load(4242, sh)).thenReturn(original);
-            assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-                "non-uniform scale (cropped/transformed source) -> omit");
-        }
-    }
-
-    @Test void selectSafeDerivative_nullWhenChildrenExistButNoneMatchLabel() {
-        // findChildrenByLabel returns an empty list (not null) when children exist but labels don't match
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        when(src.findChildrenByLabel(sh, "_master")).thenReturn(new ArrayList<>());
-        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(new ArrayList<>());
-        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-            "empty child list (no matching labels) -> null");
-    }
-
-    @Test void selectSafeDerivative_skipsUrlMasterThenFallsBackToLocalMid() {
-        // URL-backed _master is skipped, then a local _mid is returned
-        Shepherd sh = mock(Shepherd.class);
-        MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
-        MediaAsset urlMaster = child("_master", true);
-        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(urlMaster);
-        when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
-        MediaAsset mid = child("_mid", false);
-        ArrayList<MediaAsset> mids = new ArrayList<>(); mids.add(mid);
-        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(mids);
-        assertSame(mid, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
-            "a non-local _master is skipped; falls back to the local _mid");
-    }
 
     /** Build a token-auth request mock; body comes from the ServletUtilities static mock. */
     private HttpServletRequest tokenRequest() {
@@ -410,41 +140,34 @@ class MediaResolveApiTest {
         }
     }
 
-    /** A fully-populated annotation whose 1000x1000 source has a 500x500 _master derivative. */
+    /** A resolvable annotation: source asset is LocalAssetStore 1000x1000, bbox [100,200,300,400],
+        and bestSafeAsset("master") returns a local, non-_original derivative with a webURL. */
     private Annotation fullAnnotation(String id, String encId, String indId) throws Exception {
         MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
         when(src.getWidth()).thenReturn(1000.0);
         when(src.getHeight()).thenReturn(1000.0);
-
         MediaAsset master = mock(MediaAsset.class);
-        when(master.getStore()).thenReturn(mock(LocalAssetStore.class));
-        ArrayList<String> labels = new ArrayList<>(); labels.add("_master");
-        when(master.getLabels()).thenReturn(labels);
-        when(master.hasLabel("_master")).thenReturn(true);
+        when(master.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
         when(master.hasLabel("_original")).thenReturn(false);
-        when(master.getWidth()).thenReturn(500.0);
-        when(master.getHeight()).thenReturn(500.0);
-        when(master.webURL()).thenReturn(new URL("https://h/wildbook_data_dir/x/" + id + "-master.jpg"));
-        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
-
+        when(master.webURL()).thenReturn(new java.net.URL("https://h/wildbook_data_dir/x/" + id + "-master.jpg"));
+        when(src.bestSafeAsset(any(Shepherd.class), isNull(), eq("master"))).thenReturn(master);
         Annotation ann = mock(Annotation.class);
         when(ann.getId()).thenReturn(id);
         when(ann.getMediaAsset()).thenReturn(src);
-        when(src.findChildrenByLabel(any(Shepherd.class), eq("_master"))).thenReturn(masters);
         when(ann.getBbox()).thenReturn(new int[] {100, 200, 300, 400});
         when(ann.getTheta()).thenReturn(0.0);
         when(ann.getViewpoint()).thenReturn("up");
         Encounter enc = mock(Encounter.class);
         when(enc.getId()).thenReturn(encId);
-        when(enc.hasMarkedIndividual()).thenReturn(indId != null && !indId.isEmpty());
+        when(enc.hasMarkedIndividual()).thenReturn(true);
         when(enc.getIndividualID()).thenReturn(indId);
         when(ann.findEncounter(any(Shepherd.class))).thenReturn(enc);
         when(ann.getEmbeddings()).thenReturn(null);
         return ann;
     }
 
-    @Test void resolve_payload_scaledBbox_and_derivativeUrl() throws Exception {
+    @Test void resolve_payload_sourceFrameBbox_and_derivativeUrl() throws Exception {
         Annotation ann = fullAnnotation("ann-A", "enc-A", "ind-A");
         HttpServletRequest request = tokenRequest();
         HttpServletResponse resp = mock(HttpServletResponse.class);
@@ -469,12 +192,11 @@ class MediaResolveApiTest {
         assertEquals(1, arr.length(), "one entry resolved");
         JSONObject e = arr.getJSONObject(0);
         assertEquals("ann-A", e.getString("id"), "id echoed");
-        assertTrue(e.getString("imageUrl").endsWith("-master.jpg"), "serves the _master derivative url");
-        assertEquals(500, e.getInt("imageWidth"), "imageWidth is the derivative width");
-        assertEquals(500, e.getInt("imageHeight"), "imageHeight is the derivative height");
-        // src 1000x1000 -> dst 500x500 is 0.5x: [100,200,300,400] -> [50,100,150,200]
-        assertEquals("[50,100,150,200]", e.getJSONArray("bbox").toString(),
-            "bbox scaled into derivative pixel space, not raw source coords");
+        assertTrue(e.getString("imageUrl").endsWith("-master.jpg"), "serves the safeURL master derivative");
+        assertEquals(1000, e.getInt("imageWidth"), "imageWidth is the annotation asset width");
+        assertEquals(1000, e.getInt("imageHeight"), "imageHeight is the annotation asset height");
+        assertEquals("[100,200,300,400]", e.getJSONArray("bbox").toString(),
+            "bbox is returned in the source coordinate space (no server-side scaling)");
         assertEquals("up", e.getString("viewpoint"), "viewpoint passed through");
         assertEquals("enc-A", e.getString("encounterId"), "first-parent encounter id");
         assertEquals("ind-A", e.getString("individualId"), "individual id");
@@ -702,31 +424,17 @@ class MediaResolveApiTest {
             "gate query must include the Spec A annotation ACL filter; was: " + q);
     }
 
-    @Test void resolve_webUrlThrows_omitsEntryNot500() throws Exception {
-        // A visible annotation whose derivative webURL() throws (corrupt LocalAssetStore params)
-        // must be omitted (fail-closed), not turn the whole batch into a 500.
+    @Test void resolve_safeUrlThrows_omitsEntryNot500() throws Exception {
         MediaAsset src = mock(MediaAsset.class);
-        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
         when(src.getWidth()).thenReturn(1000.0);
         when(src.getHeight()).thenReturn(1000.0);
-        MediaAsset master = mock(MediaAsset.class);
-        when(master.getStore()).thenReturn(mock(LocalAssetStore.class));
-        ArrayList<String> labels = new ArrayList<>(); labels.add("_master");
-        when(master.getLabels()).thenReturn(labels);
-        when(master.hasLabel("_master")).thenReturn(true);
-        when(master.hasLabel("_original")).thenReturn(false);
-        when(master.getWidth()).thenReturn(500.0);
-        when(master.getHeight()).thenReturn(500.0);
-        when(master.webURL()).thenThrow(new IllegalArgumentException("corrupt path"));
-        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
+        when(src.bestSafeAsset(any(Shepherd.class), isNull(), anyString()))
+            .thenThrow(new IllegalArgumentException("corrupt path"));
         Annotation ann = mock(Annotation.class);
         when(ann.getId()).thenReturn("ann-x");
         when(ann.getMediaAsset()).thenReturn(src);
-        when(src.findChildrenByLabel(any(Shepherd.class), eq("_master"))).thenReturn(masters);
-        when(ann.getBbox()).thenReturn(new int[] {100, 200, 300, 400});
-        when(ann.getTheta()).thenReturn(0.0);
-        when(ann.getViewpoint()).thenReturn("up");
-
+        when(ann.getBbox()).thenReturn(new int[] {10, 10, 100, 100});
         HttpServletRequest request = tokenRequest();
         HttpServletResponse resp = mock(HttpServletResponse.class);
         StringWriter out = new StringWriter();
@@ -747,7 +455,7 @@ class MediaResolveApiTest {
         }
         verify(resp).setStatus(200);
         assertEquals(0, new JSONArray(out.toString()).length(),
-            "an annotation whose webURL() throws is omitted; the batch still returns 200");
+            "an annotation whose safeURL lookup throws is omitted; batch still 200");
     }
 
     @Test void resolve_emptyEncounterId_serializedAsNull() throws Exception {
@@ -775,5 +483,30 @@ class MediaResolveApiTest {
         }
         JSONObject e = new JSONArray(out.toString()).getJSONObject(0);
         assertTrue(e.isNull("encounterId"), "empty encounter id serialized as JSON null");
+    }
+
+    @Test void resolve_nullBbox_omits() throws Exception {
+        Annotation ann = fullAnnotation("ann-nb", "enc-nb", "ind-nb");
+        when(ann.getBbox()).thenReturn(null);
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin");
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-nb")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-nb")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(200);
+        assertEquals(0, new JSONArray(out.toString()).length(), "null bbox -> omit");
     }
 }

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -148,6 +148,7 @@ class MediaResolveApiTest {
         when(src.getWidth()).thenReturn(1000.0);
         when(src.getHeight()).thenReturn(1000.0);
         when(src.hasLabel("_original")).thenReturn(false);
+        when(src.getParentId()).thenReturn(7); // a child derivative -> served directly (the bbox frame)
         when(src.webURL()).thenReturn(new java.net.URL("https://h/wildbook_data_dir/x/" + id + "-master.jpg"));
         Annotation ann = mock(Annotation.class);
         when(ann.getId()).thenReturn(id);
@@ -427,6 +428,7 @@ class MediaResolveApiTest {
         when(src.getWidth()).thenReturn(1000.0);
         when(src.getHeight()).thenReturn(1000.0);
         when(src.hasLabel("_original")).thenReturn(false);
+        when(src.getParentId()).thenReturn(7); // child -> takes the direct webURL path
         when(src.webURL()).thenThrow(new IllegalArgumentException("corrupt path"));
         Annotation ann = mock(Annotation.class);
         when(ann.getId()).thenReturn("ann-x");
@@ -552,6 +554,56 @@ class MediaResolveApiTest {
             "_original is served via a _master child, not directly");
         assertEquals(1000, arr.getJSONObject(0).getInt("imageWidth"),
             "reported dims are the source (original) frame; consumer scales to the served master");
+    }
+
+    @Test void resolve_unlabeledRawRoot_maskedViaMasterChild() throws Exception {
+        // A raw root identified by tree position (no parent) even WITHOUT an _original label must NOT
+        // be served directly (some import paths create unlabeled raw roots). Serve a _master child.
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
+        when(src.getWidth()).thenReturn(1000.0);
+        when(src.getHeight()).thenReturn(1000.0);
+        when(src.hasLabel("_original")).thenReturn(false); // unlabeled...
+        when(src.getParentId()).thenReturn(null);          // ...but a ROOT (no parent) => raw upload
+        when(src.webURL()).thenReturn(new java.net.URL("https://h/wildbook_data_dir/x/RAW-original.jpg"));
+        MediaAsset master = mock(MediaAsset.class);
+        when(master.getStore()).thenReturn(mock(org.ecocean.media.LocalAssetStore.class));
+        when(master.hasLabel("_original")).thenReturn(false);
+        when(master.webURL()).thenReturn(new java.net.URL("https://h/wildbook_data_dir/x/safe-master.jpg"));
+        when(src.bestSafeAsset(any(Shepherd.class), isNull(), eq("master"))).thenReturn(master);
+        Annotation ann = mock(Annotation.class);
+        when(ann.getId()).thenReturn("ann-rr");
+        when(ann.getMediaAsset()).thenReturn(src);
+        when(ann.getBbox()).thenReturn(new int[] {0, 0, 400, 400});
+        when(ann.getTheta()).thenReturn(0.0);
+        when(ann.getViewpoint()).thenReturn("up");
+        Encounter enc = mock(Encounter.class);
+        when(enc.getId()).thenReturn("enc-rr");
+        when(ann.findEncounter(any(Shepherd.class))).thenReturn(enc);
+        when(ann.getEmbeddings()).thenReturn(null);
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin");
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-rr")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-rr")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(1, arr.length(), "unlabeled raw root resolves via its master child");
+        String url = arr.getJSONObject(0).getString("imageUrl");
+        assertTrue(url.endsWith("safe-master.jpg"), "served the masked _master child");
+        assertFalse(url.contains("RAW-original"), "must NOT serve the unmasked raw root directly");
     }
 
     @Test void resolve_negativeOriginBbox_clampsCorner() throws Exception {

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -149,4 +149,30 @@ class MediaResolveApiTest {
         assertSame(mid, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
             "a _master child also labeled _original is skipped; falls back to _mid");
     }
+
+    @Test void selectSafeDerivative_nullWhenChildrenExistButNoneMatchLabel() {
+        // findChildrenByLabel returns an empty list (not null) when children exist but labels don't match
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(new ArrayList<>());
+        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(new ArrayList<>());
+        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "empty child list (no matching labels) -> null");
+    }
+
+    @Test void selectSafeDerivative_skipsUrlMasterThenFallsBackToLocalMid() {
+        // URL-backed _master is skipped, then a local _mid is returned
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        MediaAsset urlMaster = child("_master", true);
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(urlMaster);
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
+        MediaAsset mid = child("_mid", false);
+        ArrayList<MediaAsset> mids = new ArrayList<>(); mids.add(mid);
+        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(mids);
+        assertSame(mid, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "a non-local _master is skipped; falls back to the local _mid");
+    }
 }

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -1,7 +1,15 @@
 package org.ecocean.api;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
+import org.ecocean.Annotation;
+import org.ecocean.media.MediaAsset;
+import org.ecocean.media.URLAssetStore;
+import org.ecocean.media.YouTubeAssetStore;
+import org.ecocean.media.LocalAssetStore;
+import org.ecocean.shepherd.core.Shepherd;
 import org.junit.jupiter.api.Test;
 
 class MediaResolveApiTest {
@@ -48,5 +56,97 @@ class MediaResolveApiTest {
     @Test void scaleBbox_nullWhenScaledRegionVanishes() {
         int[] out = MediaResolveApi.scaleBbox(new int[] {0, 0, 1, 1}, 10000, 10000, 5, 5);
         assertNull(out, "a region that rounds to <1px in the derivative -> null (omit)");
+    }
+
+    private MediaAsset child(String label, boolean urlStore) {
+        MediaAsset ma = mock(MediaAsset.class);
+        ArrayList<String> labels = new ArrayList<>();
+        labels.add(label);
+        when(ma.getLabels()).thenReturn(labels);
+        when(ma.hasLabel(label)).thenReturn(true);
+        when(ma.getStore()).thenReturn(urlStore ? mock(URLAssetStore.class) : mock(LocalAssetStore.class));
+        return ma;
+    }
+
+    private Annotation annWithSource(MediaAsset src) {
+        Annotation ann = mock(Annotation.class);
+        when(ann.getMediaAsset()).thenReturn(src);
+        return ann;
+    }
+
+    @Test void selectSafeDerivative_prefersMaster() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        MediaAsset master = child("_master", false);
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(master);
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
+        MediaAsset out = MediaResolveApi.selectSafeDerivative(annWithSource(src), sh);
+        assertSame(master, out, "a _master child must be selected first");
+    }
+
+    @Test void selectSafeDerivative_fallsBackToMidWhenNoMaster() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(null);
+        MediaAsset mid = child("_mid", false);
+        ArrayList<MediaAsset> mids = new ArrayList<>(); mids.add(mid);
+        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(mids);
+        MediaAsset out = MediaResolveApi.selectSafeDerivative(annWithSource(src), sh);
+        assertSame(mid, out, "must fall back to _mid when _master is absent (bestSafeAsset bug bypassed)");
+    }
+
+    @Test void selectSafeDerivative_nullWhenNoSafeDerivative() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(null);
+        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(null);
+        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "no _master/_mid -> null (omit)");
+    }
+
+    @Test void selectSafeDerivative_rejectsUrlAssetStoreSource() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(URLAssetStore.class));
+        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "URLAssetStore source (external original) must be rejected");
+    }
+
+    @Test void selectSafeDerivative_skipsUrlStoreChildren() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        MediaAsset urlChild = child("_master", true); // _master label but URLAssetStore
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(urlChild);
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
+        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(null);
+        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "a non-local (URLAssetStore) child must be skipped");
+    }
+
+    @Test void selectSafeDerivative_rejectsYouTubeStoreSource() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(YouTubeAssetStore.class));
+        assertNull(MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "YouTubeAssetStore source (webURL is a watch page, not image bytes) must be rejected");
+    }
+
+    @Test void selectSafeDerivative_skipsMasterAlsoLabeledOriginal_fallsBackToMid() {
+        Shepherd sh = mock(Shepherd.class);
+        MediaAsset src = mock(MediaAsset.class);
+        when(src.getStore()).thenReturn(mock(LocalAssetStore.class));
+        MediaAsset masterButOriginal = child("_master", false);
+        when(masterButOriginal.hasLabel("_original")).thenReturn(true); // also carries _original
+        ArrayList<MediaAsset> masters = new ArrayList<>(); masters.add(masterButOriginal);
+        when(src.findChildrenByLabel(sh, "_master")).thenReturn(masters);
+        MediaAsset mid = child("_mid", false);
+        ArrayList<MediaAsset> mids = new ArrayList<>(); mids.add(mid);
+        when(src.findChildrenByLabel(sh, "_mid")).thenReturn(mids);
+        assertSame(mid, MediaResolveApi.selectSafeDerivative(annWithSource(src), sh),
+            "a _master child also labeled _original is skipped; falls back to _mid");
     }
 }

--- a/src/test/java/org/ecocean/api/SearchApiChildIndexTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiChildIndexTest.java
@@ -174,6 +174,52 @@ class SearchApiChildIndexTest {
         verify(response).setStatus(200);
     }
 
+    // token POST /individual (non-admin), identity query but a DISALLOWED url sort param
+    // -> 400 and queryPit is NEVER called (sort applied by queryPit, validated up-front).
+    @Test void tokenIndividualSearch_disallowedUrlSort_returns400() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/individual");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        when(request.getParameter("sort")).thenReturn("numberEncounters");
+        // body is identity-only (default match_all), so only the sort param is offending
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenReturn(EMPTY_HITS);
+            })) {
+            new SearchApi().doPost(request, response);
+            for (OpenSearch m : os.constructed()) {
+                verify(m, never()).queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any());
+            }
+        }
+        verify(response).setStatus(400);
+        assertTrue(out.toString().contains("identity fields"),
+            "rejection mentions identity-field restriction");
+    }
+
+    // token POST /individual (non-admin), identity query + ALLOWLISTED url sort -> allowed, 200.
+    @Test void tokenIndividualSearch_identityUrlSort_ok() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/individual");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        when(request.getParameter("sort")).thenReturn("names");
+        su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+            .thenReturn(new JSONObject("{\"query\":{\"term\":{\"sex\":\"female\"}}}"));
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenReturn(EMPTY_HITS);
+            })) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+    }
+
     // token POST /occurrence -> still 403
     @Test void tokenOccurrenceSearch_returns403() throws Exception {
         when(request.getMethod()).thenReturn("POST");

--- a/src/test/java/org/ecocean/api/SearchApiChildIndexTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiChildIndexTest.java
@@ -129,6 +129,51 @@ class SearchApiChildIndexTest {
         verify(response).setStatus(200);
     }
 
+    // token POST /individual (non-admin) with a query referencing a hidden aggregate field
+    // -> 400 and queryPit is NEVER called (rejected before execution).
+    @Test void tokenIndividualSearch_disallowedQueryField_returns400() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/individual");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+            .thenReturn(new JSONObject("{\"query\":{\"range\":{\"numberEncounters\":{\"gte\":1}}}}"));
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenReturn(EMPTY_HITS);
+            })) {
+            new SearchApi().doPost(request, response);
+            for (OpenSearch m : os.constructed()) {
+                verify(m, never()).queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any());
+            }
+        }
+        verify(response).setStatus(400);
+        assertTrue(out.toString().contains("identity fields"),
+            "rejection mentions identity-field restriction");
+    }
+
+    // token POST /individual (non-admin) querying an identity field -> allowed, 200.
+    @Test void tokenIndividualSearch_identityQueryField_ok() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/individual");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+            .thenReturn(new JSONObject("{\"query\":{\"term\":{\"sex\":\"female\"}}}"));
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenReturn(EMPTY_HITS);
+            })) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+    }
+
     // token POST /occurrence -> still 403
     @Test void tokenOccurrenceSearch_returns403() throws Exception {
         when(request.getMethod()).thenReturn("POST");

--- a/src/test/java/org/ecocean/api/SearchApiChildIndexTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiChildIndexTest.java
@@ -1,0 +1,211 @@
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.ecocean.OpenSearch;
+import org.ecocean.User;
+import org.ecocean.security.WildbookTokenAuthenticationFilter;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+class SearchApiChildIndexTest {
+
+    HttpServletRequest request;
+    HttpServletResponse response;
+    StringWriter out;
+    MockedStatic<ServletUtilities> su;
+
+    @BeforeEach void setUp() throws Exception {
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        out = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(out));
+        when(request.getServletContext()).thenReturn(null);
+        when(request.getContextPath()).thenReturn("");
+        when(request.getParameter(anyString())).thenReturn(null);
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(Boolean.TRUE); // default: token request (override per-test where needed)
+        su = mockStatic(ServletUtilities.class);
+        su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+        su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+            .thenReturn(new JSONObject("{\"query\":{\"match_all\":{}}}"));
+    }
+
+    @AfterEach void tearDown() {
+        su.close();
+    }
+
+    private User mockUser(String id, boolean admin) {
+        User u = mock(User.class);
+        when(u.getId()).thenReturn(id);
+        when(u.getUUID()).thenReturn(id); // queryStore reads getUUID(); == getId() in source
+        return u;
+    }
+
+    /** Shepherd mock with the standard tx stubs + a resolved user. */
+    private MockedConstruction<Shepherd> shepherdReturning(User user, boolean admin) {
+        return mockConstruction(Shepherd.class, (m, c) -> {
+            doNothing().when(m).beginDBTransaction();
+            doNothing().when(m).setAction(anyString());
+            doNothing().when(m).rollbackAndClose();
+            when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
+            when(user.isAdmin(m)).thenReturn(admin);
+        });
+    }
+
+    private static final JSONObject EMPTY_HITS =
+        new JSONObject("{\"hits\":{\"total\":{\"value\":0},\"hits\":[]}}");
+
+    /** True if the query has a bool.filter whose acl should-clause carries a term on the given field. */
+    private static boolean filterShouldHasTerm(JSONObject q, String field) {
+        JSONArray filter = q.getJSONObject("query").getJSONObject("bool").getJSONArray("filter");
+        for (int i = 0; i < filter.length(); i++) {
+            JSONArray should = filter.getJSONObject(i).getJSONObject("bool").optJSONArray("should");
+            if (should == null) continue;
+            for (int j = 0; j < should.length(); j++) {
+                JSONObject term = should.getJSONObject(j).optJSONObject("term");
+                if ((term != null) && term.has(field)) return true;
+            }
+        }
+        return false;
+    }
+
+    // token POST /individual (non-admin) -> allowed; ACL filter uses submitterUserIds; status 200
+    @Test void tokenIndividualSearch_injectsSubmitterUserIdsFilter() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/individual");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenAnswer(inv -> {
+                        JSONObject q = inv.getArgument(1);
+                        assertTrue(q.getJSONObject("query").getJSONObject("bool").has("filter"),
+                            "ACL filter injected before queryPit");
+                        assertTrue(filterShouldHasTerm(q, "submitterUserIds"),
+                            "individual ACL should-clause uses submitterUserIds");
+                        return EMPTY_HITS;
+                    });
+            })) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+    }
+
+    // token POST /annotation (non-admin) -> allowed, filter applied -> 200
+    @Test void tokenAnnotationSearch_allowedAndFiltered() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/annotation");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenAnswer(inv -> {
+                        JSONObject q = inv.getArgument(1);
+                        assertTrue(q.getJSONObject("query").getJSONObject("bool").has("filter"),
+                            "annotation ACL filter injected before queryPit");
+                        return EMPTY_HITS;
+                    });
+            })) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+    }
+
+    // token POST /occurrence -> still 403
+    @Test void tokenOccurrenceSearch_returns403() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/occurrence");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(403);
+    }
+
+    // session (non-token) POST /individual, non-admin -> NOT blocked by token gate (proceeds to 200)
+    @Test void sessionIndividualSearch_notBlocked() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/individual");
+        when(request.getHeader("Authorization")).thenReturn(null); // no bearer
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null); // not a token request
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenReturn(EMPTY_HITS);
+            })) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+    }
+
+    // session annotation, non-admin -> still 403 (admin-only on session path)
+    @Test void sessionAnnotationSearch_nonAdmin_403() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/annotation");
+        when(request.getHeader("Authorization")).thenReturn(null); // no bearer
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null); // not a token request
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(403);
+    }
+
+    // a stored query that fails to load -> 404 "invalid searchQueryId" (NOT "unknown index")
+    @Test void storedQueryMissing_returns404InvalidId() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class)) {
+            osStatic.when(() -> OpenSearch.queryLoad(anyString())).thenReturn(null);
+            osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(true);
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(404);
+        assertTrue(out.toString().contains("invalid searchQueryId"),
+            "missing stored query returns invalid searchQueryId, not unknown index");
+    }
+
+    // token stored query owned by someone else whose indexName is invalid -> 403 owner, NOT 404
+    @Test void tokenStoredQuery_otherOwnerInvalidIndex_returns403() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class)) {
+            osStatic.when(() -> OpenSearch.queryLoad(anyString())).thenReturn(
+                new JSONObject().put("creator", "someoneElse").put("indexName", "bogus")
+                    .put("query", new JSONObject().put("match_all", new JSONObject())));
+            osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(false);
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(403);
+        verify(response, never()).setStatus(404);
+    }
+}

--- a/src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java
@@ -70,9 +70,10 @@ class SearchApiTokenAuthTest {
     private static final JSONObject EMPTY_HITS =
         new JSONObject("{\"hits\":{\"total\":{\"value\":0},\"hits\":[]}}");
 
-    @Test void tokenRequest_nonEncounterIndex_returns403() throws Exception {
+    @Test void tokenRequest_nonAllowlistedIndex_returns403() throws Exception {
+        // token index allowlist is {encounter, annotation, individual}; occurrence is outside it
         when(request.getMethod()).thenReturn("POST");
-        when(request.getPathInfo()).thenReturn("/individual");
+        when(request.getPathInfo()).thenReturn("/occurrence");
         when(request.getHeader("Authorization")).thenReturn("Bearer x");
         User user = mockUser("u1", false);
         try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false)) {
@@ -175,16 +176,16 @@ class SearchApiTokenAuthTest {
         verify(response).setStatus(403);
     }
 
-    @Test void storedQuery_nonEncounterIndex_returns403() throws Exception {
+    @Test void storedQuery_nonAllowlistedIndex_returns403() throws Exception {
         when(request.getMethod()).thenReturn("GET");
         when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
         when(request.getHeader("Authorization")).thenReturn("Bearer x");
         User user = mockUser("u1", false);
         try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
-            MockedStatic<OpenSearch> osStatic = storedQuery("individual", "u1")) {
+            MockedStatic<OpenSearch> osStatic = storedQuery("occurrence", "u1")) {
             new SearchApi().doPost(request, response);
         }
-        verify(response).setStatus(403); // own query, but wrong index
+        verify(response).setStatus(403); // own query, but index outside the token allowlist
     }
 
     @Test void storedQuery_postMethod_returns405() throws Exception {
@@ -270,7 +271,7 @@ class SearchApiTokenAuthTest {
             });
             osStatic.when(() -> OpenSearch.querySanitize(any(), any(), any()))
                 .thenAnswer(inv -> inv.getArgument(0));
-            osStatic.when(() -> OpenSearch.applyEncounterAclFilter(any(), anyString()))
+            osStatic.when(() -> OpenSearch.applyAclFilter(any(), anyString(), anyString()))
                 .thenCallRealMethod();
             new SearchApi().doPost(request, response);
         }

--- a/src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java
@@ -226,6 +226,26 @@ class SearchApiTokenAuthTest {
         verify(response).setStatus(405);
     }
 
+    @Test void sessionRequest_nonEncounterIndex_notBlockedByTokenGate() throws Exception {
+        // non-token (session) request: no Bearer, no token marker -> all tokenAuth gates skip,
+        // and the encounter-only index gate must NOT apply. /individual proceeds to execution.
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/individual");
+        when(request.getHeader("Authorization")).thenReturn(null); // no bearer
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null); // not a token request
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenReturn(EMPTY_HITS);
+            })) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200); // session path unaffected by token gates
+    }
+
     @Test void storedQuery_ownEncounter_succeeds() throws Exception {
         when(request.getMethod()).thenReturn("GET");
         when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");

--- a/src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java
@@ -1,0 +1,259 @@
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.ecocean.OpenSearch;
+import org.ecocean.User;
+import org.ecocean.security.WildbookTokenAuthenticationFilter;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+class SearchApiTokenAuthTest {
+
+    HttpServletRequest request;
+    HttpServletResponse response;
+    StringWriter out;
+    // getContext() on a Mockito request would NPE (reads serverName/cookies/context props);
+    // stub it for ALL tests. jsonFromHttpServletRequest is stubbed per-test as needed.
+    MockedStatic<ServletUtilities> su;
+
+    @BeforeEach void setUp() throws Exception {
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        out = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(out));
+        when(request.getServletContext()).thenReturn(null);
+        when(request.getContextPath()).thenReturn("");
+        when(request.getParameter(anyString())).thenReturn(null);
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(Boolean.TRUE); // default: token request (override per-test where needed)
+        su = mockStatic(ServletUtilities.class);
+        su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+        su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+            .thenReturn(new JSONObject("{\"query\":{\"match_all\":{}}}"));
+    }
+
+    @AfterEach void tearDown() {
+        su.close();
+    }
+
+    private User mockUser(String id, boolean admin) {
+        User u = mock(User.class);
+        when(u.getId()).thenReturn(id);
+        when(u.getUUID()).thenReturn(id); // queryStore reads getUUID(); == getId() in source
+        return u;
+    }
+
+    /** Shepherd mock with the standard tx stubs + a resolved user. */
+    private MockedConstruction<Shepherd> shepherdReturning(User user, boolean admin) {
+        return mockConstruction(Shepherd.class, (m, c) -> {
+            doNothing().when(m).beginDBTransaction();
+            doNothing().when(m).setAction(anyString());
+            doNothing().when(m).rollbackAndClose();
+            when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
+            when(user.isAdmin(m)).thenReturn(admin);
+        });
+    }
+
+    private static final JSONObject EMPTY_HITS =
+        new JSONObject("{\"hits\":{\"total\":{\"value\":0},\"hits\":[]}}");
+
+    @Test void tokenRequest_nonEncounterIndex_returns403() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/individual");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(403);
+    }
+
+    @Test void bearerWithoutMarker_returns401() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null); // filter did NOT mark it
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(401);
+    }
+
+    @Test void lowercaseBearerWithoutMarker_returns401() throws Exception {
+        // case-insensitive bearerPresent: "bearer ..." with no marker must still fail closed
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("bearer x");
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null);
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(401);
+    }
+
+    @Test void tokenEncounterSearch_injectsAclFilterBeforeExecution() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenAnswer(inv -> {
+                        JSONObject q = inv.getArgument(1);
+                        JSONObject bool = q.getJSONObject("query").getJSONObject("bool");
+                        assertTrue(bool.has("filter"), "ACL filter injected before queryPit");
+                        return EMPTY_HITS;
+                    });
+            })) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+    }
+
+    @Test void adminTokenEncounterSearch_doesNotInjectAclFilter() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("admin1", true);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, true);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenAnswer(inv -> {
+                        JSONObject q = inv.getArgument(1);
+                        JSONObject inner = q.getJSONObject("query");
+                        assertFalse(inner.has("bool") && inner.getJSONObject("bool").has("filter"),
+                            "admin token must NOT have an injected ACL filter");
+                        return EMPTY_HITS;
+                    });
+            })) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+    }
+
+    // ---- stored-query gating (token path) ----
+
+    /** Stub OpenSearch.queryLoad to return a stored-query doc (with indexName + creator). */
+    private MockedStatic<OpenSearch> storedQuery(String indexName, String creator) {
+        MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class);
+        osStatic.when(() -> OpenSearch.queryLoad(anyString())).thenReturn(
+            new JSONObject().put("indexName", indexName).put("creator", creator)
+                .put("query", new JSONObject().put("match_all", new JSONObject())));
+        osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(true);
+        return osStatic;
+    }
+
+    @Test void storedQuery_otherOwner_returns403() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = storedQuery("encounter", "someoneElse")) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(403);
+    }
+
+    @Test void storedQuery_nonEncounterIndex_returns403() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = storedQuery("individual", "u1")) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(403); // own query, but wrong index
+    }
+
+    @Test void storedQuery_postMethod_returns405() throws Exception {
+        // token stored-query replay is GET-only
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = storedQuery("encounter", "u1")) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(405);
+    }
+
+    @Test void storedQuery_postOtherOwner_is405NotOwnership403() throws Exception {
+        // method gate fires FIRST: wrong method must not leak ownership via a 403
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = storedQuery("encounter", "someoneElse")) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(405);
+        verify(response, never()).setStatus(403);
+    }
+
+    @Test void directIndex_getMethod_returns405() throws Exception {
+        // token direct index search is POST-only; a GET to /encounter must be 405
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(405);
+    }
+
+    @Test void storedQuery_ownEncounter_succeeds() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn("/11111111-1111-1111-1111-111111111111");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = storedQuery("encounter", "u1");
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenAnswer(inv -> {
+                        JSONObject q = inv.getArgument(1);
+                        assertTrue(q.getJSONObject("query").getJSONObject("bool").has("filter"),
+                            "own stored encounter query is ACL-scoped before execution");
+                        return EMPTY_HITS;
+                    });
+            })) {
+            // queryScrubStored is static too; stub it to extract the inner query
+            osStatic.when(() -> OpenSearch.queryScrubStored(any())).thenAnswer(inv -> {
+                JSONObject stored = inv.getArgument(0);
+                return new JSONObject().put("query", stored.optJSONObject("query"));
+            });
+            osStatic.when(() -> OpenSearch.querySanitize(any(), any(), any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+            osStatic.when(() -> OpenSearch.applyEncounterAclFilter(any(), anyString()))
+                .thenCallRealMethod();
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+    }
+}

--- a/src/test/java/org/ecocean/api/SearchTokenScopeChildIndexTest.java
+++ b/src/test/java/org/ecocean/api/SearchTokenScopeChildIndexTest.java
@@ -1,0 +1,396 @@
+package org.ecocean.api;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+
+import java.net.InetSocketAddress;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.servlet.DispatcherType;
+
+import org.apache.http.HttpHost;
+import org.apache.shiro.web.servlet.IniShiroFilter;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.ecocean.CommonConfiguration;
+import org.ecocean.OpenSearch;
+import org.ecocean.Role;
+import org.ecocean.User;
+import org.ecocean.api.auth.JwtService;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end enforcement test for the token-scoped ANNOTATION + INDIVIDUAL child-index search paths.
+ *
+ * Companion to {@link SearchTokenScopeTest} (which covers the encounter index). Boots the same
+ * harness shape: embedded Jetty + Shiro ({@code WildbookTokenAuthenticationFilter} wired onto
+ * {@code /api/v3/search/**} via the shared test {@code shiro.ini}), a real OpenSearch container,
+ * and a real PostgreSQL container. Seeds encounter, annotation and individual docs directly into
+ * OpenSearch using the REAL production mappings, plus real {@link User}/{@link Role} rows, then
+ * asserts:
+ *
+ * <ul>
+ *   <li>a non-admin token sees only annotations whose denormalized parent ACL it can satisfy
+ *       (publiclyReadable / submitterUserIds / viewUsers), with the ACL fields scrubbed,</li>
+ *   <li>a non-admin token sees only individuals with at least one visible encounter (via the
+ *       denormalized ACL union), and the returned doc is an identity-only allowlist (aggregates
+ *       such as numberEncounters / users / encounterIds are dropped),</li>
+ *   <li>an admin token is unscoped (sees both individuals) but the ACL fields are still scrubbed,</li>
+ *   <li>a token to the occurrence index is 403 (not in the token allowlist).</li>
+ * </ul>
+ *
+ * The JWT keypair is generated in {@code @BeforeAll} and published to CommonConfiguration so the
+ * production filter (which loads keys via {@code JwtService.fromConfig("context0")}) and the test
+ * signer share the same keys.
+ */
+@Testcontainers public class SearchTokenScopeChildIndexTest {
+
+    @Container static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
+        "postgres:15-alpine")
+            .withDatabaseName("wildbook_test")
+            .withUsername("wildbook")
+            .withPassword("wildbook");
+
+    @Container static GenericContainer<?> opensearch = new GenericContainer<>(DockerImageName.parse(
+        "opensearchproject/opensearch:3.1.0"))
+            .withExposedPorts(9200, 9300)
+            .withEnv("discovery.type", "single-node")
+            .withEnv("plugins.security.disabled", "true")
+            .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m")
+            .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")
+            .waitingFor(new HttpWaitStrategy()
+            .forPort(9200)
+            .forPath("/_cluster/health")
+            .forStatusCode(200)
+            .withStartupTimeout(java.time.Duration.ofMinutes(2)));
+
+    private static JwtService testJwtService;
+    private static String aliceUuid;
+    private static String adminUuid;
+    private static String bobUuid;
+
+    @BeforeAll static void setUp() throws Exception {
+        System.out.println("=== Starting SearchTokenScopeChildIndexTest Setup ===");
+
+        // --- JWT keypair: shared by filter (via config) + test signer ---
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()); // PKCS8
+        String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());   // X.509
+
+        Properties commonConfiguration = new Properties();
+        commonConfiguration.setProperty("collaborationSecurityEnabled", "true");
+        commonConfiguration.setProperty("releaseDateFormat", "yyyy-MM-dd");
+        commonConfiguration.setProperty("htmlTitle", "Unit Test");
+        commonConfiguration.setProperty("jwtPrivateKeyBase64", privB64);
+        commonConfiguration.setProperty("jwtPublicKeyBase64", pubB64);
+        commonConfiguration.setProperty("jwtIssuer", "wildbook");
+        commonConfiguration.setProperty("jwtAudience", "wildbook-scoped-api");
+        commonConfiguration.setProperty("jwtContext", "context0");
+        CommonConfiguration.initialize("context0", commonConfiguration);
+
+        testJwtService = JwtService.fromBase64Keys(privB64, pubB64, "wildbook",
+            "wildbook-scoped-api");
+
+        System.out.println("PostgreSQL started at: " + postgres.getJdbcUrl());
+        System.out.println("OpenSearch started at: " + getOpenSearchUrl());
+
+        // --- embedded Jetty + Shiro (shiro.ini wires tokenAuthSearch onto /api/v3/search/**) ---
+        Server server = new Server(new InetSocketAddress("localhost", 0));
+        ServletContextHandler ctx = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        ctx.setResourceBase("/tmp");
+
+        IniShiroFilter shiroFilter = new IniShiroFilter();
+        shiroFilter.setConfigPath("classpath:shiro.ini");
+        ctx.addFilter(new FilterHolder(shiroFilter), "/*", EnumSet.of(DispatcherType.REQUEST));
+
+        ctx.setContextPath("/");
+        ctx.addServlet(new ServletHolder(new SearchApi()), "/api/v3/search/*");
+        server.setHandler(ctx);
+        server.start();
+
+        int port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+        RestAssured.baseURI = "http://localhost";
+        RestAssured.port = port;
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+        OpenSearch.initializeClient(new HttpHost(opensearch.getHost(),
+            opensearch.getMappedPort(9200), "http"));
+
+        // seed users in Postgres + encounter/annotation/individual docs in OpenSearch
+        seedUsers();
+        seedDocs();
+
+        System.out.println("=== Setup Complete ===\n");
+    }
+
+    @AfterAll static void tearDown() {
+        System.out.println("=== Tearing Down SearchTokenScopeChildIndexTest ===");
+    }
+
+    // =========================================================================
+    // Seeding
+    // =========================================================================
+
+    private static void seedUsers() {
+        Properties properties = new Properties();
+        properties.setProperty("datanucleus.ConnectionUserName", postgres.getUsername());
+        properties.setProperty("datanucleus.ConnectionPassword", postgres.getPassword());
+        properties.setProperty("datanucleus.ConnectionDriverName", postgres.getDriverClassName());
+        properties.setProperty("datanucleus.ConnectionURL", postgres.getJdbcUrl());
+        properties.setProperty("datanucleus.schema.autoCreateTables", "true");
+
+        Shepherd myShepherd = new Shepherd("context0", properties);
+        myShepherd.setAction("SearchTokenScopeChildIndexTest.seedUsers");
+        try {
+            myShepherd.beginDBTransaction();
+
+            User alice = newUser("alice");
+            myShepherd.getPM().makePersistent(alice);
+
+            User adminUser = newUser("adminUser");
+            myShepherd.getPM().makePersistent(adminUser);
+            Role adminRole = new Role("adminUser", "admin");
+            adminRole.setContext("context0");
+            myShepherd.getPM().makePersistent(adminRole);
+
+            User bob = newUser("bob");
+            myShepherd.getPM().makePersistent(bob);
+
+            myShepherd.commitDBTransaction();
+
+            aliceUuid = alice.getId();
+            adminUuid = adminUser.getId();
+            bobUuid = bob.getId();
+            System.out.println("Seeded users: alice=" + aliceUuid + " admin=" + adminUuid
+                + " bob=" + bobUuid);
+        } catch (Exception e) {
+            myShepherd.rollbackDBTransaction();
+            throw new RuntimeException("Failed to seed users", e);
+        } finally {
+            myShepherd.closeDBTransaction();
+        }
+    }
+
+    private static User newUser(String username) {
+        String salt = ServletUtilities.getSalt().toHex();
+        String hashed = ServletUtilities.hashAndSaltPassword("password123", salt);
+        return new User(username, hashed, salt);
+    }
+
+    /**
+     * Create the encounter, annotation and individual indices with their REAL production mappings
+     * (so submitterUserId/submitterUserIds/viewUsers are keyword fields and the ACL term-queries
+     * match), then index docs carrying exactly the denormalized ACL fields the filter reads plus a
+     * few identity/aggregate fields. Refreshed before any search runs.
+     */
+    private static void seedDocs() throws Exception {
+        OpenSearch os = new OpenSearch();
+        os.ensureIndex("encounter", new org.ecocean.Encounter().opensearchMapping());
+        os.ensureIndex("annotation", new org.ecocean.Annotation().opensearchMapping());
+        os.ensureIndex("individual", new org.ecocean.MarkedIndividual().opensearchMapping());
+
+        // --- encounters (single submitterUserId) ---
+        // alice sees encA (submitter) + encB (viewUsers grant); NOT encC.
+        putDoc(os, "encounter", "encA", encDoc("encA", aliceUuid, false, new String[] {}));
+        putDoc(os, "encounter", "encB", encDoc("encB", bobUuid, false, new String[] { aliceUuid }));
+        putDoc(os, "encounter", "encC", encDoc("encC", bobUuid, false, new String[] {}));
+
+        // --- annotations (denormalized parent ACL: union set submitterUserIds) ---
+        // alice sees annA (her parent encA) + annB (parent encB grants her via viewUsers); NOT annC.
+        JSONObject annA = childAclDoc("annA", false, new String[] { aliceUuid }, new String[] {});
+        annA.put("encounterId", "encA");
+        annA.put("viewpoint", "left");
+        putDoc(os, "annotation", "annA", annA);
+
+        JSONObject annB = childAclDoc("annB", false, new String[] { bobUuid },
+            new String[] { aliceUuid });
+        annB.put("encounterId", "encB");
+        putDoc(os, "annotation", "annB", annB);
+
+        JSONObject annC = childAclDoc("annC", false, new String[] { bobUuid }, new String[] {});
+        annC.put("encounterId", "encC");
+        putDoc(os, "annotation", "annC", annC);
+
+        // --- individuals (denormalized ACL union over member encounters) ---
+        // indShared: alice satisfies via submitterUserIds + viewUsers. Carries aggregates that the
+        // token allowlist must strip.
+        JSONObject indShared = childAclDoc("indShared", false,
+            new String[] { aliceUuid, bobUuid }, new String[] { aliceUuid });
+        indShared.put("displayName", "Fluke");
+        indShared.put("sex", "female");
+        indShared.put("taxonomy", "Orcinus orca");
+        indShared.put("numberEncounters", 3);
+        indShared.put("users", new JSONArray().put(aliceUuid).put(bobUuid));
+        indShared.put("encounterIds",
+            new JSONArray().put("encA").put("encB").put("encC"));
+        putDoc(os, "individual", "indShared", indShared);
+
+        // indBobOnly: alice satisfies none of the ACL shoulds -> must not see it.
+        JSONObject indBob = childAclDoc("indBobOnly", false, new String[] { bobUuid },
+            new String[] {});
+        indBob.put("displayName", "BobWhale");
+        indBob.put("sex", "male");
+        putDoc(os, "individual", "indBobOnly", indBob);
+
+        os.getRestResponse(new org.opensearch.client.Request("POST", "/encounter/_refresh"));
+        os.getRestResponse(new org.opensearch.client.Request("POST", "/annotation/_refresh"));
+        os.getRestResponse(new org.opensearch.client.Request("POST", "/individual/_refresh"));
+        System.out.println("Seeded encounter/annotation/individual docs and refreshed indices");
+    }
+
+    /** Encounter ACL doc: single submitterUserId. */
+    private static JSONObject encDoc(String id, String submitterUserId, boolean publiclyReadable,
+        String[] viewUsers) {
+        JSONObject doc = new JSONObject();
+        doc.put("id", id);
+        doc.put("publiclyReadable", publiclyReadable);
+        doc.put("submitterUserId", submitterUserId);
+        doc.put("viewUsers", strArray(viewUsers));
+        return doc;
+    }
+
+    /** Child-index ACL doc: denormalized union set submitterUserIds + viewUsers. */
+    private static JSONObject childAclDoc(String id, boolean publiclyReadable,
+        String[] submitterUserIds, String[] viewUsers) {
+        JSONObject doc = new JSONObject();
+        doc.put("id", id);
+        doc.put("publiclyReadable", publiclyReadable);
+        doc.put("submitterUserIds", strArray(submitterUserIds));
+        doc.put("viewUsers", strArray(viewUsers));
+        return doc;
+    }
+
+    private static JSONArray strArray(String[] values) {
+        JSONArray arr = new JSONArray();
+        for (String v : values) arr.put(v);
+        return arr;
+    }
+
+    private static void putDoc(OpenSearch os, String index, String id, JSONObject doc)
+    throws Exception {
+        org.opensearch.client.Request req = new org.opensearch.client.Request("PUT",
+            "/" + index + "/_doc/" + id);
+        req.setJsonEntity(doc.toString());
+        os.getRestResponse(req);
+    }
+
+    private static String getOpenSearchUrl() {
+        return "http://" + opensearch.getHost() + ":" + opensearch.getMappedPort(9200);
+    }
+
+    private static Set<String> hitIds(Response r) {
+        JSONArray hits = new JSONObject(r.asString()).getJSONArray("hits");
+        Set<String> ids = new HashSet<>();
+        for (int i = 0; i < hits.length(); i++) ids.add(hits.getJSONObject(i).optString("id"));
+        return ids;
+    }
+
+    private static Response search(String userUuid, String index) {
+        String token = testJwtService.sign(userUuid, "context0", 60_000L);
+        return given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/" + index)
+            .then().log().ifValidationFails().extract().response();
+    }
+
+    // =========================================================================
+    // Tests
+    // =========================================================================
+
+    @Test void tokenAnnotationSearch_scopedToVisibleEncounters() throws Exception {
+        Response r = search(aliceUuid, "annotation");
+        assertEquals(200, r.statusCode(), "alice token annotation search OK");
+        Set<String> ids = hitIds(r);
+        assertTrue(ids.contains("annA"), "alice sees annotation on her own encounter");
+        assertTrue(ids.contains("annB"), "alice sees annotation on the viewUsers-granted encounter");
+        assertFalse(ids.contains("annC"), "alice must NOT see annotation on bob's private encounter");
+        assertEquals("2", r.header("X-Wildbook-Total-Hits"), "annotation total is query-time scoped");
+
+        // ACL fields must never leak in any hit
+        JSONArray hits = new JSONObject(r.asString()).getJSONArray("hits");
+        for (int i = 0; i < hits.length(); i++) {
+            JSONObject h = hits.getJSONObject(i);
+            assertFalse(h.has("publiclyReadable"), "publiclyReadable scrubbed from annotation hit");
+            assertFalse(h.has("submitterUserIds"), "submitterUserIds scrubbed from annotation hit");
+            assertFalse(h.has("viewUsers"), "viewUsers scrubbed from annotation hit");
+        }
+    }
+
+    @Test void tokenIndividualSearch_gatedAndAllowlisted() throws Exception {
+        Response r = search(aliceUuid, "individual");
+        assertEquals(200, r.statusCode(), "alice token individual search OK");
+        Set<String> ids = hitIds(r);
+        assertTrue(ids.contains("indShared"), "alice sees the shared individual (visible encounter)");
+        assertFalse(ids.contains("indBobOnly"), "alice must NOT see bob-only individual");
+        assertEquals("1", r.header("X-Wildbook-Total-Hits"), "individual total is query-time scoped");
+
+        JSONArray hits = new JSONObject(r.asString()).getJSONArray("hits");
+        JSONObject shared = hits.getJSONObject(0);
+        // allowlisted identity fields present
+        assertEquals("indShared", shared.optString("id"), "id kept");
+        assertEquals("Fluke", shared.optString("displayName"), "displayName kept");
+        assertEquals("female", shared.optString("sex"), "sex kept");
+        assertEquals("Orcinus orca", shared.optString("taxonomy"), "taxonomy kept");
+        // aggregates + ACL fields must be ABSENT
+        assertFalse(shared.has("numberEncounters"), "numberEncounters aggregate dropped");
+        assertFalse(shared.has("users"), "users aggregate dropped");
+        assertFalse(shared.has("encounterIds"), "encounterIds aggregate dropped");
+        assertFalse(shared.has("viewUsers"), "viewUsers ACL field dropped");
+        assertFalse(shared.has("submitterUserIds"), "submitterUserIds ACL field dropped");
+        assertFalse(shared.has("publiclyReadable"), "publiclyReadable ACL field dropped");
+    }
+
+    @Test void adminTokenIndividualSearch_unscoped() throws Exception {
+        Response r = search(adminUuid, "individual");
+        assertEquals(200, r.statusCode(), "admin token individual search OK");
+        Set<String> ids = hitIds(r);
+        assertTrue(ids.contains("indShared"), "admin sees shared individual");
+        assertTrue(ids.contains("indBobOnly"), "admin sees bob-only individual (unscoped)");
+        assertEquals("2", r.header("X-Wildbook-Total-Hits"), "admin token is unscoped");
+
+        // ACL fields still scrubbed from every hit (universal scrub, even for admin)
+        JSONArray hits = new JSONObject(r.asString()).getJSONArray("hits");
+        for (int i = 0; i < hits.length(); i++) {
+            JSONObject h = hits.getJSONObject(i);
+            assertFalse(h.has("publiclyReadable"), "publiclyReadable scrubbed for admin too");
+            assertFalse(h.has("submitterUserIds"), "submitterUserIds scrubbed for admin too");
+            assertFalse(h.has("viewUsers"), "viewUsers scrubbed for admin too");
+            assertFalse(h.has("editUsers"), "editUsers scrubbed for admin too");
+        }
+    }
+
+    @Test void tokenOccurrenceSearch_403() throws Exception {
+        Response r = search(aliceUuid, "occurrence");
+        assertEquals(403, r.statusCode(), "occurrence is not in the token index allowlist");
+    }
+}

--- a/src/test/java/org/ecocean/api/SearchTokenScopeChildIndexTest.java
+++ b/src/test/java/org/ecocean/api/SearchTokenScopeChildIndexTest.java
@@ -143,6 +143,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
         OpenSearch.initializeClient(new HttpHost(opensearch.getHost(),
             opensearch.getMappedPort(9200), "http"));
+        // The client now points at OUR fresh container; drop cluster-coupled static caches left by
+        // any earlier test class. A stale INDEX_EXISTS_CACHE makes ensureIndex skip real index
+        // creation, so seeded docs would dynamic-map (text) and the ACL term filters match nothing.
+        OpenSearch.INDEX_EXISTS_CACHE.clear();
+        OpenSearch.PIT_CACHE.clear();
+
+        // Evict any cached PMF for context0: it may be bound to ANOTHER test class's (now stopped)
+        // Postgres container. The first Shepherd below then creates a fresh PMF against OUR container.
+        org.ecocean.shepherd.core.TestPMFUtil.closePMF("context0");
 
         // seed users in Postgres + encounter/annotation/individual docs in OpenSearch
         seedUsers();
@@ -153,6 +162,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
     @AfterAll static void tearDown() {
         System.out.println("=== Tearing Down SearchTokenScopeChildIndexTest ===");
+        // our containers stop with this class; don't leave dead PMF / cluster caches for later classes
+        org.ecocean.shepherd.core.TestPMFUtil.closePMF("context0");
+        OpenSearch.INDEX_EXISTS_CACHE.clear();
+        OpenSearch.PIT_CACHE.clear();
     }
 
     // =========================================================================

--- a/src/test/java/org/ecocean/api/SearchTokenScopeTest.java
+++ b/src/test/java/org/ecocean/api/SearchTokenScopeTest.java
@@ -1,0 +1,329 @@
+package org.ecocean.api;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+
+import java.net.InetSocketAddress;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.servlet.DispatcherType;
+
+import org.apache.http.HttpHost;
+import org.apache.shiro.web.servlet.IniShiroFilter;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.ecocean.CommonConfiguration;
+import org.ecocean.OpenSearch;
+import org.ecocean.Role;
+import org.ecocean.User;
+import org.ecocean.api.auth.JwtService;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end enforcement test for the token-scoped encounter search path.
+ *
+ * Boots an embedded Jetty + Shiro (with {@code WildbookTokenAuthenticationFilter} wired onto
+ * {@code /api/v3/search/**} via the shared test {@code shiro.ini}), a real OpenSearch container,
+ * and a real PostgreSQL container. Seeds three encounter docs directly into the OpenSearch
+ * {@code encounter} index (deterministic: only the exact fields the ACL filter + sanitizeDoc read)
+ * plus real {@link User}/{@link Role} rows in Postgres, then asserts:
+ *
+ * <ul>
+ *   <li>a non-admin token user sees ONLY their permitted encounters AND scoped totals,</li>
+ *   <li>an admin token is unscoped,</li>
+ *   <li>a token to a non-encounter index is 403,</li>
+ *   <li>a context-drift (cookie) token is 401,</li>
+ *   <li>a token request mints no session (no JSESSIONID).</li>
+ * </ul>
+ *
+ * The JWT keypair is generated in {@code @BeforeAll} and published to CommonConfiguration so the
+ * production filter (which loads keys via {@code JwtService.fromConfig("context0")}) and the test
+ * signer share the same keys.
+ */
+@Testcontainers public class SearchTokenScopeTest {
+
+    @Container static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
+        "postgres:15-alpine")
+            .withDatabaseName("wildbook_test")
+            .withUsername("wildbook")
+            .withPassword("wildbook");
+
+    @Container static GenericContainer<?> opensearch = new GenericContainer<>(DockerImageName.parse(
+        "opensearchproject/opensearch:3.1.0"))
+            .withExposedPorts(9200, 9300)
+            .withEnv("discovery.type", "single-node")
+            .withEnv("plugins.security.disabled", "true")
+            .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m")
+            .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")
+            .waitingFor(new HttpWaitStrategy()
+            .forPort(9200)
+            .forPath("/_cluster/health")
+            .forStatusCode(200)
+            .withStartupTimeout(java.time.Duration.ofMinutes(2)));
+
+    private static JwtService testJwtService;
+    private static String aliceUuid;
+    private static String adminUuid;
+    private static String bobUuid;
+
+    @BeforeAll static void setUp() throws Exception {
+        System.out.println("=== Starting SearchTokenScopeTest Setup ===");
+
+        // --- JWT keypair (mirror JwtServiceTest): shared by filter (via config) + test signer ---
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()); // PKCS8
+        String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());   // X.509
+
+        Properties commonConfiguration = new Properties();
+        commonConfiguration.setProperty("collaborationSecurityEnabled", "true");
+        commonConfiguration.setProperty("releaseDateFormat", "yyyy-MM-dd");
+        commonConfiguration.setProperty("htmlTitle", "Unit Test");
+        commonConfiguration.setProperty("jwtPrivateKeyBase64", privB64);
+        commonConfiguration.setProperty("jwtPublicKeyBase64", pubB64);
+        commonConfiguration.setProperty("jwtIssuer", "wildbook");
+        commonConfiguration.setProperty("jwtAudience", "wildbook-scoped-api");
+        commonConfiguration.setProperty("jwtContext", "context0");
+        CommonConfiguration.initialize("context0", commonConfiguration);
+
+        testJwtService = JwtService.fromBase64Keys(privB64, pubB64, "wildbook",
+            "wildbook-scoped-api");
+
+        System.out.println("PostgreSQL started at: " + postgres.getJdbcUrl());
+        System.out.println("OpenSearch started at: " + getOpenSearchUrl());
+
+        // --- embedded Jetty + Shiro (shiro.ini wires tokenAuthSearch onto /api/v3/search/**) ---
+        Server server = new Server(new InetSocketAddress("localhost", 0));
+        ServletContextHandler ctx = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        ctx.setResourceBase("/tmp");
+
+        IniShiroFilter shiroFilter = new IniShiroFilter();
+        shiroFilter.setConfigPath("classpath:shiro.ini");
+        ctx.addFilter(new FilterHolder(shiroFilter), "/*", EnumSet.of(DispatcherType.REQUEST));
+
+        ctx.setContextPath("/");
+        ctx.addServlet(new ServletHolder(new SearchApi()), "/api/v3/search/*");
+        server.setHandler(ctx);
+        server.start();
+
+        int port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+        RestAssured.baseURI = "http://localhost";
+        RestAssured.port = port;
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+        OpenSearch.initializeClient(new HttpHost(opensearch.getHost(),
+            opensearch.getMappedPort(9200), "http"));
+
+        // seed users in Postgres + encounter docs in OpenSearch
+        seedUsers();
+        seedEncounterDocs();
+
+        System.out.println("=== Setup Complete ===\n");
+    }
+
+    @AfterAll static void tearDown() {
+        System.out.println("=== Tearing Down SearchTokenScopeTest ===");
+    }
+
+    // =========================================================================
+    // Seeding
+    // =========================================================================
+
+    /**
+     * Create real User rows (alice: normal; adminUser: admin role; bob: normal submitter).
+     * isAdmin is computed from DB roles by SearchApi, and the token filter resolves the user
+     * by UUID via Shepherd.getUserByUUID(sub) -> must return a User with a username.
+     */
+    private static void seedUsers() {
+        Properties properties = new Properties();
+        properties.setProperty("datanucleus.ConnectionUserName", postgres.getUsername());
+        properties.setProperty("datanucleus.ConnectionPassword", postgres.getPassword());
+        properties.setProperty("datanucleus.ConnectionDriverName", postgres.getDriverClassName());
+        properties.setProperty("datanucleus.ConnectionURL", postgres.getJdbcUrl());
+        properties.setProperty("datanucleus.schema.autoCreateTables", "true");
+
+        Shepherd myShepherd = new Shepherd("context0", properties);
+        myShepherd.setAction("SearchTokenScopeTest.seedUsers");
+        try {
+            myShepherd.beginDBTransaction();
+
+            User alice = newUser("alice");
+            myShepherd.getPM().makePersistent(alice);
+
+            User adminUser = newUser("adminUser");
+            myShepherd.getPM().makePersistent(adminUser);
+            Role adminRole = new Role("adminUser", "admin");
+            adminRole.setContext("context0");
+            myShepherd.getPM().makePersistent(adminRole);
+
+            User bob = newUser("bob");
+            myShepherd.getPM().makePersistent(bob);
+
+            myShepherd.commitDBTransaction();
+
+            aliceUuid = alice.getId();
+            adminUuid = adminUser.getId();
+            bobUuid = bob.getId();
+            System.out.println("Seeded users: alice=" + aliceUuid + " admin=" + adminUuid
+                + " bob=" + bobUuid);
+        } catch (Exception e) {
+            myShepherd.rollbackDBTransaction();
+            throw new RuntimeException("Failed to seed users", e);
+        } finally {
+            myShepherd.closeDBTransaction();
+        }
+    }
+
+    private static User newUser(String username) {
+        String salt = ServletUtilities.getSalt().toHex();
+        String hashed = ServletUtilities.hashAndSaltPassword("password123", salt);
+        return new User(username, hashed, salt);
+    }
+
+    /**
+     * Index three minimal encounter docs carrying exactly the fields the ACL filter
+     * (publiclyReadable / submitterUserId / viewUsers) and sanitizeDoc (id) read. The index is
+     * created first with the real Encounter mapping so submitterUserId/viewUsers are keyword
+     * fields and the ACL term-queries match. Refreshed before any search runs.
+     */
+    private static void seedEncounterDocs() throws Exception {
+        OpenSearch os = new OpenSearch();
+        // create the encounter index with the real mapping (keyword submitterUserId/viewUsers)
+        os.ensureIndex("encounter", new org.ecocean.Encounter().opensearchMapping());
+
+        // alice sees encA (she is the submitter)
+        putDoc(os, "encA", docJson("encA", aliceUuid, false, new String[] {}));
+        // alice sees encB (granted via viewUsers)
+        putDoc(os, "encB", docJson("encB", bobUuid, false, new String[] { aliceUuid }));
+        // alice must NOT see encC (bob's private encounter, no grant)
+        putDoc(os, "encC", docJson("encC", bobUuid, false, new String[] {}));
+
+        // refresh so docs are immediately searchable
+        os.getRestResponse(new org.opensearch.client.Request("POST", "/encounter/_refresh"));
+        System.out.println("Seeded 3 encounter docs (encA, encB, encC) and refreshed index");
+    }
+
+    private static JSONObject docJson(String id, String submitterUserId, boolean publiclyReadable,
+        String[] viewUsers) {
+        JSONObject doc = new JSONObject();
+        doc.put("id", id);
+        doc.put("publiclyReadable", publiclyReadable);
+        doc.put("submitterUserId", submitterUserId);
+        JSONArray vu = new JSONArray();
+        for (String u : viewUsers) vu.put(u);
+        doc.put("viewUsers", vu);
+        return doc;
+    }
+
+    private static void putDoc(OpenSearch os, String id, JSONObject doc) throws Exception {
+        org.opensearch.client.Request req = new org.opensearch.client.Request("PUT",
+            "/encounter/_doc/" + id);
+        req.setJsonEntity(doc.toString());
+        os.getRestResponse(req);
+    }
+
+    private static String getOpenSearchUrl() {
+        return "http://" + opensearch.getHost() + ":" + opensearch.getMappedPort(9200);
+    }
+
+    // =========================================================================
+    // Tests
+    // =========================================================================
+
+    @Test void tokenSearch_scopesToPermittedEncountersAndTotals() throws Exception {
+        String token = testJwtService.sign(aliceUuid, "context0", 60_000L);
+        Response r = given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/encounter")
+            .then().log().ifValidationFails().statusCode(200).extract().response();
+        JSONObject body = new JSONObject(r.asString());
+        JSONArray hits = body.getJSONArray("hits");
+        Set<String> ids = new HashSet<>();
+        for (int i = 0; i < hits.length(); i++) ids.add(hits.getJSONObject(i).optString("id"));
+        assertTrue(ids.contains("encA"), "alice sees her own encounter");
+        assertTrue(ids.contains("encB"), "alice sees the viewUsers encounter");
+        assertFalse(ids.contains("encC"), "alice must NOT see bob's private encounter");
+        assertEquals("2", r.header("X-Wildbook-Total-Hits"), "total reflects scoped set");
+    }
+
+    @Test void adminTokenSearch_seesAll() throws Exception {
+        String token = testJwtService.sign(adminUuid, "context0", 60_000L);
+        Response r = given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/encounter")
+            .then().log().ifValidationFails().statusCode(200).extract().response();
+        assertEquals("3", r.header("X-Wildbook-Total-Hits"), "admin token is unscoped");
+    }
+
+    @Test void tokenSearch_nonEncounterIndex_403() throws Exception {
+        String token = testJwtService.sign(aliceUuid, "context0", 60_000L);
+        given().header("Authorization", "Bearer " + token)
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/individual")
+            .then().log().ifValidationFails().statusCode(403);
+    }
+
+    @Test void tokenSearch_contextDriftViaCookie_401() throws Exception {
+        String token = testJwtService.sign(aliceUuid, "context0", 60_000L);
+        given().header("Authorization", "Bearer " + token)
+            .cookie("wildbookContext", "context1")
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/encounter")
+            .then().log().ifValidationFails().statusCode(401);
+    }
+
+    @Test void tokenSearch_mintsNoSession() throws Exception {
+        String token = testJwtService.sign(aliceUuid, "context0", 60_000L);
+        Response r = given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/encounter")
+            .then().log().ifValidationFails().statusCode(200).extract().response();
+        String setCookie = r.header("Set-Cookie");
+        assertFalse((setCookie != null) && setCookie.contains("JSESSIONID"),
+            "token search must not mint a JSESSIONID");
+        assertTrue(r.getCookie("JSESSIONID") == null, "no JSESSIONID cookie returned");
+        // replaying whatever cookies came back (none auth-bearing) must NOT grant access
+        given()
+            .cookies(r.getCookies() == null ? new HashMap<String, String>() : r.getCookies())
+            .contentType(io.restassured.http.ContentType.JSON)
+            .body("{\"query\":{\"match_all\":{}}}")
+            .when().post("/api/v3/search/encounter")
+            .then().log().ifValidationFails().statusCode(401);
+    }
+}

--- a/src/test/java/org/ecocean/api/SearchTokenScopeTest.java
+++ b/src/test/java/org/ecocean/api/SearchTokenScopeTest.java
@@ -141,6 +141,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
         OpenSearch.initializeClient(new HttpHost(opensearch.getHost(),
             opensearch.getMappedPort(9200), "http"));
+        // The client now points at OUR fresh container; drop cluster-coupled static caches left by
+        // any earlier test class. A stale INDEX_EXISTS_CACHE makes ensureIndex skip real index
+        // creation, so seeded docs would dynamic-map (text) and the ACL term filters match nothing.
+        OpenSearch.INDEX_EXISTS_CACHE.clear();
+        OpenSearch.PIT_CACHE.clear();
+
+        // Evict any cached PMF for context0: it may be bound to ANOTHER test class's (now stopped)
+        // Postgres container. The first Shepherd below then creates a fresh PMF against OUR container.
+        org.ecocean.shepherd.core.TestPMFUtil.closePMF("context0");
 
         // seed users in Postgres + encounter docs in OpenSearch
         seedUsers();
@@ -151,6 +160,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
     @AfterAll static void tearDown() {
         System.out.println("=== Tearing Down SearchTokenScopeTest ===");
+        // our containers stop with this class; don't leave dead PMF / cluster caches for later classes
+        org.ecocean.shepherd.core.TestPMFUtil.closePMF("context0");
+        OpenSearch.INDEX_EXISTS_CACHE.clear();
+        OpenSearch.PIT_CACHE.clear();
     }
 
     // =========================================================================

--- a/src/test/java/org/ecocean/api/SearchTokenScopeTest.java
+++ b/src/test/java/org/ecocean/api/SearchTokenScopeTest.java
@@ -287,12 +287,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         assertEquals("3", r.header("X-Wildbook-Total-Hits"), "admin token is unscoped");
     }
 
-    @Test void tokenSearch_nonEncounterIndex_403() throws Exception {
+    @Test void tokenSearch_nonAllowlistedIndex_403() throws Exception {
+        // The token index allowlist is encounter + annotation + individual (see SearchApi). Any other
+        // index must be rejected with 403. Use occurrence as the representative non-allowlisted index.
+        // (Originally probed /individual, but the token allowlist was widened to include the child
+        //  indices in a later commit; see SearchTokenScopeChildIndexTest for their scoped coverage.)
         String token = testJwtService.sign(aliceUuid, "context0", 60_000L);
         given().header("Authorization", "Bearer " + token)
             .contentType(io.restassured.http.ContentType.JSON)
             .body("{\"query\":{\"match_all\":{}}}")
-            .when().post("/api/v3/search/individual")
+            .when().post("/api/v3/search/occurrence")
             .then().log().ifValidationFails().statusCode(403);
     }
 

--- a/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+++ b/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
@@ -1,0 +1,78 @@
+package org.ecocean.api.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.Test;
+
+class JwtServiceTest {
+
+    private JwtService serviceWithFreshKeys() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()); // PKCS8
+        String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());   // X.509
+        return JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+    }
+
+    @Test void signThenVerify_roundTrip() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("user-uuid-123", "context0", 60_000L); // 60s TTL
+        Jws<Claims> jws = svc.verify(token);
+        Claims c = jws.getPayload();
+        assertEquals("user-uuid-123", c.getSubject(), "subject = user uuid");
+        assertEquals("context0", c.get("context", String.class), "context claim");
+        assertEquals("wildbook", c.getIssuer(), "issuer");
+        assertNotNull(c.getId(), "jti present");
+        assertTrue(c.getExpiration().getTime() > System.currentTimeMillis(), "exp in future");
+        assertNull(c.get("admin"), "no admin claim");
+        assertNull(c.get("roles"), "no roles claim");
+    }
+
+    @Test void expiredToken_rejected() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("u", "context0", -1000L); // already expired
+        assertThrows(JwtException.class, () -> svc.verify(token), "expired token must be rejected");
+    }
+
+    @Test void tamperedToken_rejected() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("u", "context0", 60_000L);
+        String tampered = token.substring(0, token.length() - 2) + (token.endsWith("a") ? "bb" : "aa");
+        assertThrows(JwtException.class, () -> svc.verify(tampered), "bad signature must be rejected");
+    }
+
+    @Test void wrongAudienceOrIssuer_rejected() throws Exception {
+        // SAME keypair (valid signature), but the verifier requires a different
+        // issuer/audience — this genuinely exercises requireIssuer/requireAudience
+        // (a different-key test would pass even if those checks were removed).
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+
+        JwtService signer = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+        String token = signer.sign("u", "context0", 60_000L);
+
+        JwtService wrongIssuer = JwtService.fromBase64Keys(privB64, pubB64, "evil-issuer", "wildbook-scoped-api");
+        assertThrows(JwtException.class, () -> wrongIssuer.verify(token), "mismatched issuer must be rejected");
+
+        JwtService wrongAudience = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "some-other-aud");
+        assertThrows(JwtException.class, () -> wrongAudience.verify(token), "mismatched audience must be rejected");
+    }
+
+    @Test void disabledWhenKeysMissing() {
+        JwtService svc = JwtService.fromBase64Keys(null, null, "wildbook", "wildbook-scoped-api");
+        assertFalse(svc.isEnabled(), "service disabled without keys");
+        assertThrows(IllegalStateException.class, () -> svc.sign("u", "context0", 1000L),
+            "signing while disabled must throw");
+    }
+}

--- a/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+++ b/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
@@ -147,6 +147,45 @@ class JwtServiceTest {
             "HS256-with-RSA-public-key forged token must be rejected");
     }
 
+    // ------------------------------------------------------------------ //
+    // Key-ID (kid) header tests (key-rotation support, Fix 2)            //
+    // ------------------------------------------------------------------ //
+
+    /**
+     * When a keyId is supplied via the 5-arg overload, the signed token must
+     * carry a `kid` header that survives round-trip verification.
+     */
+    @Test void keyIdHeader_setWhenProvided() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pubB64  = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+
+        JwtService svc = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api", "key-1");
+        String token = svc.sign("kid-user", "context0", 60_000L);
+        Jws<Claims> jws = svc.verify(token);
+
+        // kid header must be propagated
+        assertEquals("key-1", jws.getHeader().getKeyId(), "kid header must equal supplied keyId");
+
+        // round-trip claims must still be correct
+        Claims c = jws.getPayload();
+        assertEquals("kid-user", c.getSubject(), "subject preserved with kid header");
+        assertEquals("wildbook", c.getIssuer(), "issuer preserved with kid header");
+    }
+
+    /**
+     * When no keyId is provided (4-arg overload), the `kid` header must be
+     * absent (null) — confirming the header is not injected spuriously.
+     */
+    @Test void keyIdHeader_absentWhenNotProvided() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        String token = svc.sign("no-kid-user", "context0", 60_000L);
+        Jws<Claims> jws = svc.verify(token);
+        assertNull(jws.getHeader().getKeyId(), "kid header must be absent when no keyId supplied");
+    }
+
     /**
      * A token signed with RS384 using the SAME RSA private key must be rejected
      * once the verifier is pinned to RS256.  (This is the test that should FAIL

--- a/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+++ b/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
@@ -186,6 +186,20 @@ class JwtServiceTest {
         assertNull(jws.getHeader().getKeyId(), "kid header must be absent when no keyId supplied");
     }
 
+    // ------------------------------------------------------------------ //
+    // canVerify() predicate tests (Task 2)                               //
+    // ------------------------------------------------------------------ //
+
+    @Test void canVerify_trueWhenPublicKeyPresent() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+        assertTrue(svc.canVerify(), "service built with a keypair can verify");
+    }
+
+    @Test void canVerify_falseWhenNoKeys() {
+        JwtService svc = JwtService.fromBase64Keys(null, null, "wildbook", "wildbook-scoped-api");
+        assertFalse(svc.canVerify(), "service with no public key cannot verify");
+    }
+
     /**
      * A token signed with RS384 using the SAME RSA private key must be rejected
      * once the verifier is pinned to RS256.  (This is the test that should FAIL

--- a/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+++ b/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
@@ -2,24 +2,41 @@ package org.ecocean.api.auth;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.util.Base64;
+import java.util.Date;
+
+import javax.crypto.spec.SecretKeySpec;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.Test;
 
 class JwtServiceTest {
 
+    /** Generates a fresh RSA-2048 keypair and returns a JwtService wired to it. */
     private JwtService serviceWithFreshKeys() throws Exception {
+        return serviceWithFreshKeys("wildbook", "wildbook-scoped-api");
+    }
+
+    private JwtService serviceWithFreshKeys(String issuer, String audience) throws Exception {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
         kpg.initialize(2048);
         KeyPair kp = kpg.generateKeyPair();
         String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()); // PKCS8
         String pubB64 = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());   // X.509
-        return JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+        return JwtService.fromBase64Keys(privB64, pubB64, issuer, audience);
+    }
+
+    /** Returns a fresh RSA-2048 KeyPair (used by algorithm-confusion tests). */
+    private KeyPair freshKeyPair() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
     }
 
     @Test void signThenVerify_roundTrip() throws Exception {
@@ -74,5 +91,85 @@ class JwtServiceTest {
         assertFalse(svc.isEnabled(), "service disabled without keys");
         assertThrows(IllegalStateException.class, () -> svc.sign("u", "context0", 1000L),
             "signing while disabled must throw");
+    }
+
+    // ------------------------------------------------------------------ //
+    // Algorithm-confusion regression tests (defence-in-depth, Fix 1)      //
+    // ------------------------------------------------------------------ //
+
+    /**
+     * alg=none UNSECURED JWT must be rejected.
+     * jjwt 0.12.x will not emit alg=none via its builder, so we craft the
+     * token string manually: base64url(header) + "." + base64url(payload) + "."
+     * (empty signature part) — which is the canonical unsecured-JWT form.
+     */
+    @Test void algNone_rejected() throws Exception {
+        JwtService svc = serviceWithFreshKeys();
+
+        Base64.Encoder b64url = Base64.getUrlEncoder().withoutPadding();
+        String header  = b64url.encodeToString(
+            "{\"alg\":\"none\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8));
+        long now = System.currentTimeMillis() / 1000;
+        String payload = b64url.encodeToString(
+            ("{\"iss\":\"wildbook\",\"aud\":\"wildbook-scoped-api\","
+                + "\"sub\":\"u\",\"iat\":" + now + ",\"exp\":" + (now + 3600) + "}")
+            .getBytes(StandardCharsets.UTF_8));
+        // canonical unsecured JWT: header.payload. (empty signature)
+        String unsecuredToken = header + "." + payload + ".";
+
+        assertThrows(JwtException.class, () -> svc.verify(unsecuredToken),
+            "alg=none token must be rejected");
+    }
+
+    /**
+     * HS256 token signed with the RSA public key's raw bytes as the HMAC secret
+     * must be rejected (algorithm-confusion / symmetric-with-asymmetric attack).
+     */
+    @Test void hs256ForgedWithPublicKey_rejected() throws Exception {
+        KeyPair kp = freshKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pubB64  = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+        JwtService svc = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+
+        // forge: sign with HS256 using the RSA public key bytes as HMAC secret
+        SecretKeySpec hmacKey = new SecretKeySpec(kp.getPublic().getEncoded(), "HmacSHA256");
+        long now = System.currentTimeMillis();
+        String forged = Jwts.builder()
+            .issuer("wildbook")
+            .audience().add("wildbook-scoped-api").and()
+            .subject("u")
+            .issuedAt(new Date(now))
+            .expiration(new Date(now + 3_600_000L))
+            .signWith(hmacKey, Jwts.SIG.HS256)
+            .compact();
+
+        assertThrows(JwtException.class, () -> svc.verify(forged),
+            "HS256-with-RSA-public-key forged token must be rejected");
+    }
+
+    /**
+     * A token signed with RS384 using the SAME RSA private key must be rejected
+     * once the verifier is pinned to RS256.  (This is the test that should FAIL
+     * before Fix 1 is applied and PASS after.)
+     */
+    @Test void rs384SameKey_rejected() throws Exception {
+        KeyPair kp = freshKeyPair();
+        String privB64 = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pubB64  = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+        JwtService svc = JwtService.fromBase64Keys(privB64, pubB64, "wildbook", "wildbook-scoped-api");
+
+        // forge: sign with RS384 (stronger but wrong algorithm)
+        long now = System.currentTimeMillis();
+        String rs384Token = Jwts.builder()
+            .issuer("wildbook")
+            .audience().add("wildbook-scoped-api").and()
+            .subject("u")
+            .issuedAt(new Date(now))
+            .expiration(new Date(now + 3_600_000L))
+            .signWith(kp.getPrivate(), Jwts.SIG.RS384)
+            .compact();
+
+        assertThrows(JwtException.class, () -> svc.verify(rs384Token),
+            "RS384-signed token must be rejected when verifier is pinned to RS256");
     }
 }

--- a/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
+++ b/src/test/java/org/ecocean/api/auth/JwtServiceTest.java
@@ -55,7 +55,7 @@ class JwtServiceTest {
 
     @Test void expiredToken_rejected() throws Exception {
         JwtService svc = serviceWithFreshKeys();
-        String token = svc.sign("u", "context0", -1000L); // already expired
+        String token = svc.sign("u", "context0", -60_000L); // expired 60s ago (avoids sub-second boundary flake)
         assertThrows(JwtException.class, () -> svc.verify(token), "expired token must be rejected");
     }
 

--- a/src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java
+++ b/src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java
@@ -84,7 +84,7 @@ class WildbookTokenAuthenticationFilterTest {
     }
 
     @Test void expiredToken_returns401() throws Exception {
-        String token = realService.sign("user-uuid-1", "context0", -1_000L); // already expired
+        String token = realService.sign("user-uuid-1", "context0", -60_000L); // expired 60s ago (avoids sub-second boundary flake)
         when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
         when(request.getMethod()).thenReturn("POST");
         filterFor("context0", "alice").doFilterInternal(request, response, chain);

--- a/src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java
+++ b/src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java
@@ -1,0 +1,173 @@
+package org.ecocean.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Principal;
+import java.util.Base64;
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.ecocean.api.auth.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class WildbookTokenAuthenticationFilterTest {
+
+    private JwtService realService; // genuine RS256 keypair; sign + verify both work
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain chain;
+    private StringWriter out;
+
+    /** Filter with seams overridden: fixed context, real JwtService, canned username. */
+    private WildbookTokenAuthenticationFilter filterFor(String requestContext,
+        String resolvedUsername) {
+        return new WildbookTokenAuthenticationFilter() {
+            @Override protected String expectedContext() {
+                return "context0";
+            }
+            @Override protected String requestContext(HttpServletRequest r) {
+                return requestContext;
+            }
+            @Override protected JwtService jwtService(String context) {
+                return realService;
+            }
+            @Override protected String lookupUsername(String context, String uuid) {
+                return resolvedUsername;
+            }
+        };
+    }
+
+    @BeforeEach void setUp() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        String priv = Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded());
+        String pub = Base64.getEncoder().encodeToString(kp.getPublic().getEncoded());
+        realService = JwtService.fromBase64Keys(priv, pub, "wildbook", "wildbook-scoped-api");
+
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        chain = mock(FilterChain.class);
+        out = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(out));
+    }
+
+    @Test void noBearer_passesThroughUnchanged() throws Exception {
+        when(request.getHeader("Authorization")).thenReturn(null);
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(chain).doFilter(request, response); // original request, untouched
+        verify(response, never()).setStatus(anyInt());
+    }
+
+    @Test void validBearer_wrapsRequestWithUsernamePrincipal() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+
+        ArgumentCaptor<javax.servlet.ServletRequest> cap =
+            ArgumentCaptor.forClass(javax.servlet.ServletRequest.class);
+        verify(chain).doFilter(cap.capture(), eq(response));
+        HttpServletRequest wrapped = (HttpServletRequest) cap.getValue();
+        Principal p = wrapped.getUserPrincipal();
+        assertEquals("alice", p.toString(), "principal.toString() must yield the username");
+        assertEquals(Boolean.TRUE, wrapped.getAttribute(
+            WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR), "token-auth marker set");
+    }
+
+    @Test void expiredToken_returns401() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", -1_000L); // already expired
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(response).setStatus(401);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void wrongContextClaim_returns401() throws Exception {
+        String token = realService.sign("user-uuid-1", "contextX", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(response).setStatus(401);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void requestContextDrift_returns401() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        // token says context0, but the resolved request context is context1 (e.g. ?context=, cookie, host)
+        filterFor("context1", "alice").doFilterInternal(request, response, chain);
+        verify(response).setStatus(401);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void unknownUser_returns401() throws Exception {
+        String token = realService.sign("ghost-uuid", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        filterFor("context0", null).doFilterInternal(request, response, chain); // lookup -> null
+        verify(response).setStatus(401);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void disallowedMethod_returns405() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("DELETE");
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(response).setStatus(405);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void tamperedToken_returns401() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L) + "tamper";
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(response).setStatus(401);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void lowercaseBearerScheme_stillAuthenticates() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("bearer " + token); // lowercase scheme
+        when(request.getMethod()).thenReturn("POST");
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(chain).doFilter(any(), eq(response)); // wrapped + forwarded, not treated as no-token
+        verify(response, never()).setStatus(anyInt());
+    }
+
+    @Test void notConfigured_returns503() throws Exception {
+        JwtService noKeys = JwtService.fromBase64Keys(null, null, "wildbook", "wildbook-scoped-api");
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        WildbookTokenAuthenticationFilter f = new WildbookTokenAuthenticationFilter() {
+            @Override protected String expectedContext() {
+                return "context0";
+            }
+            @Override protected String requestContext(HttpServletRequest r) {
+                return "context0";
+            }
+            @Override protected JwtService jwtService(String context) {
+                return noKeys; // canVerify() == false
+            }
+            @Override protected String lookupUsername(String context, String uuid) {
+                return "alice";
+            }
+        };
+        f.doFilterInternal(request, response, chain);
+        verify(response).setStatus(503);
+        verify(chain, never()).doFilter(any(), any());
+    }
+}

--- a/src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java
+++ b/src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java
@@ -147,6 +147,31 @@ class WildbookTokenAuthenticationFilterTest {
         verify(response, never()).setStatus(anyInt());
     }
 
+    @Test void blankBearerToken_returns401() throws Exception {
+        // "Bearer " with no token -> token becomes "" -> jjwt throws IllegalArgumentException
+        when(request.getHeader("Authorization")).thenReturn("Bearer ");
+        when(request.getMethod()).thenReturn("POST");
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(response).setStatus(401);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test void validBearerGet_wrapsRequestWithUsernamePrincipal() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("GET");
+
+        org.mockito.ArgumentCaptor<javax.servlet.ServletRequest> cap =
+            org.mockito.ArgumentCaptor.forClass(javax.servlet.ServletRequest.class);
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(chain).doFilter(cap.capture(), eq(response));
+        javax.servlet.http.HttpServletRequest wrapped =
+            (javax.servlet.http.HttpServletRequest) cap.getValue();
+        assertEquals("alice", wrapped.getUserPrincipal().getName(), "getName() == username");
+        assertEquals("alice", wrapped.getUserPrincipal().toString(), "toString() == username");
+        verify(response, never()).setStatus(anyInt());
+    }
+
     @Test void notConfigured_returns503() throws Exception {
         JwtService noKeys = JwtService.fromBase64Keys(null, null, "wildbook", "wildbook-scoped-api");
         String token = realService.sign("user-uuid-1", "context0", 60_000L);

--- a/src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java
+++ b/src/test/java/org/ecocean/security/WildbookTokenAuthenticationFilterTest.java
@@ -83,6 +83,21 @@ class WildbookTokenAuthenticationFilterTest {
             WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR), "token-auth marker set");
     }
 
+    @Test void validBearer_setsVerifiedContextAttribute() throws Exception {
+        String token = realService.sign("user-uuid-1", "context0", 60_000L);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(request.getMethod()).thenReturn("POST");
+        org.mockito.ArgumentCaptor<javax.servlet.ServletRequest> cap =
+            org.mockito.ArgumentCaptor.forClass(javax.servlet.ServletRequest.class);
+        filterFor("context0", "alice").doFilterInternal(request, response, chain);
+        verify(chain).doFilter(cap.capture(), eq(response));
+        javax.servlet.http.HttpServletRequest wrapped =
+            (javax.servlet.http.HttpServletRequest) cap.getValue();
+        assertEquals("context0",
+            wrapped.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_CONTEXT_ATTR),
+            "filter sets the verified context attribute for SearchApi");
+    }
+
     @Test void expiredToken_returns401() throws Exception {
         String token = realService.sign("user-uuid-1", "context0", -60_000L); // expired 60s ago (avoids sub-second boundary flake)
         when(request.getHeader("Authorization")).thenReturn("Bearer " + token);

--- a/src/test/java/org/ecocean/shepherd/core/TestPMFUtil.java
+++ b/src/test/java/org/ecocean/shepherd/core/TestPMFUtil.java
@@ -1,0 +1,14 @@
+package org.ecocean.shepherd.core;
+
+/**
+ * Test-only bridge to package-private PMF lifecycle helpers. Testcontainers test classes (which
+ * live in other packages) use this to evict the statically cached PMF whose database container
+ * has stopped — see ShepherdPMF.closePMF for the full rationale.
+ */
+public final class TestPMFUtil {
+    private TestPMFUtil() {}
+
+    public static void closePMF(String context) {
+        ShepherdPMF.closePMF(context);
+    }
+}

--- a/src/test/resources/shiro.ini
+++ b/src/test/resources/shiro.ini
@@ -8,6 +8,10 @@ realmA = org.ecocean.security.ShepherdRealm
 # Set up custom authentication filter for Basic HTTP auth with password hashing
 authcBasicWildbook = org.ecocean.security.WildbookBasicHttpAuthenticationFilter
 
+# Token (Bearer JWT) auth filter for the scoped search read path. Forwards the
+# chain unchanged when there is no Bearer header (session/anon path intact).
+tokenAuthSearch = org.ecocean.security.WildbookTokenAuthenticationFilter
+
 # Configure login URL
 authc.loginUrl = /api/v3/login
 roles.unauthorizedUrl = /accessDenied.jsp
@@ -23,6 +27,11 @@ roles.unauthorizedUrl = /accessDenied.jsp
 # API token issuance and admin access-check endpoints
 /api/v3/auth/token = authcBasicWildbook
 /api/v3/can-user-access = authcBasicWildbook, roles[admin]
+
+# Token-scoped search read path. MUST precede the /** catch-all (Shiro is
+# first-match-wins). The filter forwards the chain when there is no Bearer
+# header, so session-based search requests still pass through.
+/api/v3/search/** = tokenAuthSearch
 
 # Allow everything else for testing purposes
 /** = anon

--- a/src/test/resources/shiro.ini
+++ b/src/test/resources/shiro.ini
@@ -20,5 +20,9 @@ roles.unauthorizedUrl = /accessDenied.jsp
 /api/v3/home = authc
 /api/v3/encounters/export-images = authc, roles[researcher]
 
+# API token issuance and admin access-check endpoints
+/api/v3/auth/token = authcBasicWildbook
+/api/v3/can-user-access = authcBasicWildbook, roles[admin]
+
 # Allow everything else for testing purposes
 /** = anon


### PR DESCRIPTION
## Token-scoped read API for Wildbook (Artifacts B + D + Spec A)

Makes **Java the hard permission boundary** for token-authenticated, read-only search: an external client (e.g. an AI assistant / MCP shim) presents a short-lived bearer JWT and gets back **only the data the token's user is allowed to see** — across the `encounter`, `individual`, and `annotation` indices. This is the user-facing scoped-read layer for the AI co-scientist effort.

Builds on **Artifact A** (`viewUsers` ACL hardening, already merged in #1592), which this PR's encounter ACL relies on. **This PR supersedes #1594** (Artifact B) — B's commits are included here.

### What's in it (layered)
- **Artifact B — token infra.** `JwtService` (RS256, alg-pinned), `POST /api/v3/auth/token` (Basic-auth → 30-min identity-only JWT, context-pinned), `POST /api/v3/can-user-access` (admin, live `Encounter.canUserView` backstop).
- **Artifact D — token-scoped encounter search.** New Shiro `WildbookTokenAuthenticationFilter` verifies the JWT, enforces the `context` claim + rejects context drift, and **wraps the request** so `Shepherd.getUser(request)` resolves the token user — **without `subject.login`** (no session minted; a leaked token is read-only and can't reach write endpoints). `SearchApi` then injects a real ACL pre-filter (`publiclyReadable OR submitterUserId==uuid OR viewUsers==uuid`) into the OpenSearch query **before execution**, so totals + pagination + hits are all scoped (the old path only post-sanitized hits and leaked metadata/counts). Admin token → unscoped.
- **Spec A — individual + annotation.** Extends the boundary to two more indices, gated by encounter access: the encounter ACL is denormalized onto annotation (its single parent's ACL; 0/>1 parents fail closed) and individual (union over member encounters; 0 encounters → world-readable, matching `canUserAccessMarkedIndividual`). Individual responses are **allowlisted to identity fields** (cross-encounter aggregates dropped) and the query DSL is **restricted to identity fields** (so a caller can't probe hidden aggregates via `range`/`sort`/`aggs`/`terms`-lookup/etc.). Annotation embeddings flow through (deemed non-sensitive), ACL fields scrubbed from all responses. `occurrence`/`media_asset` remain closed (403).

### Architecture notes
- **Encounter is the single ACL unit**; individual/annotation visibility are projections gated by it (`Encounter.opensearchAclFields` is the one source).
- **No fail-open / no session**: per-task and final Codex reviews traced every path — non-admin token requests always get the ACL pre-filter before `queryPit`; admin bypasses; non-token/session path unchanged.
- **Reindex triggers** keep the child indices' denormalized ACL current on collaboration/role/org changes and on encounter↔individual membership changes (reassign/merge/split), honoring `skipAutoIndexing` + the global kill-switch.

### Quality / process
- Designed and built via spec → plan → TDD (fresh-subagent-per-task with two-stage spec + code-quality review).
- **Codex adversarial review** at every stage (design, plan, and final code) to **SAFE TO MERGE** — it caught real issues that were folded in (e.g. the query-side aggregate leak: the response allowlist wasn't enough, so query/sort field restriction was added and hardened over several rounds).
- Tests: ~100 unit tests + 2 Testcontainers (real OpenSearch) integration tests.
- **Live-verified on a test server** (flakebook.wildme.org): non-admin token → identity-only individual results (scoped), annotation gated with embeddings, occurrence 403, and an individual `range` query on a hidden aggregate field → 400.

### Deploy notes (important for the reviewer / release)
- Requires a JWT keypair in `commonConfiguration.properties` (context0): **both** `jwtPrivateKeyBase64` (sign) and `jwtPublicKeyBase64` (verify) — see `docs/superpowers/runbooks/jwt-keypair-setup.md`. Missing keys → 503.
- One-time **child-index reindex** after deploy to populate the new annotation/individual ACL fields — see `docs/superpowers/runbooks/childindex-acl-reindex.md` (reset + rebuild each child index via `appadmin/opensearchSync.jsp?...&resetIndex=true`). Fail-closed during reindex (never leaky).
- `main` has advanced since this branch forked; a `main` merge may be needed before this is mergeable.

### Known follow-ups (out of scope, tracked)
- The pre-existing **session-path** (non-token) search still post-sanitizes and can leak some encounter metadata/counts — its own security PR (sibling to the `viewUsers` fix).
- Verify orgAdmin coverage in the background `viewUsers` writer (now also load-bearing for the individual unions).
- **Spec B** (detection via a service-account token + nested-kNN ACL) is a separate future design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
