### PR TITLE
Enable GET /api/v3/individuals/{id} with proper view ACL

### DIFF
--- a/src/main/java/org/ecocean/Base.java
+++ b/src/main/java/org/ecocean/Base.java
@@ -331,6 +331,9 @@ import org.json.JSONObject;
         case "annotations":
             tmp = new Annotation();
             break;
+        case "individuals":
+            tmp = new MarkedIndividual();
+            break;
         default:
             return null;
         }

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -2122,6 +2122,20 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         return Collaboration.canUserAccessMarkedIndividual(this, request);
     }
 
+    // view ACL for the generic /api/v3 GET path (see Base.jsonForApiGet). a user may view this
+    // individual if they are an admin or can view at least one of its encounters. an individual
+    // with no encounters grants no view access (rather than being visible to any logged-in user).
+    @Override public boolean canUserView(User user, Shepherd myShepherd) {
+        if (user == null) return false;
+        if (user.isAdmin(myShepherd)) return true;
+        Vector<Encounter> all = this.getEncounters();
+        if ((all == null) || all.isEmpty()) return false;
+        for (Encounter enc : all) {
+            if (enc.canUserView(user, myShepherd)) return true;
+        }
+        return false;
+    }
+
     // see note on Base class
     public List<String> userIdsWithViewAccess(Shepherd myShepherd) {
         List<String> ids = new ArrayList<String>();

--- a/src/main/java/org/ecocean/api/BaseObject.java
+++ b/src/main/java/org/ecocean/api/BaseObject.java
@@ -250,7 +250,8 @@ public class BaseObject extends ApiBase {
         try {
             User currentUser = myShepherd.getUser(request);
             Base obj = null;
-            if (args.length > 0) obj = Base.getByClassnameAndId(myShepherd, args[0], args[1]);
+            if ((args.length > 1) && Util.stringExists(args[1]))
+                obj = Base.getByClassnameAndId(myShepherd, args[0], args[1]);
             if (obj == null) {
                 rtn.put("statusCode", 404);
                 rtn.put("error", "not found");


### PR DESCRIPTION
## Summary

Enables `GET /api/v3/individuals/{individualID}` to actually resolve and return a `MarkedIndividual`. The URL pattern was already mapped to the `BaseObject` servlet in `web.xml`, and `MarkedIndividual` already overrides `Base.getById(...)`, but two pieces were missing, so the endpoint returned `404` (and would have returned `401` even once found):

1. `Base.getByClassnameAndId(...)` — the dispatch switch used by `BaseObject.processGet(...)` — handled only `encounters` and `annotations`, so an individual GET fell through to `return null` → `404 not found`.
2. `MarkedIndividual` did not override `canUserView(User, Shepherd)`. `Base.jsonForApiGet(...)` gates on `canUserView(...)`, and the `Base` default returns `false`, so the endpoint would have returned `401` for every caller even after the object resolved.

## Why

The supported way to fetch a single individual as JSON via the modern API is this `/api/v3` endpoint, which returns the sanitized OpenSearch-document representation and enforces `canUserView(...)`. With the wiring incomplete, there was no working `/api/v3` route to retrieve an individual by its `individualID`, leaving only the generic DataNucleus REST endpoint — which recursively serializes the full object graph and is unsuitable for entities with bidirectional relationships.

## Changes

- **`Base.getByClassnameAndId`** — add the `individuals` case:
  ```java
  case "individuals":
      tmp = new MarkedIndividual();
      break;
  ```
- **`MarkedIndividual.canUserView(User, Shepherd)`** — new override. A user may view an individual if they are an admin or can view at least one of its encounters. An individual with no encounters grants no view access (it is not made visible to any logged-in user). This mirrors `Encounter.canUserView(...)` and the per-encounter access loop already used for occurrences.
- **`BaseObject.processGet`** — require a non-empty id segment before lookup, so `/api/v3/individuals` (no id) returns the existing `404` path rather than throwing and falling through to a generic `500`.

## Behavior

`MarkedIndividual.getById()` → `Shepherd.getMarkedIndividual(id)` resolves by the `individualID` primary key. The response flows through `Base.jsonForApiGet(...)`:

- permitted user → sanitized individual JSON, `statusCode 200`
- user without view access → `statusCode 401`
- unknown / missing id → `statusCode 404`

## Scope note

`/api/v3/occurrences/*` is also mapped-but-unresolved by the same switch, but is intentionally **not** enabled here: the occurrence view path (`Collaboration.canUserViewOccurrence`) currently treats a zero-encounter occurrence as viewable by any authenticated user, which warrants its own review before that route is exposed.

## Testing

- `mvn compile` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
