### PR TITLE
Species-specific Modified Groth parameters (+ one-resolver consolidation)

### DIFF
--- a/devops/deploy/.dockerfiles/tomcat/commonConfiguration.properties
+++ b/devops/deploy/.dockerfiles/tomcat/commonConfiguration.properties
@@ -79,11 +79,18 @@ algorithms = I3S,HolmbergIntersection,FastDTW
 
 
 #Modified Groth algorithm parameters for spot pattern recognition
-R=8
-epsilon=0.01
-sizelim=0.9
-maxTriangleRotation=30
-C=0.99
+# Modified Groth — global defaults (corrected whale-shark optimum, 2026-06)
+epsilon=0.015
+R=8.8
+sizelim=0.94
+maxTriangleRotation=20
+C=1.146
+# Per-species overrides (sand tiger / ragged-tooth)
+epsilon.carcharias_taurus=0.008
+R.carcharias_taurus=60
+sizelim.carcharias_taurus=0.99
+maxTriangleRotation.carcharias_taurus=12
+C.carcharias_taurus=0.998
 
 #Other common properties used for some data export (e.g. Encounter Search Excel export)
 citation=Put your citation here.

--- a/devops/development/.dockerfiles/tomcat/commonConfiguration.properties
+++ b/devops/development/.dockerfiles/tomcat/commonConfiguration.properties
@@ -79,11 +79,18 @@ algorithms = I3S,HolmbergIntersection,FastDTW
 
 
 #Modified Groth algorithm parameters for spot pattern recognition
-R=8
-epsilon=0.01
-sizelim=0.9
-maxTriangleRotation=30
-C=0.99
+# Modified Groth — global defaults (corrected whale-shark optimum, 2026-06)
+epsilon=0.015
+R=8.8
+sizelim=0.94
+maxTriangleRotation=20
+C=1.146
+# Per-species overrides (sand tiger / ragged-tooth)
+epsilon.carcharias_taurus=0.008
+R.carcharias_taurus=60
+sizelim.carcharias_taurus=0.99
+maxTriangleRotation.carcharias_taurus=12
+C.carcharias_taurus=0.998
 
 #Other common properties used for some data export (e.g. Encounter Search Excel export)
 citation=Put your citation here.

--- a/docs/superpowers/plans/2026-06-22-species-specific-groth-params.md
+++ b/docs/superpowers/plans/2026-06-22-species-specific-groth-params.md
@@ -1,0 +1,429 @@
+# Species-Specific Modified Groth Parameters — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve Modified Groth matching parameters per query-species (global fallback), via one consolidated resolver used by both scan paths.
+
+**Architecture:** A new immutable `GrothParams` holder + a `CommonConfiguration.getGrothParams(genus, epithet, context)` resolver (species-key → global → safe constant). The sync (`GrothMatchServlet`), async-create (`ScanWorkItemCreationThread`), and async-write (`WriteOutScanTask`) paths all call it; `GridManager`'s hardcoded param fields/getters are retired. Per-species values live as suffixed keys in `commonConfiguration.properties`.
+
+**Tech Stack:** Java 17, Maven, JUnit 5. Repo: Wildbook (worktree `/mnt/c/Wildbook-groth-wt`, branch `skill/species-groth-params`).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-22-species-specific-groth-params-design.md`.
+- Species key: built from genus+epithet only when **both** non-blank; lowercased `Locale.ROOT`; non-`[a-z0-9]` runs → single `_`; trim leading/trailing `_`; null otherwise.
+- Param parse: trim; blank → missing; `Double.parseDouble`; reject non-finite and `<= 0`; on invalid, fall to next level (never throw mid-scan).
+- Resolution order per param: `name.<speciesKey>` → `name` (global) → hardcoded default.
+- Safe-constant defaults = corrected whale-shark optimum: epsilon=0.015, R=8.8, sizelim=0.94, maxTriangleRotation=20.0, C=1.146.
+- `secondRun` is NOT part of `GrothParams`; leave its handling untouched.
+- Build check command (whole repo, incremental): `mvn -q -DskipTests test-compile`.
+
+---
+
+### Task 1: `GrothParams` holder + `CommonConfiguration` resolver (TDD)
+
+**Files:**
+- Create: `src/main/java/org/ecocean/grid/GrothParams.java`
+- Modify: `src/main/java/org/ecocean/CommonConfiguration.java` (add resolver + helpers + constants)
+- Test: `src/test/java/org/ecocean/grid/GrothParamsTest.java`
+
+**Interfaces:**
+- Produces:
+  - `org.ecocean.grid.GrothParams(double epsilon, double R, double sizelim, double maxTriangleRotation, double C)` with getters `getEpsilon/getR/getSizelim/getMaxTriangleRotation/getC` (all `double`).
+  - `CommonConfiguration.getGrothParams(String genus, String specificEpithet, String context) -> GrothParams`
+  - `CommonConfiguration.resolveGrothParams(String genus, String specificEpithet, java.util.function.Function<String,String> lookup) -> GrothParams` (package-visible, testable)
+  - `CommonConfiguration.speciesKey(String genus, String specificEpithet) -> String` (nullable)
+
+- [ ] **Step 1: Write the failing test** — `src/test/java/org/ecocean/grid/GrothParamsTest.java`
+
+```java
+package org.ecocean.grid;
+
+import org.ecocean.CommonConfiguration;
+import org.junit.jupiter.api.Test;
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GrothParamsTest {
+
+    private static java.util.function.Function<String,String> lookup(Map<String,String> m) {
+        return m::get; // returns null for absent keys
+    }
+
+    @Test void speciesKeyNormalizes() {
+        assertEquals("carcharias_taurus", CommonConfiguration.speciesKey("Carcharias", "taurus"));
+        assertEquals("carcharias_taurus", CommonConfiguration.speciesKey("  Carcharias ", " taurus "));
+    }
+
+    @Test void speciesKeyNullWhenEitherBlank() {
+        assertNull(CommonConfiguration.speciesKey("Carcharias", ""));
+        assertNull(CommonConfiguration.speciesKey(null, "taurus"));
+        assertNull(CommonConfiguration.speciesKey("  ", "taurus"));
+    }
+
+    @Test void speciesOverrideWins() {
+        Map<String,String> p = new HashMap<>();
+        p.put("R", "8.8"); p.put("R.carcharias_taurus", "60");
+        GrothParams gp = CommonConfiguration.resolveGrothParams("Carcharias", "taurus", lookup(p));
+        assertEquals(60.0, gp.getR(), 1e-9);
+    }
+
+    @Test void fallsBackToGlobalWhenNoSpeciesKey() {
+        Map<String,String> p = new HashMap<>();
+        p.put("R", "8.8");
+        GrothParams gp = CommonConfiguration.resolveGrothParams("Rhincodon", "typus", lookup(p));
+        assertEquals(8.8, gp.getR(), 1e-9);
+    }
+
+    @Test void fallsBackToConstantWhenMissing() {
+        GrothParams gp = CommonConfiguration.resolveGrothParams("Foo", "bar", lookup(new HashMap<>()));
+        assertEquals(8.8, gp.getR(), 1e-9);          // default R
+        assertEquals(0.015, gp.getEpsilon(), 1e-9);  // default epsilon
+        assertEquals(1.146, gp.getC(), 1e-9);        // default C
+    }
+
+    @Test void nullSpeciesUsesGlobal() {
+        Map<String,String> p = new HashMap<>();
+        p.put("R", "8.8"); p.put("R.carcharias_taurus", "60");
+        GrothParams gp = CommonConfiguration.resolveGrothParams(null, null, lookup(p));
+        assertEquals(8.8, gp.getR(), 1e-9);
+    }
+
+    @Test void invalidValuesFallThrough() {
+        Map<String,String> p = new HashMap<>();
+        p.put("R.carcharias_taurus", "   ");   // blank
+        p.put("R", "NaN");                       // non-finite
+        GrothParams gp = CommonConfiguration.resolveGrothParams("Carcharias", "taurus", lookup(p));
+        assertEquals(8.8, gp.getR(), 1e-9);     // both invalid -> default
+        Map<String,String> p2 = new HashMap<>();
+        p2.put("sizelim", "-1");                 // <= 0
+        assertEquals(0.94, CommonConfiguration.resolveGrothParams("X","y", lookup(p2)).getSizelim(), 1e-9);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails to compile / fails**
+
+Run: `mvn -q test -Dtest=GrothParamsTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED"`
+Expected: FAIL — `GrothParams` / `resolveGrothParams` / `speciesKey` symbols not found.
+
+- [ ] **Step 3: Create `GrothParams`** — `src/main/java/org/ecocean/grid/GrothParams.java`
+
+```java
+package org.ecocean.grid;
+
+/** Immutable holder for the five Modified Groth matching parameters. */
+public final class GrothParams {
+    private final double epsilon, R, sizelim, maxTriangleRotation, C;
+
+    public GrothParams(double epsilon, double R, double sizelim,
+                       double maxTriangleRotation, double C) {
+        this.epsilon = epsilon;
+        this.R = R;
+        this.sizelim = sizelim;
+        this.maxTriangleRotation = maxTriangleRotation;
+        this.C = C;
+    }
+
+    public double getEpsilon() { return epsilon; }
+    public double getR() { return R; }
+    public double getSizelim() { return sizelim; }
+    public double getMaxTriangleRotation() { return maxTriangleRotation; }
+    public double getC() { return C; }
+}
+```
+
+- [ ] **Step 4: Add the resolver to `CommonConfiguration`** — insert these members (near the other Groth getters, e.g. after `getC`). Add `import org.ecocean.grid.GrothParams;` and `import java.util.function.Function;` and `import java.util.Locale;` if not present.
+
+```java
+// --- Species-aware Modified Groth parameters (June 2026) ---
+// Safe-constant defaults = corrected whale-shark optimum.
+private static final double GROTH_DEFAULT_EPSILON = 0.015;
+private static final double GROTH_DEFAULT_R = 8.8;
+private static final double GROTH_DEFAULT_SIZELIM = 0.94;
+private static final double GROTH_DEFAULT_MAXROT = 20.0;
+private static final double GROTH_DEFAULT_C = 1.146;
+
+/** Normalized property-key suffix from a species, or null if either part is blank. */
+public static String speciesKey(String genus, String specificEpithet) {
+    if (genus == null || specificEpithet == null) return null;
+    String g = genus.trim(), s = specificEpithet.trim();
+    if (g.isEmpty() || s.isEmpty()) return null;
+    String key = (g + "_" + s).toLowerCase(Locale.ROOT)
+                    .replaceAll("[^a-z0-9]+", "_")
+                    .replaceAll("^_+|_+$", "");
+    return key.isEmpty() ? null : key;
+}
+
+/** Parse a positive, finite double, or null if missing/blank/invalid. */
+private static Double positiveFiniteOrNull(String raw) {
+    if (raw == null) return null;
+    String t = raw.trim();
+    if (t.isEmpty()) return null;
+    try {
+        double d = Double.parseDouble(t);
+        if (!Double.isFinite(d) || d <= 0.0) return null;
+        return d;
+    } catch (NumberFormatException e) {
+        return null;
+    }
+}
+
+private static double resolveOne(String name, String speciesKey,
+                                 Function<String,String> lookup, double dflt) {
+    if (speciesKey != null) {
+        Double v = positiveFiniteOrNull(lookup.apply(name + "." + speciesKey));
+        if (v != null) return v;
+    }
+    Double g = positiveFiniteOrNull(lookup.apply(name));
+    if (g != null) return g;
+    return dflt;
+}
+
+/** Testable core: resolve all five params against an arbitrary property lookup. */
+static GrothParams resolveGrothParams(String genus, String specificEpithet,
+                                      Function<String,String> lookup) {
+    String sk = speciesKey(genus, specificEpithet);
+    return new GrothParams(
+        resolveOne("epsilon", sk, lookup, GROTH_DEFAULT_EPSILON),
+        resolveOne("R", sk, lookup, GROTH_DEFAULT_R),
+        resolveOne("sizelim", sk, lookup, GROTH_DEFAULT_SIZELIM),
+        resolveOne("maxTriangleRotation", sk, lookup, GROTH_DEFAULT_MAXROT),
+        resolveOne("C", sk, lookup, GROTH_DEFAULT_C));
+}
+
+/** Resolve the Groth params for a query species using configured properties. */
+public static GrothParams getGrothParams(String genus, String specificEpithet, String context) {
+    return resolveGrothParams(genus, specificEpithet, name -> getProperty(name, context));
+}
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `mvn -q test -Dtest=GrothParamsTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED"`
+Expected: PASS (7 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/java/org/ecocean/grid/GrothParams.java \
+        src/main/java/org/ecocean/CommonConfiguration.java \
+        src/test/java/org/ecocean/grid/GrothParamsTest.java
+git commit -m "feat(groth): species-aware GrothParams resolver in CommonConfiguration"
+```
+
+---
+
+### Task 2: Wire the sync path (`GrothMatchServlet`)
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/servlet/GrothMatchServlet.java`
+
+**Interfaces:**
+- Consumes: `CommonConfiguration.getGrothParams(genus, epithet, context)`, `GrothParams` getters.
+
+- [ ] **Step 1: Capture query species during the DB-load block.** In the `try` block that loads `enc` (around the existing `encDate = enc.getDate();` lines), add:
+
+```java
+queryGenus = enc.getGenus();
+querySpecificEpithet = enc.getSpecificEpithet();
+```
+Declare `String queryGenus = null, querySpecificEpithet = null;` alongside the other `enc*` locals declared before the DB block.
+
+- [ ] **Step 2: Replace the early global reads with a species-resolved lookup.** Replace the existing block:
+
+```java
+epsilon = Double.parseDouble(CommonConfiguration.getEpsilon(context));
+R = Double.parseDouble(CommonConfiguration.getR(context));
+Sizelim = Double.parseDouble(CommonConfiguration.getSizelim(context));
+maxTriangleRotation = Double.parseDouble(
+    CommonConfiguration.getMaxTriangleRotation(context));
+C = Double.parseDouble(CommonConfiguration.getC(context));
+```
+with a single resolve performed AFTER `enc` is loaded (move it just before the match loop / Phase 2):
+
+```java
+org.ecocean.grid.GrothParams gp =
+    CommonConfiguration.getGrothParams(queryGenus, querySpecificEpithet, context);
+epsilon = gp.getEpsilon();
+R = gp.getR();
+Sizelim = gp.getSizelim();
+maxTriangleRotation = gp.getMaxTriangleRotation();
+C = gp.getC();
+```
+(Keep the `double epsilon, R, Sizelim, maxTriangleRotation, C;` declarations; just assign later. The result-XML `root.addAttribute(...)` lines already use these locals and now reflect the species-resolved values — no change needed there.)
+
+- [ ] **Step 3: Compile**
+
+Run: `mvn -q -DskipTests test-compile`
+Expected: BUILD SUCCESS, no errors in `GrothMatchServlet.java`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/org/ecocean/servlet/GrothMatchServlet.java
+git commit -m "feat(groth): sync scan resolves params by query species"
+```
+
+---
+
+### Task 3: Wire the async-create path (`ScanWorkItemCreationThread`)
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/grid/ScanWorkItemCreationThread.java`
+
+**Interfaces:**
+- Consumes: `CommonConfiguration.getGrothParams(genus, epithet, context)`. The thread's `context` field (constructor arg) and `baseEnc` (already loaded via `gm.getMatchGraphEncounterLiteEntry(encounterNumber)`).
+
+- [ ] **Step 1: Move param setting to after `baseEnc` is loaded and resolve by species.** Today `props2` Groth params are set from `gm.getGrothEpsilon()` etc. BEFORE `baseEnc` exists. Delete those five lines:
+
+```java
+props2.setProperty("epsilon", gm.getGrothEpsilon());
+props2.setProperty("R", gm.getGrothR());
+props2.setProperty("Sizelim", gm.getGrothSizelim());
+props2.setProperty("maxTriangleRotation", gm.getGrothMaxTriangleRotation());
+props2.setProperty("C", gm.getGrothC());
+```
+Keep the `props2.setProperty("secondRun", gm.getGrothSecondRun());` and `props2.setProperty("rightScan", rightScan);` lines as-is.
+
+After `EncounterLite baseEnc = gm.getMatchGraphEncounterLiteEntry(encounterNumber);` (and its existing null handling), insert:
+
+```java
+String qGenus = (baseEnc != null) ? baseEnc.getGenus() : null;
+String qEpithet = (baseEnc != null) ? baseEnc.getSpecificEpithet() : null;
+org.ecocean.grid.GrothParams gp =
+    CommonConfiguration.getGrothParams(qGenus, qEpithet, context);
+props2.setProperty("epsilon", String.valueOf(gp.getEpsilon()));
+props2.setProperty("R", String.valueOf(gp.getR()));
+props2.setProperty("Sizelim", String.valueOf(gp.getSizelim()));
+props2.setProperty("maxTriangleRotation", String.valueOf(gp.getMaxTriangleRotation()));
+props2.setProperty("C", String.valueOf(gp.getC()));
+```
+Add `import org.ecocean.CommonConfiguration;` if not already imported.
+
+- [ ] **Step 2: Compile**
+
+Run: `mvn -q -DskipTests test-compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/org/ecocean/grid/ScanWorkItemCreationThread.java
+git commit -m "feat(groth): async scan-item creation resolves params by query species"
+```
+
+---
+
+### Task 4: Wire the async result writer (`WriteOutScanTask`)
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/servlet/WriteOutScanTask.java`
+
+**Interfaces:**
+- Consumes: `CommonConfiguration.getGrothParams(genus, epithet, context)`.
+
+- [ ] **Step 1: Resolve once by the query species and pass those values into the XML writer.** At each site that currently passes `CommonConfiguration.getR(context), CommonConfiguration.getEpsilon(context), CommonConfiguration.getSizelim(context), CommonConfiguration.getMaxTriangleRotation(context), CommonConfiguration.getC(context)` (~lines 86-89 and 121-124), first resolve params from the query encounter's species (the query encounter is available as the scan subject — use its `getGenus()/getSpecificEpithet()`), then pass `gp` getters:
+
+```java
+GrothParams gp = CommonConfiguration.getGrothParams(
+    queryEnc.getGenus(), queryEnc.getSpecificEpithet(), context);
+// ... pass gp.getR(), gp.getEpsilon(), gp.getSizelim(),
+//     gp.getMaxTriangleRotation(), gp.getC() in place of the CommonConfiguration.getX calls
+```
+Add `import org.ecocean.grid.GrothParams;`. (If the query `Encounter` object isn't already in scope at these lines, load it once via the existing `Shepherd`/`encNumber` and reuse for both sites.)
+
+- [ ] **Step 2: Compile**
+
+Run: `mvn -q -DskipTests test-compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/org/ecocean/servlet/WriteOutScanTask.java
+git commit -m "fix(groth): async result XML records species-resolved params"
+```
+
+---
+
+### Task 5: Retire `GridManager` hardcoded param fields/getters
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/grid/GridManager.java`
+
+**Interfaces:**
+- Removes: `getGrothEpsilon/getGrothR/getGrothSizelim/getGrothMaxTriangleRotation/getGrothC` and their backing fields. Keeps `getGrothSecondRun` and its field.
+
+- [ ] **Step 1: Confirm no remaining callers** (besides the now-updated async thread).
+
+Run: `rg -n "getGroth(Epsilon|R|Sizelim|MaxTriangleRotation|C)\b" src/main`
+Expected: no matches (the only former caller, `ScanWorkItemCreationThread`, was changed in Task 3).
+
+- [ ] **Step 2: Delete the five fields** (`private String epsilon = "0.008";` … `private String C = "1.146";`) and the five getters (`getGrothEpsilon`…`getGrothC`). Leave `secondRun` field + `getGrothSecondRun()` intact.
+
+- [ ] **Step 3: Compile**
+
+Run: `mvn -q -DskipTests test-compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/org/ecocean/grid/GridManager.java
+git commit -m "refactor(groth): remove GridManager hardcoded params (one source of truth)"
+```
+
+---
+
+### Task 6: Set global + sand-tiger property values (all three copies)
+
+**Files:**
+- Modify: `src/main/resources/bundles/commonConfiguration.properties`
+- Modify: `devops/deploy/.dockerfiles/tomcat/commonConfiguration.properties`
+- Modify: `devops/development/.dockerfiles/tomcat/commonConfiguration.properties`
+
+- [ ] **Step 1: In each of the three files**, set the global Groth block to the corrected whale-shark optimum and add the sand-tiger overrides. Replace the existing `R=/epsilon=/sizelim=/maxTriangleRotation=/C=` lines with:
+
+```
+# Modified Groth — global defaults (corrected whale-shark optimum, 2026-06)
+epsilon=0.015
+R=8.8
+sizelim=0.94
+maxTriangleRotation=20
+C=1.146
+# Per-species overrides (sand tiger / ragged-tooth)
+epsilon.carcharias_taurus=0.008
+R.carcharias_taurus=60
+sizelim.carcharias_taurus=0.99
+maxTriangleRotation.carcharias_taurus=12
+C.carcharias_taurus=0.998
+```
+
+- [ ] **Step 2: Verify all three are consistent**
+
+Run: `rg -n "^(R|epsilon|sizelim|maxTriangleRotation|C)(\.|=)" src/main/resources/bundles/commonConfiguration.properties devops/deploy/.dockerfiles/tomcat/commonConfiguration.properties devops/development/.dockerfiles/tomcat/commonConfiguration.properties`
+Expected: identical 10-line Groth block in all three.
+
+- [ ] **Step 3: Full test + compile sanity**
+
+Run: `mvn -q test -Dtest=GrothParamsTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED"` then `mvn -q -DskipTests test-compile`
+Expected: tests PASS, BUILD SUCCESS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/resources/bundles/commonConfiguration.properties \
+        devops/deploy/.dockerfiles/tomcat/commonConfiguration.properties \
+        devops/development/.dockerfiles/tomcat/commonConfiguration.properties
+git commit -m "config(groth): global=whale-shark optimum + sand-tiger overrides (all copies)"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** resolver (T1) ✓, sync wiring (T2) ✓, async-create wiring (T3) ✓, async-write XML (T4) ✓, retire GridManager (T5) ✓, properties ×3 (T6) ✓, testing (T1) ✓. `secondRun` preserved (T3, T5). Reorder-after-load (T2, T3). Normalization/parse robustness (T1).
+- **Verification limits:** T2-T5 are servlet/thread integration — verified by compile + the T1 unit test + reasoned review (no unit harness for the scan servlets). A final Codex pass on the full diff + `/code-review` precede the PR.
+- **Exact line numbers** are intentionally given as anchors (code-to-replace) rather than fixed line numbers, since edits shift them.

--- a/docs/superpowers/specs/2026-06-22-species-specific-groth-params-design.md
+++ b/docs/superpowers/specs/2026-06-22-species-specific-groth-params-design.md
@@ -1,0 +1,166 @@
+# Species-Specific Modified Groth Parameters — Design
+
+**Date:** 2026-06-22
+**Status:** approved (pending Codex design review)
+
+## Problem
+
+The five Modified Groth matching parameters (`epsilon`, `R`, `sizelim`,
+`maxTriangleRotation`, `C`) are applied **globally** to every species. Tuning done
+for whale sharks (*Rhincodon typus*) is therefore cross-applied to all species.
+Corrected, production-faithful parameter sweeps (June 2026) show the per-species
+optima genuinely diverge:
+
+| Param | Whale shark optimum | Sand tiger optimum |
+|-------|--------------------:|-------------------:|
+| epsilon | 0.015 | 0.008 |
+| R | 8.8 | 60 |
+| sizelim | 0.94 | 0.99 |
+| maxTriangleRotation | 20 | 12 |
+| C | 1.146 | 0.998 |
+
+`R` differs ~7×. One global set cannot serve both, which matches user reports of
+degraded sand tiger (*Carcharias taurus*) matching. The fix is to let the
+parameters vary by the **query encounter's species**, falling back to global
+defaults when no species-specific tuning exists.
+
+A second, related defect: the parameters are read from **two independent
+sources** depending on scan path —
+- sync `GrothMatchServlet` reads `CommonConfiguration.getR()` etc. (from
+  `commonConfiguration.properties`),
+- async `ScanWorkItemCreationThread` reads `GridManager.getGrothR()` etc. (from
+  hardcoded `GridManager` fields).
+
+These can (and currently do) disagree. This design consolidates both paths onto
+one resolver as part of the same change.
+
+## Goals
+
+1. Groth parameters resolve per query-species, with global fallback.
+2. Both scan paths (sync + async) use the **same** resolver — one source of truth.
+3. No behavior change for species without an override (given global defaults are
+   set to the corrected whale-shark optimum).
+4. Operators can tune per species by editing properties, no redeploy.
+
+## Non-Goals (YAGNI)
+
+- No DB- or JSON-backed config, no admin UI.
+- No per-location, per-viewpoint, or per-IA-class parameters.
+- No change to the Groth algorithm itself.
+- The corrected benchmark test (`GrothParameterSweepTest`) fixes are committed
+  separately, not bundled into this feature.
+
+## Design
+
+### Storage: species-keyed properties with global fallback
+
+In `commonConfiguration.properties`, parameters may carry an optional
+species-suffixed key. The suffix is the species key with the space replaced by an
+underscore (`Carcharias taurus` → `Carcharias_taurus`), matching the existing
+`GridManager` WB-1791 species convention (`genus + " " + specificEpithet`).
+
+```
+# global defaults (fallback) — corrected whale-shark optimum
+epsilon=0.015
+R=8.8
+sizelim=0.94
+maxTriangleRotation=20
+C=1.146
+
+# per-species overrides (optional) — sand tiger
+epsilon.Carcharias_taurus=0.008
+R.Carcharias_taurus=60
+sizelim.Carcharias_taurus=0.99
+maxTriangleRotation.Carcharias_taurus=12
+C.Carcharias_taurus=0.998
+```
+
+All three property copies are set consistently: the in-jar bundle
+(`src/main/resources/bundles/`) and both devops dockerfile copies
+(`devops/deploy/`, `devops/development/`). This also resolves the current
+divergence (bundle=6.8, devops=8 old defaults).
+
+### Resolver
+
+New value holder `org.ecocean.grid.GrothParams` (immutable; five `double` fields +
+getters). New static method on `CommonConfiguration`:
+
+```java
+public static GrothParams getGrothParams(String species, String context)
+```
+
+Per-parameter resolution order:
+1. `getProperty("<name>." + speciesKey, context)` if `species` non-blank
+2. else `getProperty("<name>", context)` (global)
+3. else a hardcoded safe constant (the corrected whale-shark optimum), so a
+   missing or malformed property never crashes a scan.
+
+`speciesKey` = `species.trim().replace(' ', '_')`. Null/blank species skips step 1.
+A non-numeric property value is logged and falls through to the next level rather
+than throwing.
+
+### Wiring
+
+- **`GrothMatchServlet`** (sync): derive species from the query
+  `enc.getGenus()/getSpecificEpithet()`; replace the five
+  `CommonConfiguration.getX()` calls with one `getGrothParams(species, context)`.
+  The result XML continues to record the params actually used (now species-resolved).
+- **`ScanWorkItemCreationThread`** (async): derive species from the query
+  `baseEnc` (EncounterLite carries `genus`/`specificEpithet`); replace the five
+  `gm.getGrothX()` calls with `getGrothParams(species, context)`. (Verify the
+  thread has a usable `context`; pass one in if not.)
+- **`GridManager`**: remove the hardcoded `epsilon/R/Sizelim/maxTriangleRotation/C`
+  fields and `getGrothX()` getters. Grep first for any other callers; if found,
+  point them at the resolver (global lookup). This eliminates the second source.
+
+### Data flow
+
+```
+query Encounter ──(genus + specificEpithet)──> speciesKey
+                                                   │
+GrothMatchServlet / ScanWorkItemCreationThread ────┤
+                                                   ▼
+              CommonConfiguration.getGrothParams(species, context)
+                 species key ──hit──> per-species value
+                 miss ──> global value ──miss──> safe constant
+                                                   ▼
+              EncounterLite.getPointsForBestMatch(..., epsilon, R, sizelim, rot, C, ...)
+```
+
+### Error handling / fallback
+
+- Null/blank/unknown species → global defaults.
+- Missing global property → hardcoded safe constant (corrected whale-shark optimum).
+- Malformed (non-numeric) property → log a warning, fall through; never throw mid-scan.
+
+### Testing
+
+New fast unit test for the resolver (no benchmark CSV needed):
+- species override present → returns override values
+- species absent from properties → returns global
+- null/blank species → returns global
+- malformed value → falls back, does not throw
+- speciesKey normalization (`"Carcharias taurus"` → `Carcharias_taurus`)
+
+Manual/optional: confirm whale-shark matching is unchanged (global = its optimum)
+and sand tiger now uses its override in both scan paths.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `org/ecocean/grid/GrothParams.java` | NEW — immutable 5-param holder |
+| `org/ecocean/CommonConfiguration.java` | NEW `getGrothParams(species, context)` + species-key resolution + safe constants |
+| `org/ecocean/servlet/GrothMatchServlet.java` | resolve via query species |
+| `org/ecocean/grid/ScanWorkItemCreationThread.java` | resolve via query species |
+| `org/ecocean/grid/GridManager.java` | retire hardcoded param fields/getters |
+| `commonConfiguration.properties` (×3) | consistent globals + sand tiger overrides |
+| `org/ecocean/grid/GrothParamsTest.java` | NEW — resolver unit test |
+
+## Risks
+
+- Removing `GridManager` getters could break an unseen caller → mitigate by grep
+  before removal.
+- Changing the whale-shark global from the deployed `6.8` to `8.8`: small,
+  evidence-based, approved by product owner. Whale-shark behavior shifts slightly.
+- `context` availability in the async thread → verify during implementation.

--- a/docs/superpowers/specs/2026-06-22-species-specific-groth-params-design.md
+++ b/docs/superpowers/specs/2026-06-22-species-specific-groth-params-design.md
@@ -40,7 +40,9 @@ one resolver as part of the same change.
 2. Both scan paths (sync + async) use the **same** resolver — one source of truth.
 3. No behavior change for species without an override (given global defaults are
    set to the corrected whale-shark optimum).
-4. Operators can tune per species by editing properties, no redeploy.
+4. Operators can tune per species by editing properties (requires an app restart
+   or config-cache reload — `CommonConfiguration` caches the `Properties` per
+   context once loaded; a live-reload endpoint is a possible follow-up, out of scope here).
 
 ## Non-Goals (YAGNI)
 
@@ -55,9 +57,10 @@ one resolver as part of the same change.
 ### Storage: species-keyed properties with global fallback
 
 In `commonConfiguration.properties`, parameters may carry an optional
-species-suffixed key. The suffix is the species key with the space replaced by an
-underscore (`Carcharias taurus` → `Carcharias_taurus`), matching the existing
-`GridManager` WB-1791 species convention (`genus + " " + specificEpithet`).
+species-suffixed key. The suffix is a **normalized** species key (see resolver
+below): built from genus + epithet only when both are non-blank, lowercased
+(`Locale.ROOT`), with whitespace/punctuation runs collapsed to `_`. So
+`Carcharias taurus` → `carcharias_taurus`.
 
 ```
 # global defaults (fallback) — corrected whale-shark optimum
@@ -68,11 +71,11 @@ maxTriangleRotation=20
 C=1.146
 
 # per-species overrides (optional) — sand tiger
-epsilon.Carcharias_taurus=0.008
-R.Carcharias_taurus=60
-sizelim.Carcharias_taurus=0.99
-maxTriangleRotation.Carcharias_taurus=12
-C.Carcharias_taurus=0.998
+epsilon.carcharias_taurus=0.008
+R.carcharias_taurus=60
+sizelim.carcharias_taurus=0.99
+maxTriangleRotation.carcharias_taurus=12
+C.carcharias_taurus=0.998
 ```
 
 All three property copies are set consistently: the in-jar bundle
@@ -90,28 +93,49 @@ public static GrothParams getGrothParams(String species, String context)
 ```
 
 Per-parameter resolution order:
-1. `getProperty("<name>." + speciesKey, context)` if `species` non-blank
+1. `getProperty("<name>." + speciesKey, context)` if `speciesKey` is non-null
 2. else `getProperty("<name>", context)` (global)
 3. else a hardcoded safe constant (the corrected whale-shark optimum), so a
    missing or malformed property never crashes a scan.
 
-`speciesKey` = `species.trim().replace(' ', '_')`. Null/blank species skips step 1.
-A non-numeric property value is logged and falls through to the next level rather
-than throwing.
+**Species key** (`CommonConfiguration.speciesKey(genus, epithet)`): returns null
+unless **both** genus and epithet are non-blank; otherwise
+`(genus + "_" + epithet)`, lowercased with `Locale.ROOT`, runs of non-`[A-Za-z0-9]`
+collapsed to a single `_`, leading/trailing `_` trimmed. e.g. `"Carcharias","taurus"`
+→ `carcharias_taurus`.
+
+**Value parsing** (each level): `trim()`; treat blank/whitespace as *missing*
+(fall through); `Double.parseDouble`; **reject non-finite** (`NaN`/`Infinity`) and
+out-of-range values (fall through). Do **not** reuse the existing
+`CommonConfiguration.getR()`-style getters — they call `.trim()` on a possibly-null
+value and can NPE. A value that is present-but-invalid logs a warning and falls to
+the next level.
 
 ### Wiring
 
-- **`GrothMatchServlet`** (sync): derive species from the query
-  `enc.getGenus()/getSpecificEpithet()`; replace the five
-  `CommonConfiguration.getX()` calls with one `getGrothParams(species, context)`.
-  The result XML continues to record the params actually used (now species-resolved).
-- **`ScanWorkItemCreationThread`** (async): derive species from the query
-  `baseEnc` (EncounterLite carries `genus`/`specificEpithet`); replace the five
-  `gm.getGrothX()` calls with `getGrothParams(species, context)`. (Verify the
-  thread has a usable `context`; pass one in if not.)
+**Ordering matters**: in both paths the params are currently resolved *before* the
+query encounter is loaded; resolution must move to *after* the species is known.
+
+- **`GrothMatchServlet`** (sync): config is read at lines ~66-79 but the query
+  `Encounter` isn't loaded until ~89. Capture `enc.getGenus()/getSpecificEpithet()`
+  inside the DB-load block, then call `getGrothParams(species, context)` before the
+  match loop. Result XML continues to record the params actually used (now species-resolved).
+- **`ScanWorkItemCreationThread`** (async): has a `String context` constructor arg
+  (~line 23) and `baseEnc = gm.getMatchGraphEncounterLiteEntry(...)` (~83);
+  `EncounterLite` exposes `getGenus()/getSpecificEpithet()` (~1586). Move the
+  `props2` Groth-param setting to **after** `baseEnc` is loaded (null-check it), then
+  set the five params from `getGrothParams(species, context)`. **Keep
+  `props2.setProperty("secondRun", ...)` exactly as-is** — `ScanWorkItem` reads it and
+  calls `.equals()` on it (~line 94); `secondRun` is NOT part of `GrothParams`.
+- **`WriteOutScanTask`** (async result writer): currently writes result XML from the
+  **global** `CommonConfiguration.getR()/...` (~86, ~120) — with species overrides this
+  would report different params than were used for matching. Re-resolve via the query
+  species so the XML records the values actually applied. (Caveat: config edited
+  mid-scan can still drift; acceptable.)
 - **`GridManager`**: remove the hardcoded `epsilon/R/Sizelim/maxTriangleRotation/C`
-  fields and `getGrothX()` getters. Grep first for any other callers; if found,
-  point them at the resolver (global lookup). This eliminates the second source.
+  fields and the five `getGrothX()` getters. Codex grep confirms the only callers are
+  in `ScanWorkItemCreationThread` (replaced above), so removal is safe. **Leave the
+  `secondRun` getter/handling alone.** This eliminates the second source.
 
 ### Data flow
 
@@ -129,9 +153,13 @@ GrothMatchServlet / ScanWorkItemCreationThread ────┤
 
 ### Error handling / fallback
 
-- Null/blank/unknown species → global defaults.
-- Missing global property → hardcoded safe constant (corrected whale-shark optimum).
-- Malformed (non-numeric) property → log a warning, fall through; never throw mid-scan.
+- Null/blank species (or genus/epithet) → skip species key, use global.
+- Property missing or **blank/whitespace** → treat as missing, fall to next level.
+- Present-but-invalid value (non-numeric, `NaN`, `Infinity`, out-of-range) → log a
+  warning, fall to next level; never throw mid-scan.
+- Missing even the global property → hardcoded safe constant (corrected whale-shark
+  optimum). Parsing is done in the resolver, not via the old `getR()`-style getters
+  (which NPE on null).
 
 ### Testing
 
@@ -140,7 +168,9 @@ New fast unit test for the resolver (no benchmark CSV needed):
 - species absent from properties → returns global
 - null/blank species → returns global
 - malformed value → falls back, does not throw
-- speciesKey normalization (`"Carcharias taurus"` → `Carcharias_taurus`)
+- speciesKey normalization (`"Carcharias","taurus"` → `carcharias_taurus`; blank
+  genus or epithet → null key → global)
+- present-but-blank and non-finite (`NaN`/`Infinity`) values → fall through
 
 Manual/optional: confirm whale-shark matching is unchanged (global = its optimum)
 and sand tiger now uses its override in both scan paths.
@@ -151,16 +181,23 @@ and sand tiger now uses its override in both scan paths.
 |------|--------|
 | `org/ecocean/grid/GrothParams.java` | NEW — immutable 5-param holder |
 | `org/ecocean/CommonConfiguration.java` | NEW `getGrothParams(species, context)` + species-key resolution + safe constants |
-| `org/ecocean/servlet/GrothMatchServlet.java` | resolve via query species |
-| `org/ecocean/grid/ScanWorkItemCreationThread.java` | resolve via query species |
-| `org/ecocean/grid/GridManager.java` | retire hardcoded param fields/getters |
-| `commonConfiguration.properties` (×3) | consistent globals + sand tiger overrides |
+| `org/ecocean/servlet/GrothMatchServlet.java` | resolve via query species (after enc load) |
+| `org/ecocean/grid/ScanWorkItemCreationThread.java` | resolve via query species (after baseEnc load); keep `secondRun` |
+| `org/ecocean/servlet/WriteOutScanTask.java` | resolve result-XML params via query species (not global) |
+| `org/ecocean/grid/GridManager.java` | retire 5 hardcoded param fields/getters (keep `secondRun`) |
+| `commonConfiguration.properties` (×3) | consistent globals + sand tiger overrides, updated atomically |
 | `org/ecocean/grid/GrothParamsTest.java` | NEW — resolver unit test |
 
 ## Risks
 
-- Removing `GridManager` getters could break an unseen caller → mitigate by grep
-  before removal.
-- Changing the whale-shark global from the deployed `6.8` to `8.8`: small,
-  evidence-based, approved by product owner. Whale-shark behavior shifts slightly.
-- `context` availability in the async thread → verify during implementation.
+- Removing `GridManager` getters: Codex grep confirms only `ScanWorkItemCreationThread`
+  calls them; removal safe after replacement. `secondRun` getter retained.
+- **Behavior changes for *every* species without an override**, because all three
+  property copies are being unified onto the corrected whale-shark globals (today:
+  bundle=6.8, devops=8). This is intended (the corrected globals beat the deployed
+  values for whale sharks too: +0.138 mAP), but it is not a pure no-op for non-sand-tiger
+  species — call it out in the PR. Update all three copies atomically.
+- **Config is cached per context**; property edits require an app restart / cache
+  reload to take effect (no live-reload endpoint in scope).
+- New params are slower (~3× per query for whale sharks: higher sizelim builds more
+  triangles) — accuracy/throughput tradeoff to note for scan capacity planning.

--- a/docs/superpowers/specs/2026-06-22-species-specific-groth-params-design.md
+++ b/docs/superpowers/specs/2026-06-22-species-specific-groth-params-design.md
@@ -188,6 +188,21 @@ and sand tiger now uses its override in both scan paths.
 | `commonConfiguration.properties` (×3) | consistent globals + sand tiger overrides, updated atomically |
 | `org/ecocean/grid/GrothParamsTest.java` | NEW — resolver unit test |
 
+## Decision log
+
+- **Global-default value (Option A, approved):** global = corrected whale-shark
+  optimum. Whale shark and sand tiger are validated; **zebra shark (*Stegostoma
+  tigrinum*), nursehound (*Scyliorhinus stellaris*), and sevengill (*Notorynchus
+  cepedianus*) knowingly move onto whale-shark globals without their own validation.**
+  Accepted as a reasonable default until per-species sweeps exist.
+
+## Follow-ups (out of scope for this PR)
+
+- Corrected sweeps for zebra shark (~98K spot rows) and nursehound (~12K) → add
+  their own overrides if they diverge.
+- Commit the corrected `GrothParameterSweepTest` benchmark fixes (separate change).
+- Optional live config-reload endpoint (params are currently cached per context).
+
 ## Risks
 
 - Removing `GridManager` getters: Codex grep confirms only `ScanWorkItemCreationThread`

--- a/src/main/java/org/ecocean/CommonConfiguration.java
+++ b/src/main/java/org/ecocean/CommonConfiguration.java
@@ -8,6 +8,10 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
+import java.util.function.Function;
+import java.util.Locale;
+
+import org.ecocean.grid.GrothParams;
 
 import javax.servlet.ServletContext;
 
@@ -431,6 +435,67 @@ public class CommonConfiguration {
 
     public static String getC(String context) {
         return getProperty("C", context).trim();
+    }
+
+    // --- Species-aware Modified Groth parameters (June 2026) ---
+    // Safe-constant defaults = corrected whale-shark optimum.
+    private static final double GROTH_DEFAULT_EPSILON = 0.015;
+    private static final double GROTH_DEFAULT_R = 8.8;
+    private static final double GROTH_DEFAULT_SIZELIM = 0.94;
+    private static final double GROTH_DEFAULT_MAXROT = 20.0;
+    private static final double GROTH_DEFAULT_C = 1.146;
+
+    /** Normalized property-key suffix from a species, or null if either part is blank. */
+    public static String speciesKey(String genus, String specificEpithet) {
+        if (genus == null || specificEpithet == null) return null;
+        String g = genus.trim(), s = specificEpithet.trim();
+        if (g.isEmpty() || s.isEmpty()) return null;
+        String key = (g + "_" + s).toLowerCase(Locale.ROOT)
+                        .replaceAll("[^a-z0-9]+", "_")
+                        .replaceAll("^_+|_+$", "");
+        return key.isEmpty() ? null : key;
+    }
+
+    /** Parse a positive, finite double, or null if missing/blank/invalid. */
+    private static Double positiveFiniteOrNull(String raw) {
+        if (raw == null) return null;
+        String t = raw.trim();
+        if (t.isEmpty()) return null;
+        try {
+            double d = Double.parseDouble(t);
+            if (!Double.isFinite(d) || d <= 0.0) return null;
+            return d;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static double resolveOne(String name, String speciesKey,
+                                     Function<String,String> lookup, double dflt) {
+        if (speciesKey != null) {
+            Double v = positiveFiniteOrNull(lookup.apply(name + "." + speciesKey));
+            if (v != null) return v;
+        }
+        Double g = positiveFiniteOrNull(lookup.apply(name));
+        if (g != null) return g;
+        return dflt;
+    }
+
+    /** Testable core: resolve all five params against an arbitrary property lookup. */
+    public static GrothParams resolveGrothParams(String genus, String specificEpithet,
+                                                 Function<String,String> lookup) {
+        String sk = speciesKey(genus, specificEpithet);
+        return new GrothParams(
+            resolveOne("epsilon", sk, lookup, GROTH_DEFAULT_EPSILON),
+            resolveOne("R", sk, lookup, GROTH_DEFAULT_R),
+            resolveOne("sizelim", sk, lookup, GROTH_DEFAULT_SIZELIM),
+            resolveOne("maxTriangleRotation", sk, lookup, GROTH_DEFAULT_MAXROT),
+            resolveOne("C", sk, lookup, GROTH_DEFAULT_C));
+    }
+
+    /** Resolve the Groth params for a query species using configured properties. */
+    public static GrothParams getGrothParams(String genus, String specificEpithet, String context) {
+        return resolveGrothParams(genus, specificEpithet, name -> getProperty(name, context));
     }
 
     public static String getHTMLDescription(String context) {

--- a/src/main/java/org/ecocean/grid/GridManager.java
+++ b/src/main/java/org/ecocean/grid/GridManager.java
@@ -42,12 +42,6 @@ public class GridManager {
 
     // public ConcurrentHashMap<String,Integer> scanTaskSizes=new ConcurrentHashMap<String, Integer>();
 
-    // Modified Groth algorithm parameters (optimized via GrothParameterSweepTest)
-    private String epsilon = "0.008";
-    private String R = "6.8";
-    private String Sizelim = "0.671";
-    private String maxTriangleRotation = "22.5";
-    private String C = "1.146";
     private String secondRun = "true";
 
     private static ConcurrentHashMap<String,
@@ -266,26 +260,6 @@ public class GridManager {
         } else {
             return (100 * numCollisions / numCompletedWorkItems);
         }
-    }
-
-    public String getGrothEpsilon() {
-        return epsilon;
-    }
-
-    public String getGrothR() {
-        return R;
-    }
-
-    public String getGrothSizelim() {
-        return Sizelim;
-    }
-
-    public String getGrothMaxTriangleRotation() {
-        return maxTriangleRotation;
-    }
-
-    public String getGrothC() {
-        return C;
     }
 
     public String getGrothSecondRun() {

--- a/src/main/java/org/ecocean/grid/GrothParams.java
+++ b/src/main/java/org/ecocean/grid/GrothParams.java
@@ -1,0 +1,21 @@
+package org.ecocean.grid;
+
+/** Immutable holder for the five Modified Groth matching parameters. */
+public final class GrothParams {
+    private final double epsilon, R, sizelim, maxTriangleRotation, C;
+
+    public GrothParams(double epsilon, double R, double sizelim,
+                       double maxTriangleRotation, double C) {
+        this.epsilon = epsilon;
+        this.R = R;
+        this.sizelim = sizelim;
+        this.maxTriangleRotation = maxTriangleRotation;
+        this.C = C;
+    }
+
+    public double getEpsilon() { return epsilon; }
+    public double getR() { return R; }
+    public double getSizelim() { return sizelim; }
+    public double getMaxTriangleRotation() { return maxTriangleRotation; }
+    public double getC() { return C; }
+}

--- a/src/main/java/org/ecocean/grid/ScanWorkItemCreationThread.java
+++ b/src/main/java/org/ecocean/grid/ScanWorkItemCreationThread.java
@@ -74,9 +74,14 @@ public class ScanWorkItemCreationThread implements Runnable, ISharkGridThread {
         // myShepherd.beginDBTransaction();
         // EncounterLite baseEnc=new EncounterLite(myShepherd.getEncounter(encounterNumber));
         EncounterLite baseEnc = gm.getMatchGraphEncounterLiteEntry(encounterNumber);
-        // Resolve Groth params by query encounter's species
-        String qGenus = (baseEnc != null) ? baseEnc.getGenus() : null;
-        String qEpithet = (baseEnc != null) ? baseEnc.getSpecificEpithet() : null;
+        if (baseEnc == null) {
+            System.out.println("ScanWorkItemCreationThread: encounterNumber " + encounterNumber +
+                " not found in match graph — cannot build work items, aborting.");
+            return;
+        }
+        // Resolve Groth params by query encounter's species (baseEnc is guaranteed non-null here)
+        String qGenus = baseEnc.getGenus();
+        String qEpithet = baseEnc.getSpecificEpithet();
         org.ecocean.grid.GrothParams gp = CommonConfiguration.getGrothParams(qGenus, qEpithet, context);
         props2.setProperty("epsilon", String.valueOf(gp.getEpsilon()));
         props2.setProperty("R", String.valueOf(gp.getR()));

--- a/src/main/java/org/ecocean/grid/ScanWorkItemCreationThread.java
+++ b/src/main/java/org/ecocean/grid/ScanWorkItemCreationThread.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.Enumeration;
 import java.util.Vector;
 import javax.jdo.Query;
+import org.ecocean.CommonConfiguration;
 
 public class ScanWorkItemCreationThread implements Runnable, ISharkGridThread {
     public Thread threadCreationObject;
@@ -65,14 +66,6 @@ public class ScanWorkItemCreationThread implements Runnable, ISharkGridThread {
             rightScan = "true";
         }
         props2.setProperty("rightScan", rightScan);
-
-        // Modified Groth algorithm parameters
-        // pulled from the gridManager
-        props2.setProperty("epsilon", gm.getGrothEpsilon());
-        props2.setProperty("R", gm.getGrothR());
-        props2.setProperty("Sizelim", gm.getGrothSizelim());
-        props2.setProperty("maxTriangleRotation", gm.getGrothMaxTriangleRotation());
-        props2.setProperty("C", gm.getGrothC());
         props2.setProperty("secondRun", gm.getGrothSecondRun());
 
         Vector<String> newSWIs = new Vector<String>();
@@ -81,6 +74,15 @@ public class ScanWorkItemCreationThread implements Runnable, ISharkGridThread {
         // myShepherd.beginDBTransaction();
         // EncounterLite baseEnc=new EncounterLite(myShepherd.getEncounter(encounterNumber));
         EncounterLite baseEnc = gm.getMatchGraphEncounterLiteEntry(encounterNumber);
+        // Resolve Groth params by query encounter's species
+        String qGenus = (baseEnc != null) ? baseEnc.getGenus() : null;
+        String qEpithet = (baseEnc != null) ? baseEnc.getSpecificEpithet() : null;
+        org.ecocean.grid.GrothParams gp = CommonConfiguration.getGrothParams(qGenus, qEpithet, context);
+        props2.setProperty("epsilon", String.valueOf(gp.getEpsilon()));
+        props2.setProperty("R", String.valueOf(gp.getR()));
+        props2.setProperty("Sizelim", String.valueOf(gp.getSizelim()));
+        props2.setProperty("maxTriangleRotation", String.valueOf(gp.getMaxTriangleRotation()));
+        props2.setProperty("C", String.valueOf(gp.getC()));
         // myShepherd.rollbackDBTransaction();
         // now, add the workItems
         // myShepherd.beginDBTransaction();

--- a/src/main/java/org/ecocean/servlet/GrothMatchServlet.java
+++ b/src/main/java/org/ecocean/servlet/GrothMatchServlet.java
@@ -93,14 +93,15 @@ public class GrothMatchServlet extends HttpServlet {
                 }
 
                 queryArray = querySpots.toArray(new SuperSpot[0]);
-                queryGenus = enc.getGenus();
-                querySpecificEpithet = enc.getSpecificEpithet();
                 encDate = enc.getDate();
                 encSex = enc.getSex() != null ? enc.getSex() : "unknown";
                 encIndividualID = ServletUtilities.handleNullString(enc.getIndividualID());
                 encSize = enc.getSizeAsDouble() != null ? enc.getSize() + " meters" : "unknown";
                 encLocation = enc.getLocation();
                 encLocationID = enc.getLocationID();
+                // Query species for species-aware Groth param resolution (below).
+                queryGenus = enc.getGenus();
+                querySpecificEpithet = enc.getSpecificEpithet();
             } finally {
                 myShepherd.rollbackDBTransaction();
                 myShepherd.closeDBTransaction();

--- a/src/main/java/org/ecocean/servlet/GrothMatchServlet.java
+++ b/src/main/java/org/ecocean/servlet/GrothMatchServlet.java
@@ -63,24 +63,13 @@ public class GrothMatchServlet extends HttpServlet {
             return;
         }
 
-        // Read Groth parameters from config
+        // Groth parameter locals — resolved after enc is loaded (see Phase 1/2 boundary)
         double epsilon, R, Sizelim, maxTriangleRotation, C;
-        try {
-            epsilon = Double.parseDouble(CommonConfiguration.getEpsilon(context));
-            R = Double.parseDouble(CommonConfiguration.getR(context));
-            Sizelim = Double.parseDouble(CommonConfiguration.getSizelim(context));
-            maxTriangleRotation = Double.parseDouble(
-                CommonConfiguration.getMaxTriangleRotation(context));
-            C = Double.parseDouble(CommonConfiguration.getC(context));
-        } catch (NumberFormatException e) {
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                "Invalid Groth parameters in configuration: " + e.getMessage());
-            return;
-        }
 
         // Phase 1: Short DB transaction to load query encounter spots
         SuperSpot[] queryArray;
         String encDate, encSex, encIndividualID, encLocation, encLocationID, encSize;
+        String queryGenus = null, querySpecificEpithet = null;
         {
             Shepherd myShepherd = new Shepherd(context);
             myShepherd.setAction("GrothMatchServlet.class");
@@ -104,6 +93,8 @@ public class GrothMatchServlet extends HttpServlet {
                 }
 
                 queryArray = querySpots.toArray(new SuperSpot[0]);
+                queryGenus = enc.getGenus();
+                querySpecificEpithet = enc.getSpecificEpithet();
                 encDate = enc.getDate();
                 encSex = enc.getSex() != null ? enc.getSex() : "unknown";
                 encIndividualID = ServletUtilities.handleNullString(enc.getIndividualID());
@@ -115,6 +106,15 @@ public class GrothMatchServlet extends HttpServlet {
                 myShepherd.closeDBTransaction();
             }
         }
+
+        // Resolve Groth parameters by query encounter's species
+        org.ecocean.grid.GrothParams gp =
+            CommonConfiguration.getGrothParams(queryGenus, querySpecificEpithet, context);
+        epsilon = gp.getEpsilon();
+        R = gp.getR();
+        Sizelim = gp.getSizelim();
+        maxTriangleRotation = gp.getMaxTriangleRotation();
+        C = gp.getC();
 
         // Phase 2: CPU-heavy Groth matching — no DB transaction needed
         long startTime = System.currentTimeMillis();

--- a/src/main/java/org/ecocean/servlet/WriteOutScanTask.java
+++ b/src/main/java/org/ecocean/servlet/WriteOutScanTask.java
@@ -70,8 +70,11 @@ public class WriteOutScanTask extends HttpServlet {
             String newEncShark = "";
             String newEncSize = "";
             Encounter newEnc = myShepherd.getEncounter(encNumber);
-            String wqGenus = (newEnc != null) ? newEnc.getGenus() : null;
-            String wqEpithet = (newEnc != null) ? newEnc.getSpecificEpithet() : null;
+            // Resolve species from the in-memory match graph (same source as ScanWorkItemCreationThread),
+            // not from the DB encounter, so the Groth params are consistent with the async creation thread.
+            EncounterLite qle = GridManager.getMatchGraph().get(encNumber);
+            String wqGenus = (qle != null) ? qle.getGenus() : null;
+            String wqEpithet = (qle != null) ? qle.getSpecificEpithet() : null;
             org.ecocean.grid.GrothParams gp = CommonConfiguration.getGrothParams(wqGenus, wqEpithet, context);
             newEncDate = newEnc.getDate();
             if (newEnc.getIndividualID() != null) {

--- a/src/main/java/org/ecocean/servlet/WriteOutScanTask.java
+++ b/src/main/java/org/ecocean/servlet/WriteOutScanTask.java
@@ -70,6 +70,9 @@ public class WriteOutScanTask extends HttpServlet {
             String newEncShark = "";
             String newEncSize = "";
             Encounter newEnc = myShepherd.getEncounter(encNumber);
+            String wqGenus = (newEnc != null) ? newEnc.getGenus() : null;
+            String wqEpithet = (newEnc != null) ? newEnc.getSpecificEpithet() : null;
+            org.ecocean.grid.GrothParams gp = CommonConfiguration.getGrothParams(wqGenus, wqEpithet, context);
             newEncDate = newEnc.getDate();
             if (newEnc.getIndividualID() != null) {
                 newEncShark = newEnc.getIndividualID();
@@ -83,10 +86,10 @@ public class WriteOutScanTask extends HttpServlet {
             if (taskID.startsWith("scanR")) {
                 righty = true;
             }
-            boolean successfulWrite = writeResult(res, encNumber, CommonConfiguration.getR(context),
-                CommonConfiguration.getEpsilon(context), CommonConfiguration.getSizelim(context),
-                CommonConfiguration.getMaxTriangleRotation(context),
-                CommonConfiguration.getC(context), newEncDate, newEncShark, newEncSize, righty,
+            boolean successfulWrite = writeResult(res, encNumber, String.valueOf(gp.getR()),
+                String.valueOf(gp.getEpsilon()), String.valueOf(gp.getSizelim()),
+                String.valueOf(gp.getMaxTriangleRotation()),
+                String.valueOf(gp.getC()), newEncDate, newEncShark, newEncSize, righty,
                 cutoff, myShepherd, context, "", null);
             boolean successfulI3SWrite = i3sWriteThis(myShepherd, res, encNumber, newEncDate,
                 newEncShark, newEncSize, righty, 2.5, context);
@@ -118,10 +121,10 @@ public class WriteOutScanTask extends HttpServlet {
                     Arrays.sort(resLoc, new MatchComparator());
                     // System.out.println("resLoc="+resLoc.length+"; filtered="+filtered.size());
                     successfulLocationIDWrite = writeResult(resLoc, encNumber,
-                        CommonConfiguration.getR(context), CommonConfiguration.getEpsilon(context),
-                        CommonConfiguration.getSizelim(context),
-                        CommonConfiguration.getMaxTriangleRotation(context),
-                        CommonConfiguration.getC(context), newEncDate, newEncShark, newEncSize,
+                        String.valueOf(gp.getR()), String.valueOf(gp.getEpsilon()),
+                        String.valueOf(gp.getSizelim()),
+                        String.valueOf(gp.getMaxTriangleRotation()),
+                        String.valueOf(gp.getC()), newEncDate, newEncShark, newEncSize,
                         righty, cutoff, myShepherd, context, "LocationID", locs);
                 }
             }

--- a/src/main/resources/bundles/commonConfiguration.properties
+++ b/src/main/resources/bundles/commonConfiguration.properties
@@ -54,11 +54,18 @@ algorithms = I3S,HolmbergIntersection,FastDTW
 
 
 #Modified Groth algorithm parameters for spot pattern recognition
-R=6.8
-epsilon=0.008
-sizelim=0.671
-maxTriangleRotation=22.5
+# Modified Groth — global defaults (corrected whale-shark optimum, 2026-06)
+epsilon=0.015
+R=8.8
+sizelim=0.94
+maxTriangleRotation=20
 C=1.146
+# Per-species overrides (sand tiger / ragged-tooth)
+epsilon.carcharias_taurus=0.008
+R.carcharias_taurus=60
+sizelim.carcharias_taurus=0.99
+maxTriangleRotation.carcharias_taurus=12
+C.carcharias_taurus=0.998
 
 #Other common properties used for some data export (e.g. Encounter Search Excel export)
 citation=Put your citation here.

--- a/src/test/java/org/ecocean/grid/GrothParameterSweepTest.java
+++ b/src/test/java/org/ecocean/grid/GrothParameterSweepTest.java
@@ -134,7 +134,7 @@ class GrothParameterSweepTest {
         // Step 5: Build catalog
         catalog = new LinkedHashMap<>();
         for (Map.Entry<String, ArrayList<SuperSpot>> entry : encounterSpots.entrySet()) {
-            if (entry.getValue().size() >= 3) {
+            if (entry.getValue().size() >= 4) {  // production-visible spot count (>=4)
                 EncounterLite el = new EncounterLite();
                 el.processLeftSpots(entry.getValue());
                 catalog.put(entry.getKey(), el);
@@ -462,7 +462,7 @@ class GrothParameterSweepTest {
 
         for (String queryEncId : queryEncIds) {
             ArrayList<SuperSpot> querySpots = encounterSpots.get(queryEncId);
-            if (querySpots == null || querySpots.size() < 3) continue;
+            if (querySpots == null || querySpots.size() < 4) continue;  // production requires >=4 query spots (GrothMatchServlet:99)
 
             SuperSpot[] queryArray = querySpots.toArray(new SuperSpot[0]);
             String trueIndId = encounterToIndividual.get(queryEncId);
@@ -503,15 +503,38 @@ class GrothParameterSweepTest {
             }
             totalTimeNanos += System.nanoTime() - startNanos;
 
-            results.sort((a, b) -> Double.compare(b.matchValue, a.matchValue));
+            // Production-faithful scoring: mirror GrothMatchServlet / WriteOutScanTask.
+            // (1) gate: a match is only shown when matchValue>0 AND
+            //     matchValue*adjustedMatchValue>2;
+            // (2) sort by that product (MatchComparator), with a deterministic
+            //     encounterNumber tiebreak so ground-truth insertion order can never
+            //     leak into the ranking (MatchComparator returns 0 on ties, and Java's
+            //     stable sort would otherwise keep the truth-first ordering);
+            // (3) cap to the top 100 displayed matches.
+            List<MatchObject> visible = new ArrayList<>();
+            for (MatchObject mo : results) {
+                if (mo.getMatchValue() > 0 &&
+                    (mo.getMatchValue() * mo.getAdjustedMatchValue()) > 2) {
+                    visible.add(mo);
+                }
+            }
+            visible.sort((a, b) -> {
+                double pa = a.getMatchValue() * a.getAdjustedMatchValue();
+                double pb = b.getMatchValue() * b.getAdjustedMatchValue();
+                int cmp = Double.compare(pb, pa);
+                if (cmp != 0) return cmp;
+                return a.getEncounterNumber().compareTo(b.getEncounterNumber());
+            });
+            if (visible.size() > 100) visible = new ArrayList<>(visible.subList(0, 100));
 
-            // Rank-1
-            int rank = findCorrectRank(results, queryEncId, trueIndId);
+            // Rank-1 / Rank-5 over the production-visible list. numTrueInCatalog remains
+            // the AP denominator, so true matches suppressed by the gate or pushed past
+            // rank 100 correctly count as misses.
+            int rank = findCorrectRank(visible, queryEncId, trueIndId);
             if (rank == 1) rank1Hits++;
             if (rank >= 1 && rank <= 5) rank5Hits++;
 
-            // Average Precision for this query
-            double ap = computeAP(results, trueEncounters, numTrueInCatalog);
+            double ap = computeAP(visible, trueEncounters, numTrueInCatalog);
             sumAP += ap;
 
             queriesRun++;
@@ -562,15 +585,15 @@ class GrothParameterSweepTest {
         for (Map.Entry<String, List<String>> entry : individualToEncounters.entrySet()) {
             String indId = entry.getKey();
             int encCount = entry.getValue().size();
-            // Verify at least one encounter is in the catalog
-            boolean hasCatalogEntry = false;
+            // Require >=2 catalog-resident (>=4-spot) encounters, so that after the query
+            // encounter is chosen from this set at least one true match remains in the
+            // catalog. This guarantees runBenchmark never skips the query for an empty
+            // true-match set, which would otherwise bias the sample (Codex Major #4).
+            int catalogEncs = 0;
             for (String encId : entry.getValue()) {
-                if (catalog.containsKey(encId)) {
-                    hasCatalogEntry = true;
-                    break;
-                }
+                if (catalog.containsKey(encId)) catalogEncs++;
             }
-            if (!hasCatalogEntry) continue;
+            if (catalogEncs < 2) continue;
 
             if (encCount == 2) {
                 twoEncInds.add(indId);
@@ -589,14 +612,20 @@ class GrothParameterSweepTest {
         // Select from 2-encounter individuals
         for (int i = 0; i < Math.min(halfQueries, twoEncInds.size()); i++) {
             String indId = twoEncInds.get(i);
-            List<String> encIds = individualToEncounters.get(indId);
+            List<String> encIds = new ArrayList<>();
+            for (String e : individualToEncounters.get(indId)) {
+                if (catalog.containsKey(e)) encIds.add(e);  // catalog-resident only
+            }
             queries.add(encIds.get(rng.nextInt(encIds.size())));
         }
 
         // Select from multi-encounter individuals
         for (int i = 0; i < Math.min(halfQueries, multiEncInds.size()); i++) {
             String indId = multiEncInds.get(i);
-            List<String> encIds = individualToEncounters.get(indId);
+            List<String> encIds = new ArrayList<>();
+            for (String e : individualToEncounters.get(indId)) {
+                if (catalog.containsKey(e)) encIds.add(e);  // catalog-resident only
+            }
             queries.add(encIds.get(rng.nextInt(encIds.size())));
         }
 
@@ -617,10 +646,11 @@ class GrothParameterSweepTest {
         double lo = (idx > 0) ? coarseValues[idx - 1] : winner * 0.7;
         double hi = (idx < coarseValues.length - 1) ? coarseValues[idx + 1] : winner * 1.3;
 
-        double[] fine = new double[5];
+        double[] fine = new double[6];
         for (int i = 0; i < 5; i++) {
             fine[i] = lo + (hi - lo) * i / 4.0;
         }
+        fine[5] = winner;  // always re-evaluate the current best so Round 2 cannot regress (Codex Major #5)
         return fine;
     }
 

--- a/src/test/java/org/ecocean/grid/GrothParameterSweepTest.java
+++ b/src/test/java/org/ecocean/grid/GrothParameterSweepTest.java
@@ -303,7 +303,7 @@ class GrothParameterSweepTest {
         double[] kingen = runBenchmark(0.008, 49.8, 0.998, 12.33, 0.998);
         System.out.println("  Kingen 2019 complete.");
         double[] optimized = runBenchmark(0.008, 6.8, 0.671, 22.5, 1.146);
-        System.out.println("  Optimized complete.");
+        System.out.println("  Original tuning (R=6.8, historical) complete.");
 
         // --- Print comparison table ---
         int q = (int) oldDefaults[3];
@@ -311,7 +311,7 @@ class GrothParameterSweepTest {
         System.out.println();
         System.out.println("----------------------------------------------------------------");
         System.out.printf("%-28s | %-16s | %-16s | %-16s%n",
-            "Metric", "Old Defaults", "Kingen 2019", "Optimized");
+            "Metric", "Old Defaults", "Kingen 2019", "Orig tuning R=6.8");
         System.out.println("----------------------------------------------------------------");
 
         System.out.printf("%-28s | %-16s | %-16s | %-16s%n",
@@ -365,7 +365,7 @@ class GrothParameterSweepTest {
         System.out.println("----------------------------------------------------------------");
 
         System.out.println();
-        System.out.println("=== Improvement Summary (Optimized vs Old Defaults) ===");
+        System.out.println("=== Improvement Summary (Original tuning R=6.8 vs Old Defaults) ===");
         System.out.printf("Rank-1:  %+.0f queries (%.1f%% -> %.1f%%)%n",
             optimized[0] - oldDefaults[0],
             100.0 * oldDefaults[0] / q, 100.0 * optimized[0] / q);
@@ -375,7 +375,7 @@ class GrothParameterSweepTest {
             speedupVsOld > 1 ? "faster" : "slower");
 
         System.out.println();
-        System.out.println("=== Improvement Summary (Optimized vs Kingen 2019) ===");
+        System.out.println("=== Improvement Summary (Original tuning R=6.8 vs Kingen 2019) ===");
         System.out.printf("Rank-1:  %+.0f queries (%.1f%% -> %.1f%%)%n",
             optimized[0] - kingen[0],
             100.0 * kingen[0] / q, 100.0 * optimized[0] / q);

--- a/src/test/java/org/ecocean/grid/GrothParamsTest.java
+++ b/src/test/java/org/ecocean/grid/GrothParamsTest.java
@@ -1,0 +1,64 @@
+package org.ecocean.grid;
+
+import org.ecocean.CommonConfiguration;
+import org.junit.jupiter.api.Test;
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GrothParamsTest {
+
+    private static java.util.function.Function<String,String> lookup(Map<String,String> m) {
+        return m::get; // returns null for absent keys
+    }
+
+    @Test void speciesKeyNormalizes() {
+        assertEquals("carcharias_taurus", CommonConfiguration.speciesKey("Carcharias", "taurus"));
+        assertEquals("carcharias_taurus", CommonConfiguration.speciesKey("  Carcharias ", " taurus "));
+    }
+
+    @Test void speciesKeyNullWhenEitherBlank() {
+        assertNull(CommonConfiguration.speciesKey("Carcharias", ""));
+        assertNull(CommonConfiguration.speciesKey(null, "taurus"));
+        assertNull(CommonConfiguration.speciesKey("  ", "taurus"));
+    }
+
+    @Test void speciesOverrideWins() {
+        Map<String,String> p = new HashMap<>();
+        p.put("R", "8.8"); p.put("R.carcharias_taurus", "60");
+        GrothParams gp = CommonConfiguration.resolveGrothParams("Carcharias", "taurus", lookup(p));
+        assertEquals(60.0, gp.getR(), 1e-9);
+    }
+
+    @Test void fallsBackToGlobalWhenNoSpeciesKey() {
+        Map<String,String> p = new HashMap<>();
+        p.put("R", "8.8");
+        GrothParams gp = CommonConfiguration.resolveGrothParams("Rhincodon", "typus", lookup(p));
+        assertEquals(8.8, gp.getR(), 1e-9);
+    }
+
+    @Test void fallsBackToConstantWhenMissing() {
+        GrothParams gp = CommonConfiguration.resolveGrothParams("Foo", "bar", lookup(new HashMap<>()));
+        assertEquals(8.8, gp.getR(), 1e-9);          // default R
+        assertEquals(0.015, gp.getEpsilon(), 1e-9);  // default epsilon
+        assertEquals(1.146, gp.getC(), 1e-9);        // default C
+    }
+
+    @Test void nullSpeciesUsesGlobal() {
+        Map<String,String> p = new HashMap<>();
+        p.put("R", "8.8"); p.put("R.carcharias_taurus", "60");
+        GrothParams gp = CommonConfiguration.resolveGrothParams(null, null, lookup(p));
+        assertEquals(8.8, gp.getR(), 1e-9);
+    }
+
+    @Test void invalidValuesFallThrough() {
+        Map<String,String> p = new HashMap<>();
+        p.put("R.carcharias_taurus", "   ");   // blank
+        p.put("R", "NaN");                       // non-finite
+        GrothParams gp = CommonConfiguration.resolveGrothParams("Carcharias", "taurus", lookup(p));
+        assertEquals(8.8, gp.getR(), 1e-9);     // both invalid -> default
+        Map<String,String> p2 = new HashMap<>();
+        p2.put("sizelim", "-1");                 // <= 0
+        assertEquals(0.94, CommonConfiguration.resolveGrothParams("X","y", lookup(p2)).getSizelim(), 1e-9);
+    }
+}


### PR DESCRIPTION
## Summary

Makes the Modified Groth matching parameters (`epsilon`, `R`, `sizelim`, `maxTriangleRotation`, `C`) **species-aware**: resolved per query-encounter species, falling back to global defaults. Also consolidates the two divergent parameter sources (GridManager hardcoded fields vs. `commonConfiguration.properties`) into a **single resolver** used by every scan path.

## Why

Corrected, production-faithful parameter sweeps show the per-species optima genuinely diverge — one global set cannot serve both species, which matches user reports of degraded sand tiger (*Carcharias taurus*) matching:

| Param | Whale shark optimum | Sand tiger optimum |
|---|---:|---:|
| epsilon | 0.015 | 0.008 |
| R | 8.8 | 60 |
| sizelim | 0.94 | 0.99 |
| maxTriangleRotation | 20 | 12 |
| C | 1.146 | 0.998 |

`R` differs ~7×. On whale-shark data (production-faithful benchmark), the new global defaults beat the previously-deployed `R=6.8` tuning by **+0.138 mAP (0.574 → 0.712, ~+24%)** and beat Kingen 2019 by +0.098 mAP — so adopting them improves the majority species too, not just sand tiger.

## What changed

- **New** `org.ecocean.grid.GrothParams` (immutable 5-param holder) + `CommonConfiguration.getGrothParams(genus, specificEpithet, context)` resolver: per-param lookup order `name.<speciesKey>` → `name` (global) → safe constant. Species key = lowercased, normalized `genus_epithet` (null if either blank). Robust parse (blank → missing; rejects `NaN`/`Infinity`/`<=0`; never throws mid-scan).
- **All three scan paths route through the resolver**, each resolving *after* the query species is known: `GrothMatchServlet` (sync), `ScanWorkItemCreationThread` (async create), `WriteOutScanTask` (async result XML). The two async paths resolve species from the same match-graph `EncounterLite` for within-scan consistency.
- **`GridManager` hardcoded Groth param fields/getters removed** (one source of truth). `secondRun` retained (consumed downstream via `.equals()`).
- **`commonConfiguration.properties` (all 3 copies)**: global = corrected whale-shark optimum; `*.carcharias_taurus` overrides for sand tiger.
- **`GrothParameterSweepTest` corrected** to be production-faithful (rank by `matchValue*adjustedMatchValue` with the `>2` display gate + top-100 cap, deterministic tiebreak, ≥4 spots, guaranteed-true-match query selection). New `GrothParamsTest` unit-tests the resolver.

## Behavior note

Species **without** an override (e.g. *Stegostoma tigrinum*, *Scyliorhinus stellaris*) move from today's deployed values to the corrected whale-shark globals. This is intended; those species haven't been individually swept yet (see follow-ups).

## Reviews & verification

- Design and final diff both reviewed by Codex (`codex exec`); all Major findings resolved.
- Per-task spec+quality reviews; whole-branch review: ready to merge.
- `GrothParamsTest` passes; full project `test-compile` succeeds.
- **Merge-clean verified** (`git merge-tree`, 0 conflicts) against `main`, **#1610** (deleted-spotmaps), and **#1611** (I3S live scan). The species-capture site was deliberately placed to avoid colliding with #1611's `queryLite` insertion.

## Follow-ups (out of scope)

- Corrected sweeps for zebra shark (~98K spot rows) and nursehound (~12K); add overrides if they diverge.
- Remove now-unused `CommonConfiguration.getR()/getEpsilon()/…` global getters (dead after this change; left in place to avoid JSP/external caller surprises).
- Optional live config-reload endpoint (params are cached per context; edits currently need a restart).

Design spec and implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
