### PR TITLE
Set acmId on manual annotations so they are matchable candidates

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -1588,6 +1588,14 @@ public class Annotation extends Base implements java.io.Serializable {
         Feature ft = new Feature("org.ecocean.boundingBox", fparams);
         Annotation ann = new Annotation(null, ft, iaClass);
         ann.setViewpoint(viewpoint);
+        // acmId is required for an annotation to be indexed and considered as a
+        // match CANDIDATE: both the OpenSearch indexer (matchAgainst==true &&
+        // acmId != null) and Annotation.getMatchingSetQuery (exists: acmId)
+        // filter on it. The v2 detection path sets it (MlServiceProcessor does
+        // setAcmId(getId())); manual creation omitted it, so manually-drawn
+        // annotations got an embedding but were never matchable candidates.
+        // Mirror the v2 convention: use the annotation's own id.
+        ann.setAcmId(ann.getId());
         ma.addFeature(ft);
         ma.setDetectionStatus("complete");
         myShepherd.getPM().makePersistent(ft);


### PR DESCRIPTION
## Problem
`Annotation.createFromApi` (React manual-annotation create; also the delete+recreate edit path) builds the annotation with an embedding, iaClass, viewpoint, and `matchAgainst=true` — but never sets `acmId`. Both the OpenSearch indexer (`matchAgainst==true && acmId != null`) and `Annotation.getMatchingSetQuery` (`exists: acmId`) require it, so manual annotations are extracted but **never indexed as match candidates** — invisible to the matcher. Confirmed live: 521 whaleshark annotations have embeddings + matchAgainst but null acmId and are excluded from candidacy.

## Fix
Mirror the v2 detection path (`MlServiceProcessor` sets `acmId = annotation id`): call `ann.setAcmId(ann.getId())` at creation. Codex-reviewed (converged); verified placement is not lost by the later cloneEncounter/trivial-removal logic.

## Follow-up (ops, not in this PR)
Existing manual annotations need a one-time backfill (`acmId = id` where `matchAgainst && acmId IS NULL` and an embedding exists) + OpenSearch reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)