### PR TITLE
Restore mouse-wheel zoom on React match-results and encounter image viewers

### DIFF
--- a/frontend/src/components/AnnotationOverlay.jsx
+++ b/frontend/src/components/AnnotationOverlay.jsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
+import useWheelZoom from "../hooks/useWheelZoom";
 
 const VISIBLE_MARGIN_PX = 40;
 
@@ -248,6 +249,16 @@ const InteractiveAnnotationOverlay = forwardRef(
         window.removeEventListener("resize", handleResize);
       };
     }, [zoom]);
+
+    // Mouse-wheel zoom mirrors the zoomIn/zoomOut imperative-handle behavior.
+    const handleWheelZoom = (direction) => {
+      setZoom((z) => {
+        const nextZoom = clampZoom(z + direction * zoomStep);
+        setPan((prev) => clampPan(prev, nextZoom));
+        return nextZoom;
+      });
+    };
+    useWheelZoom(outerContainerRef, handleWheelZoom, imageLoaded);
 
     const panZoomTransform = `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`;
 

--- a/frontend/src/components/ImageModal.jsx
+++ b/frontend/src/components/ImageModal.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import useWheelZoom from "../hooks/useWheelZoom";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import { observer } from "mobx-react-lite";
@@ -18,13 +19,15 @@ import Tooltip from "../components/ToolTip";
 export const ImageModal = observer(
   ({
     onClose,
-    assets = [],
+    assets: assetsProp = [],
     index = 0,
     setIndex,
     rects = [],
     imageStore = {},
   }) => {
-    if (!assets || !assets.length) return null;
+    // Normalize once (handles null, not just undefined) so all hooks/render below
+    // are array-safe and the empty guard can sit after the hooks (Rules of Hooks).
+    const assets = Array.isArray(assetsProp) ? assetsProp : [];
     const intl = useIntl();
     const deleteAnnotationConfirmMsg = intl.formatMessage({
       id: "CONFIRM_DELETE_ANNOTATION",
@@ -37,6 +40,7 @@ export const ImageModal = observer(
     const themeColor = React.useContext(ThemeColorContext);
     const thumbsRef = useRef(null);
     const imgRef = useRef(null);
+    const imageContainerRef = useRef(null);
     const [scaleX, setScaleX] = useState(1);
     const [scaleY, setScaleY] = useState(1);
     const [imageReady, setImageReady] = useState(false);
@@ -64,6 +68,13 @@ export const ImageModal = observer(
       e.preventDefault();
       setDragStart({ x: e.clientX, y: e.clientY, startPan: pan });
     };
+
+    // Mouse-wheel zoom matches the zoom-in / reset buttons (step 0.25, range 1..3);
+    // pan re-centers via the [zoom, safeIndex] effect above.
+    const handleWheelZoom = (direction) => {
+      setZoom((z) => Math.min(3, Math.max(1, z + direction * 0.25)));
+    };
+    useWheelZoom(imageContainerRef, handleWheelZoom);
 
     useEffect(() => {
       if (!dragStart) return;
@@ -205,6 +216,10 @@ export const ImageModal = observer(
     const hasNonTrivialAnnotations = imageStore.encounterAnnotations?.some(
       (a) => !a.isTrivial && (a.boundingBox?.[2] || 0) > 0 && (a.boundingBox?.[3] || 0) > 0
     );
+
+    // Guard placed after all hooks so hook order stays stable across renders
+    // (Rules of Hooks). All hooks above are null-safe when assets is empty.
+    if (!assets || !assets.length) return null;
 
     return (
       <div
@@ -354,6 +369,7 @@ export const ImageModal = observer(
                 </button>
                 <div
                   id="image-modal-image-container"
+                  ref={imageContainerRef}
                   className="position-relative d-flex justify-content-center align-items-center"
                   style={{
                     width: "100%",

--- a/frontend/src/hooks/useWheelZoom.js
+++ b/frontend/src/hooks/useWheelZoom.js
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Attaches a native, non-passive "wheel" listener to targetRef.current so that
+ * mouse-wheel scrolling zooms the image instead of scrolling the page. A native
+ * listener (rather than React's synthetic onWheel) is required because React
+ * registers wheel handlers passively, which cannot call preventDefault().
+ *
+ * The hook does not own any zoom state; the caller supplies onZoom and keeps its
+ * existing zoom/pan/clamp semantics.
+ *
+ * @param {React.RefObject} targetRef element the listener is attached to
+ * @param {(direction: number, event: WheelEvent) => void} onZoom called with
+ *        direction = +1 to zoom in (wheel up / deltaY < 0) and -1 to zoom out
+ *        (wheel down / deltaY > 0)
+ * @param {boolean} [enabled=true] when false, no listener is attached
+ */
+export default function useWheelZoom(targetRef, onZoom, enabled = true) {
+  // Keep the latest callback in a ref so the listener is not re-subscribed on
+  // every render (and callers do not need to memoize onZoom).
+  const onZoomRef = useRef(onZoom);
+  useEffect(() => {
+    onZoomRef.current = onZoom;
+  }, [onZoom]);
+
+  useEffect(() => {
+    const el = targetRef.current;
+    if (!el || !enabled) return undefined;
+
+    const handleWheel = (e) => {
+      if (e.deltaY === 0) return;
+      e.preventDefault();
+      onZoomRef.current(e.deltaY < 0 ? 1 : -1, e);
+    };
+
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, [targetRef, enabled]);
+}


### PR DESCRIPTION
## Problem

A researcher reported she can no longer **mouse-wheel to zoom** on the React match-results page images and has to use the icon buttons. Confirmed: there is **no `wheel`/`onWheel` listener anywhere in the React frontend** — wheel-to-zoom existed in the older viewer and was never ported into the React rewrite.

## Fix

Restore wheel-zoom and standardize it behind a small shared hook so the three (currently divergent) zoom/pan viewers can share one implementation.

- **New `frontend/src/hooks/useWheelZoom.js`** — attaches a **native, non-passive** `wheel` listener to a target element. A native listener is required because React's synthetic `onWheel` is registered passively and cannot `preventDefault()`, so the page would scroll behind the zoom. The hook owns no zoom state: callers pass `onZoom(direction)` (`+1` in / `-1` out) and keep their own zoom/pan/clamp semantics. A latest-callback ref avoids re-subscribing the listener every render.
- **`AnnotationOverlay.jsx`** (match-results viewer, the reported regression) — wheel zoom mirrors the existing `zoomIn`/`zoomOut` imperative handle (`clampZoom` + `clampPan` + `zoomStep`), gated on `imageLoaded`, attached to the existing `outerContainerRef`.
- **`ImageModal.jsx`** (encounter-page modal) — wheel zoom matches its buttons (step `0.25`, range `1..3`); pan re-centers via the existing `[zoom, safeIndex]` effect. Listener attached to a new ref on `#image-modal-image-container`. Also moved the `if (!assets…) return null` guard **below** the hooks (it previously sat above all hooks — a latent Rules-of-Hooks violation) and normalized the `assets` prop to an array so the hooks are null-safe.

## Behavior decisions

- **One zoom step per wheel notch, centered** — matches what the icon buttons already do. Zoom-to-cursor is deliberately left as a future enhancement: the two viewers use different `transformOrigin` (top-left vs center) and pan models (clamped vs reset-on-zoom), so cursor-anchoring would reintroduce per-component divergence.
- `preventDefault()` stops the page from scrolling while zooming. The listener is scoped to the image container only.
- No change to the zoom buttons, imperative handle, pan-drag, annotation rendering, or zoom bounds.

## Scope / follow-up

- **`ImageGalleryModal.jsx` is intentionally excluded.** Its zoom/pan comes from the still-open #1596 (no zoom on `main`); adding wheel-zoom there now would conflict. It gets the same `useWheelZoom` hook in a quick follow-up once #1596 merges.
- Trackpads emit many small wheel events, so wheel-zoom can feel fast on a trackpad; acceptable for restoring the mouse-wheel behavior and bounded by the zoom clamps. A delta-accumulation throttle is a possible future refinement.

## Testing

- Babel parse OK; ESLint clean (project flat config) on all three files; LF; `git diff --check` clean.
- Design and implementation each reviewed by a second-opinion pass (caught and fixed the ImageModal hook-ordering + null-safety issues).
- Manual (after build/deploy): on `/react/match-results`, wheel up/down over an image zooms in/out within bounds, the page doesn't scroll, annotation rects stay aligned, and the buttons still work. Same on the encounter-page image modal.

Reviewed by Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
