### PR TITLE
Migrate Social Diagram reads to secured /api/v3/individuals/info/social-data

### DIFF
--- a/docs/superpowers/plans/2026-06-24-social-diagram-api-v3-reads.md
+++ b/docs/superpowers/plans/2026-06-24-social-diagram-api-v3-reads.md
@@ -1,0 +1,736 @@
+# Social Diagram read-path migration to `/api/v3` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the three crashing/unsafe legacy `/api/*` reads behind the `individuals.jsp` Social Diagram with one secured, ACL-filtering `/api/v3` endpoint, and rewrite the diagram JS to use it.
+
+**Architecture:** A new `social-data` GET branch in the existing `org.ecocean.api.MarkedIndividualInfo` servlet assembles, server-side and ACL-filtered, the encounter table and relationship table data for one individual. The legacy d3 JS (`encounter-calls.js`) is rewritten to fetch that single endpoint instead of `/api/jdoql` + per-object REST gets.
+
+**Tech Stack:** Java 17, DataNucleus JDO, servlets; JUnit 5 + Testcontainers (Postgres) + Mockito for backend tests; legacy d3/jQuery JS (no automated harness — manual verification).
+
+## Global Constraints
+
+- Commit LF only. After every Edit/Write to a tracked file run `perl -i -pe 's/\r\n/\n/g' <file>` and verify `grep -cP '\r$' <file>` is `0`.
+- Branch: `fix/social-diagram-api-v3-reads` (already created, stacked on `fix/api-v3-individuals-get` / PR #1633). Do not branch off bare `main` — this depends on `MarkedIndividual.canUserView`.
+- Reads only. Do NOT modify the relationship write flow (`RelationshipDelete`, the add/edit form, `getRelationshipData`/line 585) or the bubble-graph JSP feed (line 29).
+- No new endpoint URL/web.xml mapping; no OpenSearch serializer change.
+- Spec: `docs/superpowers/specs/2026-06-24-social-diagram-api-v3-reads-design.md` (authoritative; this plan implements it).
+- Maven single-test run: `mvn test -Dtest=MarkedIndividualInfoTest#<method> -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED -Xmx2g"` (match the repo's existing surefire argLine; copy from a currently-passing api test invocation if it differs).
+
+## File Structure
+
+- **Modify** `src/main/java/org/ecocean/api/MarkedIndividualInfo.java` — add the `social-data` route branch and private assembly helpers. All new server logic lives here (one focused servlet; no new class needed).
+- **Modify** `src/main/java/org/ecocean/MarkedIndividual.java` — add a `getAlternateID()` getter (partner display needs it; field is private with no accessor).
+- **Create** `src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java` — Testcontainers + direct-`doGet` tests for routing, status codes, and ACL filtering.
+- **Modify** `src/main/webapp/javascript/bubbleDiagram/encounter-calls.js` — rewrite `getEncounterTableData` (491) and `getRelationshipTableData` (655); delete `getIndividualData` (703).
+
+---
+
+### Task 1: Add `MarkedIndividual.getAlternateID()`
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/MarkedIndividual.java` (near the existing `getNickName()` at ~line 888)
+
+**Interfaces:**
+- Produces: `public String MarkedIndividual.getAlternateID()` returning the private `alternateid` field. Consumed by Task 5's partner block.
+
+- [ ] **Step 1: Add the getter**
+
+Insert after `getNickName()` (~line 890):
+
+```java
+    public String getAlternateID() {
+        return alternateid;
+    }
+```
+
+- [ ] **Step 2: Normalize + compile**
+
+Run: `perl -i -pe 's/\r\n/\n/g' src/main/java/org/ecocean/MarkedIndividual.java && grep -cP '\r$' src/main/java/org/ecocean/MarkedIndividual.java` (expect `0`)
+Run: `mvn -o compile`
+Expected: `BUILD SUCCESS`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/org/ecocean/MarkedIndividual.java
+git commit -m "feat: add MarkedIndividual.getAlternateID accessor"
+```
+
+---
+
+### Task 2: Endpoint skeleton — routing, auth gate, status codes
+
+Add the `social-data` branch returning `{encounters:[], relationships:[]}` for a viewable individual; establish the test class + Testcontainers fixture.
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/api/MarkedIndividualInfo.java`
+- Test: `src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java` (create)
+
+**Interfaces:**
+- Produces: `GET /api/v3/individuals/info/social-data?id={individualId}` → JSON `{success, statusCode, individualId, encounters:[], relationships:[]}`. Status: 401 anonymous, 400 blank id, 404 unknown id, 403 not-viewable, 200 ok. Private method signature later tasks extend: `private JSONObject getSocialData(Shepherd myShepherd, HttpServletRequest request, User user)`.
+
+- [ ] **Step 1: Write failing tests for routing/status codes**
+
+Create `src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java`. Use the established harness (Testcontainers Postgres + `context0` PMF init as in `SearchTokenScopeChildIndexTest`; direct `doGet` with mocked request/response + `StringWriter` as in `AuthTokenTest`). Shared fixture:
+
+```java
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Properties;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.CommonConfiguration;
+import org.ecocean.Encounter;
+import org.ecocean.MarkedIndividual;
+import org.ecocean.User;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.shepherd.core.TestPMFUtil;
+import org.json.JSONObject;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class MarkedIndividualInfoTest {
+    @Container static PostgreSQLContainer<?> postgres =
+        new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("wildbook_test").withUsername("wildbook").withPassword("wildbook");
+
+    static Properties props;
+
+    @BeforeAll static void setUp() {
+        Properties cc = new Properties();
+        cc.setProperty("collaborationSecurityEnabled", "true");
+        CommonConfiguration.initialize("context0", cc);
+        props = new Properties();
+        props.setProperty("datanucleus.ConnectionUserName", postgres.getUsername());
+        props.setProperty("datanucleus.ConnectionPassword", postgres.getPassword());
+        props.setProperty("datanucleus.ConnectionDriverName", postgres.getDriverClassName());
+        props.setProperty("datanucleus.ConnectionURL", postgres.getJdbcUrl());
+        props.setProperty("datanucleus.schema.autoCreateTables", "true");
+        TestPMFUtil.closePMF("context0");
+    }
+
+    @AfterAll static void tearDown() { TestPMFUtil.closePMF("context0"); }
+
+    // helper: invoke doGet and return parsed JSON body + captured status
+    static JSONObject invoke(User authUser, String idParam) throws Exception {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        when(req.getRequestURI()).thenReturn("/api/v3/individuals/info/social-data");
+        when(req.getParameter("id")).thenReturn(idParam);
+        // ServletUtilities.getContext + getUser must yield context0 + authUser:
+        when(req.getServletContext()).thenReturn(null);
+        // NOTE: confirm how MarkedIndividualInfo resolves the User from request in this repo
+        //       (myShepherd.getUser(request)); stub the session/principal accordingly.
+        new MarkedIndividualInfo().doGet(req, resp);
+        return new JSONObject(out.toString());
+    }
+}
+```
+
+Add the status-code tests (create one viewable individual with one owned encounter in a `@BeforeAll`-seeded transaction using `props`; see `EncounterExportImagesTest` seeding):
+
+```java
+    @Test void anonymousIs401() throws Exception {
+        JSONObject j = invoke(null, "any-id");
+        assertEquals(401, j.optInt("statusCode"));
+    }
+    @Test void blankIdIs400() throws Exception {
+        JSONObject j = invoke(seededOwner, "");
+        assertEquals(400, j.optInt("statusCode"));
+    }
+    @Test void unknownIdIs404() throws Exception {
+        JSONObject j = invoke(seededOwner, "00000000-0000-0000-0000-000000000000");
+        assertEquals(404, j.optInt("statusCode"));
+    }
+    @Test void viewableReturns200WithArrays() throws Exception {
+        JSONObject j = invoke(seededOwner, seededIndivId);
+        assertEquals(200, j.optInt("statusCode"));
+        assertTrue(j.has("encounters"));
+        assertTrue(j.has("relationships"));
+    }
+```
+
+(Seed `seededOwner`, `seededIndivId`, and a non-owner user `stranger` in `@BeforeAll` after `setUp`; persist a `User`, an `Encounter` with `enc.setSubmitterID(owner.getUsername())`, and `new MarkedIndividual(displayName, enc)` via `storeNewMarkedIndividual`. Add `notViewableIs403` once a stranger user exists and `collaborationSecurityEnabled` is on.)
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+Run: `mvn test -Dtest=MarkedIndividualInfoTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: FAIL (the `social-data` branch does not exist yet → body is the servlet's `unknown request` default, statusCode 500/mismatch).
+
+- [ ] **Step 3: Implement the route branch + gate**
+
+In `MarkedIndividualInfo.doGet`, extend the dispatch (after the existing `next_name` branch):
+
+```java
+        if (args[0].equals("individuals") && args[1].equals("info")) {
+            if (args[2].equals("next_name")) {
+                results = getNextNames(myShepherd, request, currentUser);
+            } else if (args[2].equals("social-data")) {
+                results = getSocialData(myShepherd, request, currentUser);
+            }
+        }
+```
+
+Add the method (skeleton — encounters/relationships filled in Tasks 3–5):
+
+```java
+    private JSONObject getSocialData(Shepherd myShepherd, HttpServletRequest request, User user) {
+        JSONObject rtn = new JSONObject();
+        rtn.put("success", false);
+        String id = request.getParameter("id");
+        if (!Util.stringExists(id)) {
+            rtn.put("statusCode", 400);
+            rtn.put("error", "missing id");
+            return rtn;
+        }
+        MarkedIndividual indiv = myShepherd.getMarkedIndividual(id.trim());
+        if (indiv == null) {
+            rtn.put("statusCode", 404);
+            rtn.put("error", "not found");
+            return rtn;
+        }
+        if (!indiv.canUserView(user, myShepherd)) {
+            rtn.put("statusCode", 403);
+            rtn.put("error", "access denied");
+            return rtn;
+        }
+        rtn.put("individualId", indiv.getId());
+        rtn.put("encounters", new org.json.JSONArray());
+        rtn.put("relationships", new org.json.JSONArray());
+        rtn.put("success", true);
+        rtn.put("statusCode", 200);
+        return rtn;
+    }
+```
+
+Add imports as needed: `org.ecocean.Encounter`, `org.ecocean.social.Relationship`, `org.json.JSONArray`, `java.util.*`.
+
+- [ ] **Step 4: Run tests — verify pass**
+
+Run: `mvn test -Dtest=MarkedIndividualInfoTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS (status-code tests green).
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' src/main/java/org/ecocean/api/MarkedIndividualInfo.java src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
+git add src/main/java/org/ecocean/api/MarkedIndividualInfo.java src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
+git commit -m "feat: add /api/v3/individuals/info/social-data route with auth gate"
+```
+
+---
+
+### Task 3: Encounter rows with per-encounter ACL filter + dataTypes
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/api/MarkedIndividualInfo.java`
+- Test: `src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java`
+
+**Interfaces:**
+- Consumes: `getSocialData` skeleton (Task 2).
+- Produces: each `encounters[]` row = `{catalogNumber, dateInMilliseconds, year, month, day, locationID, occurrenceID, sex, behavior, alternateid, dataTypes}` (occurringWith added in Task 4). Private helpers `boolean encCanView(Encounter, User, Shepherd, Map<String,Boolean>)`, `String computeDataTypes(Encounter)`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the test class (seed: an individual with two encounters owned by different users; a third encounter with a tissue sample + annotation):
+
+```java
+    @Test void onlyViewableEncountersReturned() throws Exception {
+        // owner sees both their encounters; stranger (no collab) sees only public ones
+        JSONObject asOwner = invoke(seededOwner, seededIndivId);
+        JSONObject asStranger = invoke(stranger, seededIndivId);
+        assertTrue(asOwner.getJSONArray("encounters").length()
+                   > asStranger.getJSONArray("encounters").length());
+    }
+    @Test void dataTypesBothWhenTissueAndAnnotation() throws Exception {
+        JSONObject j = invoke(seededOwner, indivWithTissueAndAnnotId);
+        String dt = j.getJSONArray("encounters").getJSONObject(0).getString("dataTypes");
+        assertEquals("both", dt);
+    }
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `mvn test -Dtest=MarkedIndividualInfoTest#onlyViewableEncountersReturned -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: FAIL (encounters array is empty).
+
+- [ ] **Step 3: Implement encounter assembly**
+
+Replace `rtn.put("encounters", new org.json.JSONArray());` in `getSocialData` with:
+
+```java
+        Map<String, Boolean> encViewCache = new HashMap<String, Boolean>();
+        JSONArray encArr = new JSONArray();
+        if (indiv.getEncounters() != null) {
+            for (Encounter enc : indiv.getEncounters()) {
+                if (!encCanView(enc, user, myShepherd, encViewCache)) continue;
+                JSONObject e = new JSONObject();
+                e.put("catalogNumber", enc.getCatalogNumber());
+                Long dim = enc.getDateInMilliseconds();
+                if (dim != null) e.put("dateInMilliseconds", dim.longValue());
+                e.put("year", enc.getYear());
+                e.put("month", enc.getMonth());
+                e.put("day", enc.getDay());
+                e.put("locationID", enc.getLocationID());
+                e.put("occurrenceID", enc.getOccurrenceID());
+                e.put("sex", enc.getSex());
+                e.put("behavior", enc.getBehavior());
+                e.put("alternateid", enc.getAlternateID());
+                e.put("dataTypes", computeDataTypes(enc));
+                encArr.put(e);
+            }
+        }
+        rtn.put("encounters", encArr);
+```
+
+Add helpers:
+
+```java
+    private boolean encCanView(Encounter enc, User user, Shepherd myShepherd,
+        Map<String, Boolean> cache) {
+        String eid = enc.getId();
+        Boolean cached = cache.get(eid);
+        if (cached != null) return cached.booleanValue();
+        boolean v = enc.canUserView(user, myShepherd);
+        cache.put(eid, v);
+        return v;
+    }
+
+    // Mirrors the legacy encounter-calls.js dataTypes precedence (ANY annotation counts;
+    // tissue type is the static "TissueSample").
+    private String computeDataTypes(Encounter enc) {
+        List<org.ecocean.genetics.TissueSample> ts = enc.getTissueSamples();
+        boolean hasTissue = (ts != null) && !ts.isEmpty();
+        List<org.ecocean.Annotation> anns = enc.getAnnotations();
+        boolean hasAnn = (anns != null) && !anns.isEmpty();
+        if (hasTissue && hasAnn) return "both";
+        if (hasTissue) return "TissueSample";
+        if (hasAnn) {
+            String eventID = enc.getEventID();
+            if ((eventID != null) && (eventID.indexOf("youtube") > -1)) return "youtube-image";
+            return "image";
+        }
+        return "";
+    }
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `mvn test -Dtest=MarkedIndividualInfoTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS.
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' src/main/java/org/ecocean/api/MarkedIndividualInfo.java src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
+git add -A && git commit -m "feat: social-data encounter rows with per-encounter ACL filter + dataTypes"
+```
+
+---
+
+### Task 4: `occurringWith` (per-companion-encounter ACL, memoized display string)
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/api/MarkedIndividualInfo.java`
+- Test: `src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java`
+
+**Interfaces:**
+- Consumes: `encCanView` cache (Task 3).
+- Produces: each encounter row gains `occurringWith` (a `", "`-joined string of viewable co-occurring individual `displayName`s). Helper `String occurringWith(Encounter enc, MarkedIndividual focal, User, Shepherd, Map<String,Boolean> encViewCache, Map<String,String> occCache)`.
+
+- [ ] **Step 1: Write failing test (the co-occurrence leak guard)**
+
+Seed: an occurrence containing the focal individual's encounter + a companion encounter owned by `stranger` (not viewable by `seededOwner` if security blocks it — invert ownership so the focal owner can see focal but NOT the companion). Assert the companion's displayName is absent from `occurringWith`:
+
+```java
+    @Test void occurringWithExcludesNonViewableCompanion() throws Exception {
+        JSONObject j = invoke(focalOwner, focalIndivIdInSharedOcc);
+        org.json.JSONArray encs = j.getJSONArray("encounters");
+        for (int i = 0; i < encs.length(); i++) {
+            String ow = encs.getJSONObject(i).optString("occurringWith", "");
+            assertFalse(ow.contains(hiddenCompanionDisplayName),
+                "non-viewable companion must not leak into occurringWith");
+        }
+    }
+    @Test void occurringWithIncludesViewableCompanion() throws Exception {
+        JSONObject j = invoke(focalOwner, focalIndivIdWithViewableCompanion);
+        String ow = j.getJSONArray("encounters").getJSONObject(0).optString("occurringWith", "");
+        assertTrue(ow.contains(viewableCompanionDisplayName));
+    }
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `mvn test -Dtest=MarkedIndividualInfoTest#occurringWithIncludesViewableCompanion -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: FAIL (no `occurringWith` field yet).
+
+- [ ] **Step 3: Implement `occurringWith`**
+
+Thread the focal individual and an occurrence cache into the encounter loop. Add `Map<String,String> occCache = new HashMap<String,String>();` next to `encViewCache`, and inside the row build add:
+
+```java
+                e.put("occurringWith", occurringWith(enc, indiv, user, myShepherd, encViewCache, occCache));
+```
+
+Add the helper:
+
+```java
+    // ACL-correct co-occurrence: per the spec, a companion is included ONLY if the
+    // companion's own encounter in the occurrence passes enc.canUserView — never
+    // occurrence-level auth (which admits an occurrence if ANY encounter is viewable).
+    private String occurringWith(Encounter enc, MarkedIndividual focal, User user,
+        Shepherd myShepherd, Map<String, Boolean> encViewCache, Map<String, String> occCache) {
+        String occId = enc.getOccurrenceID();
+        if (occId == null) return "";
+        String memo = occCache.get(occId);
+        if (memo != null) return memo;
+        org.ecocean.Occurrence occ = enc.getOccurrence(myShepherd);
+        String focalId = focal.getId();
+        java.util.LinkedHashSet<String> names = new java.util.LinkedHashSet<String>();
+        if ((occ != null) && (occ.getEncounters() != null)) {
+            for (Encounter coEnc : occ.getEncounters()) {
+                MarkedIndividual coInd = coEnc.getIndividual();
+                if (coInd == null) continue;
+                if ((focalId != null) && focalId.equals(coInd.getIndividualID())) continue;
+                if (!encCanView(coEnc, user, myShepherd, encViewCache)) continue;
+                String dn = coInd.getDisplayName();
+                if (Util.stringExists(dn)) names.add(dn);
+            }
+        }
+        String joined = String.join(", ", names);
+        occCache.put(occId, joined);
+        return joined;
+    }
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `mvn test -Dtest=MarkedIndividualInfoTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS.
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' src/main/java/org/ecocean/api/MarkedIndividualInfo.java src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
+git add -A && git commit -m "feat: ACL-filtered occurringWith on social-data encounter rows"
+```
+
+---
+
+### Task 5: Relationship rows — `_id`, partner resolution + ACL, embedded partner
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/api/MarkedIndividualInfo.java`
+- Test: `src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java`
+
+**Interfaces:**
+- Produces: each `relationships[]` row = `{_id, type, relatedSocialUnitName, markedIndividualName1, markedIndividualName2, markedIndividualRole1, markedIndividualRole2, startTime, endTime, partner:{individualID, displayName, nickName, alternateid, sex, localHaplotypeReflection}}`. Helpers `JSONObject relationshipRow(...)`, `boolean partnerCanView(...)`, `String relationshipDatastoreId(Relationship)`.
+
+- [ ] **Step 1: Write failing tests (`_id` round-trip + partner filter)**
+
+Seed: focal individual with a relationship to a viewable partner, and a second relationship to a non-viewable partner. The `_id` round-trip asserts the emitted id, reconstructed as the legacy `persistenceID`, resolves the same `Relationship`:
+
+```java
+    @Test void relationshipIdRoundTripsThroughGetObjectById() throws Exception {
+        JSONObject j = invoke(focalOwner, focalIndivWithViewableRel);
+        String id = j.getJSONArray("relationships").getJSONObject(0).getString("_id");
+        String persistenceID = id + "[OID]org.ecocean.social.Relationship";
+        Shepherd s = new Shepherd("context0", props);
+        s.beginDBTransaction();
+        try {
+            org.ecocean.social.Relationship rel =
+                (org.ecocean.social.Relationship) s.getPM()
+                    .getObjectById(org.ecocean.social.Relationship.class, persistenceID);
+            assertNotNull(rel, "emitted _id must resolve the same Relationship the legacy "
+                + "edit/remove path resolves");
+        } finally { s.rollbackAndClose(); }
+    }
+    @Test void relationshipToNonViewablePartnerOmitted() throws Exception {
+        JSONObject j = invoke(focalOwner, focalIndivWithHiddenPartnerRel);
+        // only the viewable-partner relationship is present
+        org.json.JSONArray rels = j.getJSONArray("relationships");
+        for (int i = 0; i < rels.length(); i++) {
+            String pid = rels.getJSONObject(i).getJSONObject("partner").getString("individualID");
+            assertNotEquals(hiddenPartnerId, pid);
+        }
+    }
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `mvn test -Dtest=MarkedIndividualInfoTest#relationshipIdRoundTripsThroughGetObjectById -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: FAIL (relationships array empty).
+
+- [ ] **Step 3: Implement relationship assembly**
+
+Replace `rtn.put("relationships", new org.json.JSONArray());` with:
+
+```java
+        Map<String, Boolean> partnerViewCache = new HashMap<String, Boolean>();
+        JSONArray relArr = new JSONArray();
+        for (Relationship rel : myShepherd.getAllRelationshipsForMarkedIndividual(indiv.getId())) {
+            JSONObject row = relationshipRow(rel, indiv, user, myShepherd, partnerViewCache);
+            if (row != null) relArr.put(row);
+        }
+        rtn.put("relationships", relArr);
+```
+
+Add helpers:
+
+```java
+    private JSONObject relationshipRow(Relationship rel, MarkedIndividual focal, User user,
+        Shepherd myShepherd, Map<String, Boolean> partnerViewCache) {
+        MarkedIndividual partner = rel.getOtherMarkedIndividual(focal);
+        if (partner == null) { // object link not populated; fall back to non-self name
+            String focalId = focal.getId();
+            String n1 = rel.getMarkedIndividualName1();
+            String n2 = rel.getMarkedIndividualName2();
+            String otherName = null;
+            if ((n1 != null) && !n1.equals(focalId)) otherName = n1;
+            else if ((n2 != null) && !n2.equals(focalId)) otherName = n2;
+            if (otherName != null) partner = myShepherd.getMarkedIndividual(otherName);
+        }
+        if (partner == null) return null;
+        if (!partnerCanView(partner, user, myShepherd, partnerViewCache)) return null;
+
+        JSONObject r = new JSONObject();
+        r.put("_id", relationshipDatastoreId(rel));
+        r.put("type", rel.getType());
+        r.put("relatedSocialUnitName", rel.getRelatedSocialUnitName());
+        r.put("markedIndividualName1", rel.getMarkedIndividualName1());
+        r.put("markedIndividualName2", rel.getMarkedIndividualName2());
+        r.put("markedIndividualRole1", rel.getMarkedIndividualRole1());
+        r.put("markedIndividualRole2", rel.getMarkedIndividualRole2());
+        r.put("startTime", rel.getStartTime());
+        r.put("endTime", rel.getEndTime());
+
+        JSONObject p = new JSONObject();
+        p.put("individualID", partner.getIndividualID());
+        p.put("displayName", partner.getDisplayName());
+        p.put("nickName", partner.getNickName());
+        p.put("alternateid", partner.getAlternateID());
+        p.put("sex", partner.getSex());
+        p.put("localHaplotypeReflection", partner.getHaplotype());
+        r.put("partner", p);
+        return r;
+    }
+
+    private boolean partnerCanView(MarkedIndividual partner, User user, Shepherd myShepherd,
+        Map<String, Boolean> cache) {
+        String pid = partner.getId();
+        Boolean cached = cache.get(pid);
+        if (cached != null) return cached.booleanValue();
+        boolean v = partner.canUserView(user, myShepherd);
+        cache.put(pid, v);
+        return v;
+    }
+
+    // Emits the DataNucleus datastore-identity string in the legacy `_id` form, so the
+    // retained edit/remove buttons (which append "[OID]org.ecocean.social.Relationship")
+    // resolve the same row via getObjectById. Verified by relationshipIdRoundTripsThroughGetObjectById.
+    private String relationshipDatastoreId(Relationship rel) {
+        Object oid = javax.jdo.JDOHelper.getObjectId(rel);
+        if (oid == null) return null;
+        String s = oid.toString();
+        int idx = s.indexOf("[OID]");
+        return (idx > -1) ? s.substring(0, idx) : s;
+    }
+```
+
+> If the round-trip test fails on the id format, inspect the actual `JDOHelper.getObjectId(rel).toString()` value in the test and adjust `relationshipDatastoreId` to emit exactly the substring the legacy `_id` carried (the test is the source of truth here).
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `mvn test -Dtest=MarkedIndividualInfoTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS.
+
+- [ ] **Step 5: Normalize + commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' src/main/java/org/ecocean/api/MarkedIndividualInfo.java src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
+git add -A && git commit -m "feat: social-data relationship rows with partner ACL filter + legacy-compatible _id"
+```
+
+---
+
+### Task 6: Large-individual correctness/memoization test
+
+**Files:**
+- Test: `src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java`
+
+**Interfaces:**
+- Consumes: full `getSocialData` (Tasks 3–5).
+
+- [ ] **Step 1: Write the test**
+
+Seed a focal individual with several encounters across a large occurrence (many co-occurring encounters) and a relationship whose partner has many encounters. Assert the call completes and returns correctly-filtered data:
+
+```java
+    @Test void largeIndividualAssemblesCorrectly() throws Exception {
+        JSONObject j = invoke(focalOwner, largeFocalIndivId);
+        assertEquals(200, j.optInt("statusCode"));
+        // every returned encounter is one the owner may view; occurringWith only viewable companions
+        assertTrue(j.getJSONArray("encounters").length() > 0);
+    }
+```
+
+- [ ] **Step 2: Run — verify pass** (logic already implemented; this guards the memoized paths)
+
+Run: `mvn test -Dtest=MarkedIndividualInfoTest#largeIndividualAssemblesCorrectly -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full backend suite once**
+
+Run: `mvn -o test -Dtest=MarkedIndividualInfoTest -DargLine="--add-opens java.base/java.lang=ALL-UNNAMED -Xmx2g"`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
+git add -A && git commit -m "test: large-individual social-data assembly + memoization coverage"
+```
+
+---
+
+### Task 7: Rewrite the diagram JS to the new endpoint
+
+No automated harness exists for `src/main/webapp/javascript/`; verification is manual + Codex review of the diff.
+
+**Files:**
+- Modify: `src/main/webapp/javascript/bubbleDiagram/encounter-calls.js`
+
+**Interfaces:**
+- Consumes: `GET /api/v3/individuals/info/social-data?id={individualId}` → `{encounters:[…], relationships:[…]}` (Tasks 2–5).
+
+- [ ] **Step 1: Add a single fetch + cache, and rewrite `getEncounterTableData` (line ~488)**
+
+Replace the body of `getEncounterTableData` so it fetches the new endpoint once and builds rows from `response.encounters`, taking `occurringWith` directly from each row instead of cross-referencing `occurrenceObjectArray`. Keep the existing date-precision logic (`dateInMilliseconds`/`year`/`month`/`day`), `dataTypes`→icon mapping, and the final `makeTable(encounterData, "#encountHead", "#encountBody", "date", null)` + row-click wiring unchanged:
+
+```javascript
+var getEncounterTableData = function(occurrenceObjectArray, individualID) {
+    d3.json(wildbookGlobals.baseUrl + "/api/v3/individuals/info/social-data?id=" + encodeURIComponent(individualID), function(error, json) {
+        if (error) { console.log("error"); return; }
+        var encounterData = [];
+        var encs = (json && json.encounters) ? json.encounters : [];
+        for (var i = 0; i < encs.length; i++) {
+            var row = encs[i];
+            var date;
+            var dim = new Date(row.dateInMilliseconds);
+            if (dim > 0) {
+                date = dim.toISOString().substring(0, 10);
+                if (row.day < 1) { date = date.substring(0, 7); }
+                if (row.month < 0) { date = date.substring(0, 4); }
+            } else if (row.year) {
+                date = row.year;
+                if (row.month) { date += "-" + row.month; }
+                if (row.day) { date += "-" + row.day; }
+            } else { date = dict['unknown']; }
+            var encounter = {
+                catalogNumber: row.catalogNumber,
+                date: date,
+                location: row.locationID || "",
+                dataTypes: row.dataTypes || "",
+                alternateID: row.alternateid,
+                sex: row.sex,
+                occurringWith: row.occurringWith || "",
+                behavior: row.behavior
+            };
+            encounterData.push(encounter);
+        }
+        makeTable(encounterData, "#encountHead", "#encountBody", "date", null);
+        $('#encountTable tr').attr("onClick", "return encountTableAuxClick(this);")
+                             .attr("onAuxClick", "return encountTableAuxClick(this);")
+                             .each(function() {
+                                encountUrl = "encounters/encounter.jsp?number=" + ($(this).attr("class"));
+                                $(this).find("td").first().wrapInner("<a href=\"" + encountUrl + "\"></a>");
+                             });
+    });
+}
+```
+
+- [ ] **Step 2: Rewrite `getRelationshipTableData` (line ~653) and delete `getIndividualData` (line ~698)**
+
+Build relationship rows from `response.relationships`, reading partner display from the embedded `partner` object (no per-partner fetch). Preserve the `roles`/`relationshipWith`/`edit`/`remove` row shape `makeRelTable` expects and keep `_id` for the edit/remove buttons:
+
+```javascript
+var getRelationshipTableData = function(individualID) {
+    d3.json(wildbookGlobals.baseUrl + "/api/v3/individuals/info/social-data?id=" + encodeURIComponent(individualID), function(error, json) {
+        if (error) { console.log("error"); return; }
+        var relationshipTableData = [];
+        var rels = (json && json.relationships) ? json.relationships : [];
+        for (var i = 0; i < rels.length; i++) {
+            var rel = rels[i];
+            var relationshipID = rel._id;
+            var markedIndividualRole, relationshipWithRole;
+            if (rel.markedIndividualName1 != individualID) {
+                markedIndividualRole = rel.markedIndividualRole2;
+                relationshipWithRole = rel.markedIndividualRole1;
+            } else {
+                markedIndividualRole = rel.markedIndividualRole1;
+                relationshipWithRole = rel.markedIndividualRole2;
+            }
+            var p = rel.partner || {};
+            relationshipTableData.push({
+                "roles": [markedIndividualRole, relationshipWithRole],
+                "relationshipWith": [p.individualID, p.nickName, p.alternateid, p.sex, p.localHaplotypeReflection, p.displayName],
+                "type": rel.type,
+                "socialUnit": rel.relatedSocialUnitName,
+                "edit": ["edit", relationshipID],
+                "remove": ["remove", relationshipID]
+            });
+        }
+        makeRelTable(relationshipTableData, "#relationshipHead", "#relationshipBody", "text");
+    });
+}
+```
+
+Delete the entire `getIndividualData = function (...) { ... }` definition (it is no longer called).
+
+- [ ] **Step 3: Normalize line endings**
+
+Run: `perl -i -pe 's/\r\n/\n/g' src/main/webapp/javascript/bubbleDiagram/encounter-calls.js && grep -cP '\r$' src/main/webapp/javascript/bubbleDiagram/encounter-calls.js`
+Expected: `0`
+
+- [ ] **Step 4: Manual verification**
+
+Deploy/refresh, open `individuals.jsp?number=<id>` → Social Diagram tab. Confirm in the browser Network tab:
+- One `GET /api/v3/individuals/info/social-data?id=…` (200), no `/api/jdoql` and no `/api/org.ecocean.*` requests.
+- Encounter table populates with date/location/dataTypes icons/occurringWith/sex/behavior.
+- Relationship table populates with roles/partner display; **edit and remove buttons still open/operate** (they call the unchanged legacy write path keyed by `_id`).
+- An account that cannot view some encounters sees only its viewable encounters and no hidden companions in "occurring with".
+
+- [ ] **Step 5: Codex review of the JS diff, then commit**
+
+Run a Codex review (codex-review skill) on the `encounter-calls.js` diff before committing; address any Major/Minor findings. Then:
+
+```bash
+git add src/main/webapp/javascript/bubbleDiagram/encounter-calls.js
+git commit -m "feat: Social Diagram reads via /api/v3 social-data; drop legacy /api/jdoql + per-partner gets"
+```
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage:** endpoint+routing (Task 2) ✓; individual gate (Task 2) ✓; per-encounter ACL (Task 3) ✓; dataTypes legacy semantics (Task 3) ✓; occurringWith ACL display-string (Task 4) ✓; relationship rows + partner ACL + legacy `_id` (Task 5) ✓; memoization + large-individual (Tasks 3–6) ✓; JS rewrite incl. removal of line 703 and retention of edit/remove (Task 7) ✓; error codes (Task 2) ✓; bubble-graph residual left untouched (no task touches line 29) ✓.
+- **Placeholder scan:** all code steps contain real code; the one conditional ("if the round-trip test fails…") is guidance attached to a real implementation, not a placeholder.
+- **Type consistency:** `encCanView`/`partnerCanView` cache `Map<String,Boolean>`; `occCache` `Map<String,String>`; helper names and the `getSocialData` signature are consistent across Tasks 2–6; JS field names (`alternateid`, `occurringWith`, `_id`, `partner.*`) match the endpoint output.
+
+## Execution dependency note
+
+Test seeding (`seededOwner`, `stranger`, `focalOwner`, the various individual ids, large/occurrence/partner fixtures) is described per task; consolidate it into `@BeforeAll`/helper methods in the test class as tasks accrete, following `EncounterExportImagesTest` and `SearchTokenScopeChildIndexTest`. Confirm how `MarkedIndividualInfo` resolves the current `User` from the request (`myShepherd.getUser(request)`) and stub that consistently in `invoke(...)`.

--- a/docs/superpowers/specs/2026-06-24-social-diagram-api-v3-reads-design.md
+++ b/docs/superpowers/specs/2026-06-24-social-diagram-api-v3-reads-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-24
 **Branch:** `fix/social-diagram-api-v3-reads` (off `fix/api-v3-individuals-get`, which is PR #1633)
-**Status:** design — awaiting spec review
+**Status:** design — revised after Codex review (round 1); awaiting spec review
 
 ## Problem
 
@@ -14,65 +14,88 @@ through the generic DataNucleus REST servlet (`/api/*`, `org.ecocean.servlet.Res
 |------|------|-------|---------|
 | 491 | `GET /api/jdoql?SELECT FROM MarkedIndividual WHERE individualID=="…"` | encounter table | **StackOverflowError** — the recursive POJO serializer loops on the `User`↔`Organization` bidirectional reference cycle. Also bypasses the collaboration/role ACL. |
 | 655 | `GET /api/jdoql?SELECT FROM org.ecocean.social.Relationship WHERE …` | relationship table | same unsafe servlet |
-| 703 | `GET /api/org.ecocean.MarkedIndividual/{id}` (per partner) | partner display in relationship table | same recursive serializer; N+1 |
+| 703 | `GET /api/org.ecocean.MarkedIndividual/{id}` (per partner) | partner display in relationship table | same recursive serializer; client-side N+1 |
 
 The `/api/jdoql` MarkedIndividual query is the exact request that produced the reported
 `StackOverflowError`.
 
-A separate, already-merged change (PR #1633) added a safe, ACL-aware
-`GET /api/v3/individuals/{id}`. However, that endpoint returns the **OpenSearch document**
-shape — individual scalars, `socialUnits[]`, `relationships[]` (partner summary only), and
-**encounter aggregates only** (`encounterIds[]`, counts, co-occurrence map). It exposes
-**no per-encounter detail** (date, location, catalogNumber, tissue/annotation indicators,
-behavior, per-encounter sex), so it cannot directly feed the encounter table.
+PR #1633 added a safe, ACL-aware `GET /api/v3/individuals/{id}`, but it returns the
+**OpenSearch document** shape (individual scalars, `socialUnits[]`, partner-summary
+`relationships[]`, and encounter **aggregates only** — `encounterIds[]`, counts,
+co-occurrence map). It exposes **no per-encounter detail**, so it cannot feed the encounter
+table directly.
 
 ## Scope
 
-**Reads only.** Migrate the three crashing/unsafe read calls (491, 655, 703).
+**Reads only.** Migrate the three crashing/unsafe read calls (491, 655, 703) onto one new
+secured endpoint.
 
-Out of scope (left on the legacy API for a separate effort):
-- Co-occurrence table — line 29, `GET /encounters/occurrenceGraphJson.jsp` (a dedicated
-  JSP, not the crashing servlet).
-- Relationship **write** flow — line 585 (`getRelationshipData`, populates the edit form)
-  and the add/edit/remove relationship form. These POST/PATCH/DELETE through the legacy
-  API and have no `/api/v3` equivalent yet.
+Out of scope (left on the legacy API, by decision):
+- The d3 **bubble-graph visualization** — `getData` / line 29, `GET /encounters/occurrenceGraphJson.jsp`.
+  See "Known residual exposure" below.
+- Relationship **write** flow — line 585 (`getRelationshipData`, edit-form populate) and the
+  add/edit/remove relationship form. These POST/PATCH/DELETE through the legacy API and have
+  no `/api/v3` equivalent yet. **The relationship table continues to render edit/remove
+  buttons that call these legacy write paths**, so the new endpoint must preserve the exact
+  relationship identifier those paths expect (see Security/Identity below).
 
 ## Approach
 
-Option B from brainstorming: **one dedicated, server-assembled read endpoint** (chosen to
-avoid an N+1 over `/api/v3/encounters/{id}`, since Sharkbook individuals routinely have
-large encounter counts). Server-side assembly is also what makes per-encounter ACL
-filtering enforceable.
+Option B: **one dedicated, server-assembled read endpoint**. Chosen over an N+1 across
+`/api/v3/encounters/{id}` because Sharkbook individuals routinely have large encounter
+counts, and because server-side assembly is what makes per-encounter ACL filtering
+enforceable.
 
 ### Endpoint
 
 `GET /api/v3/individuals/info/social-data?id={individualId}`
 
 New `args[2] == "social-data"` branch in `org.ecocean.api.MarkedIndividualInfo.doGet`.
-This servlet already owns `/api/v3/individuals/info/*` (so no routing collision with
-`BaseObject`'s `/api/v3/individuals/*`), already returns `401` for an anonymous caller,
-and already runs inside a managed Shepherd transaction. No change to web.xml. No change to
-any OpenSearch serializer (so no reindex).
+This servlet already owns `/api/v3/individuals/info/*` (no routing collision with
+`BaseObject`'s `/api/v3/individuals/*`), already returns `401` for an anonymous caller, and
+already runs inside a managed Shepherd transaction. No web.xml change; no OpenSearch
+serializer change (no reindex).
 
 ### Security model
 
 1. **Caller auth** — anonymous → `401` (inherited from `MarkedIndividualInfo`).
 2. **Individual gate** — load the individual by id; if
-   `individual.canUserView(currentUser, myShepherd)` is false → `403`. Uses the
-   `MarkedIndividual.canUserView` added in PR #1633 (admin, or can view ≥1 encounter).
-3. **Per-encounter filter (primary requirement)** — iterate `individual.getEncounters()`
-   and include an encounter row **only if `enc.canUserView(currentUser, myShepherd)`**
-   (admin / owner / collaboration via `Collaboration.canUserAccessEncounter`). Non-viewable
-   encounters are dropped before serialization — never written to the response. This closes
-   the legacy behavior where `/api/jdoql` returned every encounter regardless of ACL.
-4. **Relationship partner filter** — include a relationship row only if its partner
-   `MarkedIndividual` is viewable by the caller (`partner.canUserView`). Prevents leaking a
-   partner's identity across a collaboration boundary. A relationship whose partner is not
-   resolvable/viewable is omitted.
+   `individual.canUserView(currentUser, myShepherd)` is false → `403`
+   (the `MarkedIndividual.canUserView` from PR #1633).
+3. **Per-encounter filter (primary requirement)** — iterate `individual.getEncounters()` and
+   include an encounter row **only if `enc.canUserView(currentUser, myShepherd)`**. Encounters
+   the caller can't see are dropped before serialization. (Note: `canUserView` admits an
+   encounter for an admin OR via `Collaboration.canUserAccessEncounter`.)
+4. **Co-occurrence ("occurring with") filter** — computed **server-side in this endpoint**,
+   not from the legacy JSP. For each viewable encounter, find its occurrence's co-occurring
+   individuals and include a companion **only if that companion's encounter in the occurrence
+   is itself `canUserView` for the caller**. This closes the leak Codex flagged: the legacy
+   `occurrenceGraphJson.jsp` authorizes an occurrence if *any* encounter is viewable and then
+   serializes *every* companion's id/name/sex/haplotype.
+5. **Relationship partner filter** — resolve the partner robustly (object link
+   `Relationship.getOtherMarkedIndividual(self)` first; if null, fall back to the non-self
+   `markedIndividualName{1,2}` via `myShepherd.getMarkedIndividual(name)`). Include the
+   relationship row **only if the resolved partner is non-null and
+   `partner.canUserView(currentUser, myShepherd)`**; otherwise omit the row (and never
+   serialize any partner field). Prevents leaking partner identity across collaboration
+   boundaries.
+
+### Identity requirement (do not break the retained write path)
+
+The relationship row's `_id` MUST be byte-identical to the value the legacy REST API exposed
+as `_id` — the DataNucleus **datastore identity** string. The retained edit/remove buttons
+build `persistenceID = _id + "[OID]org.ecocean.social.Relationship"` (`individuals.jsp:1819`)
+and `RelationshipDelete` resolves the row via `getObjectById` on that. Derive the id with
+DataNucleus identity utilities (e.g. the identity object from `JDOHelper.getObjectId(rel)` /
+the PM), matching the legacy format exactly. A regression test (below) must confirm the
+emitted `_id`, run through the existing `persistenceID` construction, resolves the same
+`Relationship`.
 
 ### Response shape
 
-Field names mirror what `encounter-calls.js` already consumes, to keep the JS rewrite small.
+Field names mirror what `encounter-calls.js` already reads, so the JS **row-assembly logic is
+retained** (only the data *source* changes, plus `occurringWith` now arrives from the endpoint
+and partner detail is embedded).
 
 ```json
 {
@@ -89,12 +112,13 @@ Field names mirror what `encounter-calls.js` already consumes, to keep the JS re
       "sex": "female",
       "behavior": "…",
       "alternateid": "…",
-      "dataTypes": "both"
+      "dataTypes": "both",
+      "occurringWith": ["DISPLAYNAME-A id=uuid-a", "DISPLAYNAME-B id=uuid-b"]
     }
   ],
   "relationships": [
     {
-      "_id": "relationship-uuid",
+      "_id": "<datastore-identity string, legacy-compatible>",
       "type": "…",
       "relatedSocialUnitName": "…",
       "markedIndividualName1": "…",
@@ -116,41 +140,46 @@ Field names mirror what `encounter-calls.js` already consumes, to keep the JS re
 }
 ```
 
-- `dataTypes` is computed server-side using the exact precedence currently in the JS:
-  `both` (tissue samples AND non-trivial annotations) → tissue sample `type` (tissue only)
-  → `youtube-image` (annotations whose `eventID` contains "youtube") → `image` (annotations)
-  → `""`.
-- `year` / `month` / `day` / `dateInMilliseconds` are passed through so the JS keeps its
-  existing date-precision formatting unchanged.
-- `partner` is embedded so the per-partner fetch (line 703) is removed entirely.
+- `dataTypes` is computed server-side using the **exact legacy precedence** in the JS, treating
+  **any** annotation as image/youtube data (i.e. `getAnnotations().size() > 0`, NOT
+  non-trivial-only — preserving current behavior): `both` (tissue samples AND annotations) →
+  the tissue sample `type` (tissue only) → `youtube-image` (annotation whose `eventID`
+  contains "youtube") → `image` (annotation) → `""`.
+- `occurringWith` is the ACL-filtered companion list per encounter (same
+  `"displayName id=uuid"` token format the JS already splits on), replacing the join against
+  the legacy JSP for the encounter table.
+- `year`/`month`/`day`/`dateInMilliseconds` are passed through so the JS keeps its existing
+  date-precision formatting unchanged.
+- `partner` is embedded so the per-partner fetch (line 703) is removed.
 
 ### Server assembly
 
-A private method in `MarkedIndividualInfo` builds the payload from domain getters
-(no OpenSearch dependency):
+A private method in `MarkedIndividualInfo` builds the payload from domain getters (no
+OpenSearch dependency):
 
-- Encounters: `enc.getCatalogNumber()`, `enc.getDateInMilliseconds()`, `getYear/getMonth/getDay`,
+- Encounters: `enc.getCatalogNumber()`, `getDateInMilliseconds()`, `getYear/getMonth/getDay`,
   `getLocationID()`, `getOccurrenceID()`, `getSex()`, `getBehavior()`, `getAlternateID()`,
-  `getTissueSamples()`, `getAnnotations()` (non-trivial count), `getEventID()` (for `dataTypes`).
-- Relationships: `myShepherd.getAllRelationshipsForMarkedIndividual(id)`, then per relationship
-  the `Relationship` getters plus the partner `MarkedIndividual` (`getOtherMarkedIndividual`/
-  the non-self name) for the embedded partner block.
+  `getTissueSamples()`, `getAnnotations()`, `getEventID()` (for `dataTypes`); plus the
+  ACL-filtered co-occurring individuals for `occurringWith` (via the encounter's occurrence).
+- Relationships: `myShepherd.getAllRelationshipsForMarkedIndividual(id)`; per relationship the
+  `Relationship` getters, the legacy-compatible `_id`, and the robustly-resolved + ACL-checked
+  partner block.
 
 ### JavaScript changes (`encounter-calls.js`)
 
-- `getEncounterTableData` (491): one `d3.json` GET to the new endpoint; build the table from
-  `response.encounters`. The `occurringWith` cross-referencing against
-  `occurrenceObjectArray` (from the co-occurrence JSP) is preserved; only the data source for
-  encounter rows changes.
-- `getRelationshipTableData` (655): build the table from `response.relationships`; partner
-  display read from the embedded `partner` object.
-- `getIndividualData` (703): **removed** — partner detail now arrives embedded.
-- Untouched: `getData`/line 29 (co-occurrence JSP), `getRelationshipData`/line 585 (edit-form
-  write path), the add/edit/remove form handlers.
+- `getEncounterTableData` (491): replace the jdoql call with one fetch to the new endpoint;
+  the existing row-assembly loop is retained but reads `response.encounters[i]` and takes
+  `occurringWith` from the row instead of cross-referencing `occurrenceObjectArray`.
+- `getRelationshipTableData` (655): build rows from `response.relationships`; the existing
+  role/`relationshipWith`/`edit`/`remove` array construction is retained; partner display read
+  from the embedded `partner` (no per-partner fetch). The `edit`/`remove` button values keep
+  using `_id`, so the legacy write path is unaffected.
+- `getIndividualData` (703): **removed**.
+- Untouched: `getData`/line 29 (bubble graph), `getRelationshipData`/line 585 (edit-form write
+  path), add/edit/remove form handlers.
 
-To avoid double-fetching, the response (which carries both `encounters` and `relationships`)
-may be fetched once per diagram load and cached in a module variable, with both table
-builders reading from it. Exact caching detail deferred to the implementation plan.
+Because the response carries both arrays, it is fetched once per diagram load and cached in a
+module variable; both table builders read from it. (Caching detail finalized in the plan.)
 
 ## Error handling
 
@@ -164,32 +193,54 @@ builders reading from it. Exact caching detail deferred to the implementation pl
 
 All via the existing `statusCode` JSON convention in `MarkedIndividualInfo`.
 
+## Performance
+
+This removes the **client-side HTTP N+1** (one request instead of 1 + per-encounter-individual
++ per-partner). Server-side cost is bounded by the individual's encounter count: the
+per-encounter ACL check and `occurringWith` computation touch occurrences and (via partner
+`canUserView`) partner encounters, and reading `dataTypes` touches lazy tissue/annotation
+collections — all inside the single managed transaction. A test exercises a large-encounter
+individual to confirm acceptable behavior; if needed, the plan may add per-occurrence/partner
+memoization. No new unbounded query is introduced.
+
 ## Testing
 
-JUnit 5 + Testcontainers, in `src/test/java/org/ecocean/api/` (or the closest existing
-home for this servlet's tests):
+JUnit 5 + Testcontainers, under `src/test/java/org/ecocean/api/`:
 
-1. **Per-encounter ACL** — an individual with encounters owned by different users: a
-   non-admin collaborator sees only the encounters they may view; an admin sees all;
-   counts match the filter.
-2. **Individual gate** — a non-viewable individual returns 403; a viewable one returns 200.
-3. **Relationship partner filter** — a relationship to a non-viewable partner is omitted;
-   to a viewable partner is included with the embedded partner block.
-4. **dataTypes precedence** — encounters with (tissue+annotation), tissue-only,
-   youtube-annotation, plain-annotation, and neither map to the expected `dataTypes` value.
-5. **Bad input** — blank `id` → 400; unknown `id` → 404; anonymous → 401.
+1. **Per-encounter ACL** — individual with encounters owned by different users: a non-admin
+   collaborator sees only viewable encounters; an admin sees all; counts match the filter.
+2. **Co-occurrence ACL** — an occurrence containing a non-viewable companion: that companion
+   does NOT appear in any encounter row's `occurringWith`; a viewable companion does.
+3. **Individual gate** — non-viewable individual → 403; viewable → 200.
+4. **Relationship partner filter** — relationship to a non-viewable/unresolvable partner is
+   omitted; to a viewable partner is included with the embedded partner block.
+5. **Relationship `_id` round-trip** — the emitted `_id`, passed through the
+   `persistenceID = _id + "[OID]org.ecocean.social.Relationship"` construction, resolves the
+   same `Relationship` via the `getObjectById` path used by `RelationshipDelete`.
+6. **dataTypes precedence** — (tissue+annotation), tissue-only, youtube-annotation,
+   plain-annotation, neither → expected `dataTypes` value (matching legacy "any annotation").
+7. **Bad input** — blank `id` → 400; unknown `id` → 404; anonymous → 401.
 
-Manual verification: open the Social Diagram on an individual; confirm both tables populate
-and that no `/api/jdoql` or `/api/org.ecocean.*` request is issued (network tab).
+Manual: open the Social Diagram on an individual; confirm both tables populate and that no
+`/api/jdoql` or `/api/org.ecocean.*` request is issued (network tab); confirm edit/remove
+buttons still resolve their relationship.
+
+## Known residual exposure (documented, not fixed here)
+
+The d3 **bubble-graph visualization** (`getData`/line 29) still sources companion individuals
+from `occurrenceGraphJson.jsp`, which is not ACL-filtered. Per the agreed scope, the encounter
+**table** is secured (its `occurringWith` now comes from the filtered endpoint), but the graph
+viz retains this pre-existing co-occurrence exposure. Tracked as a follow-up; not described
+further in public artifacts beyond this note.
 
 ## Dependencies / sequencing
 
 Depends on `MarkedIndividual.canUserView` (PR #1633). This branch is stacked on
-`fix/api-v3-individuals-get`; it should merge after #1633 (or be rebased onto `main` once
-#1633 lands).
+`fix/api-v3-individuals-get`; merge after #1633 lands (or rebase onto `main` once it does).
 
-## Out-of-scope follow-ups (noted, not done here)
+## Out-of-scope follow-ups
 
-- Migrating the relationship **write** flow (585 + form) to `/api/v3` endpoints.
-- Retiring / locking down the generic `/api/jdoql` + `/api/{class}/{id}` RestServlet surface
+- Migrating the relationship **write** flow (585 + form) to `/api/v3`.
+- Securing the bubble-graph companion feed (line 29).
+- Retiring/locking down the generic `/api/jdoql` + `/api/{class}/{id}` RestServlet surface
   (tracked privately as a security item).

--- a/docs/superpowers/specs/2026-06-24-social-diagram-api-v3-reads-design.md
+++ b/docs/superpowers/specs/2026-06-24-social-diagram-api-v3-reads-design.md
@@ -1,0 +1,195 @@
+# Social Diagram read-path migration to `/api/v3`
+
+**Date:** 2026-06-24
+**Branch:** `fix/social-diagram-api-v3-reads` (off `fix/api-v3-individuals-get`, which is PR #1633)
+**Status:** design — awaiting spec review
+
+## Problem
+
+The legacy individual page `individuals.jsp` renders a **Social Diagram** tab whose
+JavaScript (`src/main/webapp/javascript/bubbleDiagram/encounter-calls.js`) reads data
+through the generic DataNucleus REST servlet (`/api/*`, `org.ecocean.servlet.RestServlet`):
+
+| Line | Call | Feeds | Problem |
+|------|------|-------|---------|
+| 491 | `GET /api/jdoql?SELECT FROM MarkedIndividual WHERE individualID=="…"` | encounter table | **StackOverflowError** — the recursive POJO serializer loops on the `User`↔`Organization` bidirectional reference cycle. Also bypasses the collaboration/role ACL. |
+| 655 | `GET /api/jdoql?SELECT FROM org.ecocean.social.Relationship WHERE …` | relationship table | same unsafe servlet |
+| 703 | `GET /api/org.ecocean.MarkedIndividual/{id}` (per partner) | partner display in relationship table | same recursive serializer; N+1 |
+
+The `/api/jdoql` MarkedIndividual query is the exact request that produced the reported
+`StackOverflowError`.
+
+A separate, already-merged change (PR #1633) added a safe, ACL-aware
+`GET /api/v3/individuals/{id}`. However, that endpoint returns the **OpenSearch document**
+shape — individual scalars, `socialUnits[]`, `relationships[]` (partner summary only), and
+**encounter aggregates only** (`encounterIds[]`, counts, co-occurrence map). It exposes
+**no per-encounter detail** (date, location, catalogNumber, tissue/annotation indicators,
+behavior, per-encounter sex), so it cannot directly feed the encounter table.
+
+## Scope
+
+**Reads only.** Migrate the three crashing/unsafe read calls (491, 655, 703).
+
+Out of scope (left on the legacy API for a separate effort):
+- Co-occurrence table — line 29, `GET /encounters/occurrenceGraphJson.jsp` (a dedicated
+  JSP, not the crashing servlet).
+- Relationship **write** flow — line 585 (`getRelationshipData`, populates the edit form)
+  and the add/edit/remove relationship form. These POST/PATCH/DELETE through the legacy
+  API and have no `/api/v3` equivalent yet.
+
+## Approach
+
+Option B from brainstorming: **one dedicated, server-assembled read endpoint** (chosen to
+avoid an N+1 over `/api/v3/encounters/{id}`, since Sharkbook individuals routinely have
+large encounter counts). Server-side assembly is also what makes per-encounter ACL
+filtering enforceable.
+
+### Endpoint
+
+`GET /api/v3/individuals/info/social-data?id={individualId}`
+
+New `args[2] == "social-data"` branch in `org.ecocean.api.MarkedIndividualInfo.doGet`.
+This servlet already owns `/api/v3/individuals/info/*` (so no routing collision with
+`BaseObject`'s `/api/v3/individuals/*`), already returns `401` for an anonymous caller,
+and already runs inside a managed Shepherd transaction. No change to web.xml. No change to
+any OpenSearch serializer (so no reindex).
+
+### Security model
+
+1. **Caller auth** — anonymous → `401` (inherited from `MarkedIndividualInfo`).
+2. **Individual gate** — load the individual by id; if
+   `individual.canUserView(currentUser, myShepherd)` is false → `403`. Uses the
+   `MarkedIndividual.canUserView` added in PR #1633 (admin, or can view ≥1 encounter).
+3. **Per-encounter filter (primary requirement)** — iterate `individual.getEncounters()`
+   and include an encounter row **only if `enc.canUserView(currentUser, myShepherd)`**
+   (admin / owner / collaboration via `Collaboration.canUserAccessEncounter`). Non-viewable
+   encounters are dropped before serialization — never written to the response. This closes
+   the legacy behavior where `/api/jdoql` returned every encounter regardless of ACL.
+4. **Relationship partner filter** — include a relationship row only if its partner
+   `MarkedIndividual` is viewable by the caller (`partner.canUserView`). Prevents leaking a
+   partner's identity across a collaboration boundary. A relationship whose partner is not
+   resolvable/viewable is omitted.
+
+### Response shape
+
+Field names mirror what `encounter-calls.js` already consumes, to keep the JS rewrite small.
+
+```json
+{
+  "success": true,
+  "statusCode": 200,
+  "individualId": "cb9e44ca-…",
+  "encounters": [
+    {
+      "catalogNumber": "…",
+      "dateInMilliseconds": 1610000000000,
+      "year": 2021, "month": 1, "day": 7,
+      "locationID": "…",
+      "occurrenceID": "…",
+      "sex": "female",
+      "behavior": "…",
+      "alternateid": "…",
+      "dataTypes": "both"
+    }
+  ],
+  "relationships": [
+    {
+      "_id": "relationship-uuid",
+      "type": "…",
+      "relatedSocialUnitName": "…",
+      "markedIndividualName1": "…",
+      "markedIndividualName2": "…",
+      "markedIndividualRole1": "…",
+      "markedIndividualRole2": "…",
+      "startTime": 1610000000000,
+      "endTime": -1,
+      "partner": {
+        "individualID": "…",
+        "displayName": "…",
+        "nickName": "…",
+        "alternateid": "…",
+        "sex": "…",
+        "localHaplotypeReflection": "…"
+      }
+    }
+  ]
+}
+```
+
+- `dataTypes` is computed server-side using the exact precedence currently in the JS:
+  `both` (tissue samples AND non-trivial annotations) → tissue sample `type` (tissue only)
+  → `youtube-image` (annotations whose `eventID` contains "youtube") → `image` (annotations)
+  → `""`.
+- `year` / `month` / `day` / `dateInMilliseconds` are passed through so the JS keeps its
+  existing date-precision formatting unchanged.
+- `partner` is embedded so the per-partner fetch (line 703) is removed entirely.
+
+### Server assembly
+
+A private method in `MarkedIndividualInfo` builds the payload from domain getters
+(no OpenSearch dependency):
+
+- Encounters: `enc.getCatalogNumber()`, `enc.getDateInMilliseconds()`, `getYear/getMonth/getDay`,
+  `getLocationID()`, `getOccurrenceID()`, `getSex()`, `getBehavior()`, `getAlternateID()`,
+  `getTissueSamples()`, `getAnnotations()` (non-trivial count), `getEventID()` (for `dataTypes`).
+- Relationships: `myShepherd.getAllRelationshipsForMarkedIndividual(id)`, then per relationship
+  the `Relationship` getters plus the partner `MarkedIndividual` (`getOtherMarkedIndividual`/
+  the non-self name) for the embedded partner block.
+
+### JavaScript changes (`encounter-calls.js`)
+
+- `getEncounterTableData` (491): one `d3.json` GET to the new endpoint; build the table from
+  `response.encounters`. The `occurringWith` cross-referencing against
+  `occurrenceObjectArray` (from the co-occurrence JSP) is preserved; only the data source for
+  encounter rows changes.
+- `getRelationshipTableData` (655): build the table from `response.relationships`; partner
+  display read from the embedded `partner` object.
+- `getIndividualData` (703): **removed** — partner detail now arrives embedded.
+- Untouched: `getData`/line 29 (co-occurrence JSP), `getRelationshipData`/line 585 (edit-form
+  write path), the add/edit/remove form handlers.
+
+To avoid double-fetching, the response (which carries both `encounters` and `relationships`)
+may be fetched once per diagram load and cached in a module variable, with both table
+builders reading from it. Exact caching detail deferred to the implementation plan.
+
+## Error handling
+
+| Condition | Status |
+|-----------|--------|
+| anonymous caller | 401 |
+| missing/blank `id` | 400 |
+| individual not found | 404 |
+| individual not viewable | 403 |
+| success | 200 |
+
+All via the existing `statusCode` JSON convention in `MarkedIndividualInfo`.
+
+## Testing
+
+JUnit 5 + Testcontainers, in `src/test/java/org/ecocean/api/` (or the closest existing
+home for this servlet's tests):
+
+1. **Per-encounter ACL** — an individual with encounters owned by different users: a
+   non-admin collaborator sees only the encounters they may view; an admin sees all;
+   counts match the filter.
+2. **Individual gate** — a non-viewable individual returns 403; a viewable one returns 200.
+3. **Relationship partner filter** — a relationship to a non-viewable partner is omitted;
+   to a viewable partner is included with the embedded partner block.
+4. **dataTypes precedence** — encounters with (tissue+annotation), tissue-only,
+   youtube-annotation, plain-annotation, and neither map to the expected `dataTypes` value.
+5. **Bad input** — blank `id` → 400; unknown `id` → 404; anonymous → 401.
+
+Manual verification: open the Social Diagram on an individual; confirm both tables populate
+and that no `/api/jdoql` or `/api/org.ecocean.*` request is issued (network tab).
+
+## Dependencies / sequencing
+
+Depends on `MarkedIndividual.canUserView` (PR #1633). This branch is stacked on
+`fix/api-v3-individuals-get`; it should merge after #1633 (or be rebased onto `main` once
+#1633 lands).
+
+## Out-of-scope follow-ups (noted, not done here)
+
+- Migrating the relationship **write** flow (585 + form) to `/api/v3` endpoints.
+- Retiring / locking down the generic `/api/jdoql` + `/api/{class}/{id}` RestServlet surface
+  (tracked privately as a security item).

--- a/docs/superpowers/specs/2026-06-24-social-diagram-api-v3-reads-design.md
+++ b/docs/superpowers/specs/2026-06-24-social-diagram-api-v3-reads-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-24
 **Branch:** `fix/social-diagram-api-v3-reads` (off `fix/api-v3-individuals-get`, which is PR #1633)
-**Status:** design — revised after Codex review (round 1); awaiting spec review
+**Status:** design — revised after Codex review (rounds 1–2); awaiting spec review
 
 ## Problem
 
@@ -67,11 +67,13 @@ serializer change (no reindex).
    the caller can't see are dropped before serialization. (Note: `canUserView` admits an
    encounter for an admin OR via `Collaboration.canUserAccessEncounter`.)
 4. **Co-occurrence ("occurring with") filter** — computed **server-side in this endpoint**,
-   not from the legacy JSP. For each viewable encounter, find its occurrence's co-occurring
-   individuals and include a companion **only if that companion's encounter in the occurrence
-   is itself `canUserView` for the caller**. This closes the leak Codex flagged: the legacy
-   `occurrenceGraphJson.jsp` authorizes an occurrence if *any* encounter is viewable and then
-   serializes *every* companion's id/name/sex/haplotype.
+   not from the legacy JSP. For each viewable encounter, walk its occurrence's encounter list
+   (`occ.getEncounters()`) and include a companion individual **only if that companion's own
+   encounter in the occurrence is itself `enc.canUserView(currentUser, myShepherd)`**. Do NOT
+   use occurrence-level authorization — `Collaboration.canUserViewOccurrence` admits an
+   occurrence when *any* one encounter is viewable, which is exactly the leak: the legacy
+   `occurrenceGraphJson.jsp` authorizes that way and then serializes *every* companion's
+   id/name/sex/haplotype. The check must be per-companion-encounter.
 5. **Relationship partner filter** — resolve the partner robustly (object link
    `Relationship.getOtherMarkedIndividual(self)` first; if null, fall back to the non-self
    `markedIndividualName{1,2}` via `myShepherd.getMarkedIndividual(name)`). Include the
@@ -113,7 +115,7 @@ and partner detail is embedded).
       "behavior": "…",
       "alternateid": "…",
       "dataTypes": "both",
-      "occurringWith": ["DISPLAYNAME-A id=uuid-a", "DISPLAYNAME-B id=uuid-b"]
+      "occurringWith": "DISPLAYNAME-A, DISPLAYNAME-B"
     }
   ],
   "relationships": [
@@ -145,9 +147,10 @@ and partner detail is embedded).
   non-trivial-only — preserving current behavior): `both` (tissue samples AND annotations) →
   the tissue sample `type` (tissue only) → `youtube-image` (annotation whose `eventID`
   contains "youtube") → `image` (annotation) → `""`.
-- `occurringWith` is the ACL-filtered companion list per encounter (same
-  `"displayName id=uuid"` token format the JS already splits on), replacing the join against
-  the legacy JSP for the encounter table.
+- `occurringWith` is a **display string** — the comma-joined (`", "`) `displayName`s of the
+  ACL-filtered co-occurring individuals — matching the legacy value the encounter table passes
+  straight into `makeTable` (it is a column string, not an array; an array would be mis-rendered
+  as control data). It replaces the join against the legacy JSP for the encounter table.
 - `year`/`month`/`day`/`dateInMilliseconds` are passed through so the JS keeps its existing
   date-precision formatting unchanged.
 - `partner` is embedded so the per-partner fetch (line 703) is removed.
@@ -196,12 +199,19 @@ All via the existing `statusCode` JSON convention in `MarkedIndividualInfo`.
 ## Performance
 
 This removes the **client-side HTTP N+1** (one request instead of 1 + per-encounter-individual
-+ per-partner). Server-side cost is bounded by the individual's encounter count: the
-per-encounter ACL check and `occurringWith` computation touch occurrences and (via partner
-`canUserView`) partner encounters, and reading `dataTypes` touches lazy tissue/annotation
-collections — all inside the single managed transaction. A test exercises a large-encounter
-individual to confirm acceptable behavior; if needed, the plan may add per-occurrence/partner
-memoization. No new unbounded query is introduced.
++ per-partner). Server-side cost, however, is more than linear in the focal individual's
+encounter count: `occurringWith` walks each focal occurrence's full encounter list
+(`occ.getEncounters()`), and each relationship's `partner.canUserView` can scan every encounter
+on that partner. To keep this bounded, the implementation **must memoize**:
+- per-encounter `canUserView` results (an encounter may recur across the focal individual's
+  occurrences and as a companion);
+- per-occurrence the computed set of viewable companion individuals;
+- per-partner-individual the `canUserView` result (reused across multiple relationships).
+
+All work stays inside the single managed transaction; no new unbounded query is introduced.
+The large-individual test (below) must cover a focal individual with **large occurrences**
+(many co-occurring encounters) **and** relationships whose **partners have many encounters**,
+to exercise these paths.
 
 ## Testing
 
@@ -220,6 +230,10 @@ JUnit 5 + Testcontainers, under `src/test/java/org/ecocean/api/`:
 6. **dataTypes precedence** — (tissue+annotation), tissue-only, youtube-annotation,
    plain-annotation, neither → expected `dataTypes` value (matching legacy "any annotation").
 7. **Bad input** — blank `id` → 400; unknown `id` → 404; anonymous → 401.
+8. **Large individual** — a focal individual with large occurrences (many co-occurring
+   encounters) and relationships whose partners have many encounters: completes within the
+   single transaction and returns correct, ACL-filtered results (exercises the memoization
+   paths).
 
 Manual: open the Social Diagram on an individual; confirm both tables populate and that no
 `/api/jdoql` or `/api/org.ecocean.*` request is issued (network tab); confirm edit/remove

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -892,6 +892,10 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         return many.get(0);
     }
 
+    public String getAlternateID() {
+        return alternateid;
+    }
+
     public void setNickName(String newName) {
         this.addNameByKey(NAMES_KEY_NICKNAME, newName);
     }

--- a/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
+++ b/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.ecocean.Occurrence;
+
 import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
 import org.ecocean.Encounter;
@@ -85,6 +87,7 @@ public class MarkedIndividualInfo extends ApiBase {
         }
         rtn.put("individualId", indiv.getId());
         Map<String, Boolean> encViewCache = new HashMap<String, Boolean>();
+        Map<String, String> occCache = new HashMap<String, String>();
         JSONArray encArr = new JSONArray();
         if (indiv.getEncounters() != null) {
             for (Encounter enc : indiv.getEncounters()) {
@@ -102,6 +105,7 @@ public class MarkedIndividualInfo extends ApiBase {
                 e.put("behavior", enc.getBehavior());
                 e.put("alternateid", enc.getAlternateID());
                 e.put("dataTypes", computeDataTypes(enc));
+                e.put("occurringWith", occurringWith(enc, indiv, user, myShepherd, encViewCache, occCache));
                 encArr.put(e);
             }
         }
@@ -173,6 +177,33 @@ public class MarkedIndividualInfo extends ApiBase {
         return rtn;
     }
 
+
+    // ACL-correct co-occurrence: per the spec, a companion is included ONLY if the
+    // companion's own encounter in the occurrence passes enc.canUserView — never
+    // occurrence-level auth (which admits an occurrence if ANY encounter is viewable).
+    private String occurringWith(Encounter enc, MarkedIndividual focal, User user,
+        Shepherd myShepherd, Map<String, Boolean> encViewCache, Map<String, String> occCache) {
+        String occId = enc.getOccurrenceID();
+        if (occId == null) return "";
+        String memo = occCache.get(occId);
+        if (memo != null) return memo;
+        Occurrence occ = enc.getOccurrence(myShepherd);
+        String focalId = focal.getId();
+        java.util.LinkedHashSet<String> names = new java.util.LinkedHashSet<String>();
+        if ((occ != null) && (occ.getEncounters() != null)) {
+            for (Encounter coEnc : occ.getEncounters()) {
+                MarkedIndividual coInd = coEnc.getIndividual();
+                if (coInd == null) continue;
+                if ((focalId != null) && focalId.equals(coInd.getIndividualID())) continue;
+                if (!encCanView(coEnc, user, myShepherd, encViewCache)) continue;
+                String dn = coInd.getDisplayName();
+                if (Util.stringExists(dn)) names.add(dn);
+            }
+        }
+        String joined = String.join(", ", names);
+        occCache.put(occId, joined);
+        return joined;
+    }
 
     private boolean encCanView(Encounter enc, User user, Shepherd myShepherd,
         Map<String, Boolean> cache) {

--- a/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
+++ b/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.Encounter;
 import org.ecocean.LocationID;
 import org.ecocean.MarkedIndividual;
 import org.ecocean.MultiValue;
@@ -32,7 +33,7 @@ public class MarkedIndividualInfo extends ApiBase {
         if (currentUser == null) {
             response.setStatus(401);
             response.setHeader("Content-Type", "application/json");
-            response.getWriter().write("{\"success\": false}");
+            response.getWriter().write("{\"success\": false, \"statusCode\": 401}");
             myShepherd.rollbackDBTransaction();
             myShepherd.closeDBTransaction();
             return;
@@ -47,6 +48,8 @@ public class MarkedIndividualInfo extends ApiBase {
         if (args[0].equals("individuals") && args[1].equals("info")) {
             if (args[2].equals("next_name")) {
                 results = getNextNames(myShepherd, request, currentUser);
+            } else if (args[2].equals("social-data")) {
+                results = getSocialData(myShepherd, request, currentUser);
             }
         }
 
@@ -56,6 +59,34 @@ public class MarkedIndividualInfo extends ApiBase {
         response.setCharacterEncoding("UTF-8");
         response.setHeader("Content-Type", "application/json");
         response.getWriter().write(results.toString());
+    }
+
+    private JSONObject getSocialData(Shepherd myShepherd, HttpServletRequest request, User user) {
+        JSONObject rtn = new JSONObject();
+        rtn.put("success", false);
+        String id = request.getParameter("id");
+        if (!Util.stringExists(id)) {
+            rtn.put("statusCode", 400);
+            rtn.put("error", "missing id");
+            return rtn;
+        }
+        MarkedIndividual indiv = myShepherd.getMarkedIndividual(id.trim());
+        if (indiv == null) {
+            rtn.put("statusCode", 404);
+            rtn.put("error", "not found");
+            return rtn;
+        }
+        if (!indiv.canUserView(user, myShepherd)) {
+            rtn.put("statusCode", 403);
+            rtn.put("error", "access denied");
+            return rtn;
+        }
+        rtn.put("individualId", indiv.getId());
+        rtn.put("encounters", new JSONArray());
+        rtn.put("relationships", new JSONArray());
+        rtn.put("success", true);
+        rtn.put("statusCode", 200);
+        return rtn;
     }
 
     private JSONObject getNextNames(Shepherd myShepherd, HttpServletRequest request, User user) {

--- a/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
+++ b/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
@@ -7,7 +7,9 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.ServletException;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
@@ -82,7 +84,28 @@ public class MarkedIndividualInfo extends ApiBase {
             return rtn;
         }
         rtn.put("individualId", indiv.getId());
-        rtn.put("encounters", new JSONArray());
+        Map<String, Boolean> encViewCache = new HashMap<String, Boolean>();
+        JSONArray encArr = new JSONArray();
+        if (indiv.getEncounters() != null) {
+            for (Encounter enc : indiv.getEncounters()) {
+                if (!encCanView(enc, user, myShepherd, encViewCache)) continue;
+                JSONObject e = new JSONObject();
+                e.put("catalogNumber", enc.getCatalogNumber());
+                Long dim = enc.getDateInMilliseconds();
+                if (dim != null) e.put("dateInMilliseconds", dim.longValue());
+                e.put("year", enc.getYear());
+                e.put("month", enc.getMonth());
+                e.put("day", enc.getDay());
+                e.put("locationID", enc.getLocationID());
+                e.put("occurrenceID", enc.getOccurrenceID());
+                e.put("sex", enc.getSex());
+                e.put("behavior", enc.getBehavior());
+                e.put("alternateid", enc.getAlternateID());
+                e.put("dataTypes", computeDataTypes(enc));
+                encArr.put(e);
+            }
+        }
+        rtn.put("encounters", encArr);
         rtn.put("relationships", new JSONArray());
         rtn.put("success", true);
         rtn.put("statusCode", 200);
@@ -150,6 +173,33 @@ public class MarkedIndividualInfo extends ApiBase {
         return rtn;
     }
 
+
+    private boolean encCanView(Encounter enc, User user, Shepherd myShepherd,
+        Map<String, Boolean> cache) {
+        String eid = enc.getId();
+        Boolean cached = cache.get(eid);
+        if (cached != null) return cached.booleanValue();
+        boolean v = enc.canUserView(user, myShepherd);
+        cache.put(eid, v);
+        return v;
+    }
+
+    // Mirrors the legacy encounter-calls.js dataTypes precedence (ANY annotation counts;
+    // tissue type is the static "TissueSample").
+    private String computeDataTypes(Encounter enc) {
+        List<org.ecocean.genetics.TissueSample> ts = enc.getTissueSamples();
+        boolean hasTissue = (ts != null) && !ts.isEmpty();
+        List<org.ecocean.Annotation> anns = enc.getAnnotations();
+        boolean hasAnn = (anns != null) && !anns.isEmpty();
+        if (hasTissue && hasAnn) return "both";
+        if (hasTissue) return "TissueSample";
+        if (hasAnn) {
+            String eventID = enc.getEventID();
+            if ((eventID != null) && (eventID.indexOf("youtube") > -1)) return "youtube-image";
+            return "image";
+        }
+        return "";
+    }
 
 /* from matchResults.jsp ...
 String projectIdPrefix = request.getParameter("projectIdPrefix");

--- a/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
+++ b/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.ecocean.Occurrence;
+import org.ecocean.social.Relationship;
 
 import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
@@ -110,7 +111,13 @@ public class MarkedIndividualInfo extends ApiBase {
             }
         }
         rtn.put("encounters", encArr);
-        rtn.put("relationships", new JSONArray());
+        Map<String, Boolean> partnerViewCache = new HashMap<String, Boolean>();
+        JSONArray relArr = new JSONArray();
+        for (Relationship rel : myShepherd.getAllRelationshipsForMarkedIndividual(indiv.getId())) {
+            JSONObject row = relationshipRow(rel, indiv, user, myShepherd, partnerViewCache);
+            if (row != null) relArr.put(row);
+        }
+        rtn.put("relationships", relArr);
         rtn.put("success", true);
         rtn.put("statusCode", 200);
         return rtn;
@@ -231,6 +238,65 @@ public class MarkedIndividualInfo extends ApiBase {
             return "image";
         }
         return "";
+    }
+
+    private JSONObject relationshipRow(Relationship rel, MarkedIndividual focal, User user,
+        Shepherd myShepherd, Map<String, Boolean> partnerViewCache) {
+        MarkedIndividual partner = rel.getOtherMarkedIndividual(focal);
+        if (partner == null) { // object link not populated; fall back to non-self name
+            String focalId = focal.getId();
+            String n1 = rel.getMarkedIndividualName1();
+            String n2 = rel.getMarkedIndividualName2();
+            String otherName = null;
+            if ((n1 != null) && !n1.equals(focalId)) otherName = n1;
+            else if ((n2 != null) && !n2.equals(focalId)) otherName = n2;
+            if (otherName != null) partner = myShepherd.getMarkedIndividual(otherName);
+        }
+        if (partner == null) return null;
+        if (!partnerCanView(partner, user, myShepherd, partnerViewCache)) return null;
+
+        JSONObject r = new JSONObject();
+        r.put("_id", relationshipDatastoreId(rel));
+        r.put("type", rel.getType());
+        r.put("relatedSocialUnitName", rel.getRelatedSocialUnitName());
+        r.put("markedIndividualName1", rel.getMarkedIndividualName1());
+        r.put("markedIndividualName2", rel.getMarkedIndividualName2());
+        r.put("markedIndividualRole1", rel.getMarkedIndividualRole1());
+        r.put("markedIndividualRole2", rel.getMarkedIndividualRole2());
+        r.put("startTime", rel.getStartTime());
+        r.put("endTime", rel.getEndTime());
+
+        JSONObject p = new JSONObject();
+        p.put("individualID", partner.getIndividualID());
+        p.put("displayName", partner.getDisplayName());
+        p.put("nickName", partner.getNickName());
+        p.put("alternateid", partner.getAlternateID());
+        p.put("sex", partner.getSex());
+        p.put("localHaplotypeReflection", partner.getHaplotype());
+        r.put("partner", p);
+        return r;
+    }
+
+    private boolean partnerCanView(MarkedIndividual partner, User user, Shepherd myShepherd,
+        Map<String, Boolean> cache) {
+        String pid = partner.getId();
+        if (pid == null) return partner.canUserView(user, myShepherd);
+        Boolean cached = cache.get(pid);
+        if (cached != null) return cached.booleanValue();
+        boolean v = partner.canUserView(user, myShepherd);
+        cache.put(pid, v);
+        return v;
+    }
+
+    // Emits the DataNucleus datastore-identity string in the legacy `_id` form, so the
+    // retained edit/remove buttons (which append "[OID]org.ecocean.social.Relationship")
+    // resolve the same row via getObjectById. Verified by relationshipIdRoundTripsThroughGetObjectById.
+    private String relationshipDatastoreId(Relationship rel) {
+        Object oid = javax.jdo.JDOHelper.getObjectId(rel);
+        if (oid == null) return null;
+        String s = oid.toString();
+        int idx = s.indexOf("[OID]");
+        return (idx > -1) ? s.substring(0, idx) : s;
     }
 
 /* from matchResults.jsp ...

--- a/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
+++ b/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
@@ -177,6 +177,7 @@ public class MarkedIndividualInfo extends ApiBase {
     private boolean encCanView(Encounter enc, User user, Shepherd myShepherd,
         Map<String, Boolean> cache) {
         String eid = enc.getId();
+        if (eid == null) return enc.canUserView(user, myShepherd);
         Boolean cached = cache.get(eid);
         if (cached != null) return cached.booleanValue();
         boolean v = enc.canUserView(user, myShepherd);

--- a/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
+++ b/src/main/java/org/ecocean/api/MarkedIndividualInfo.java
@@ -50,20 +50,23 @@ public class MarkedIndividualInfo extends ApiBase {
         if (args.length < 3) throw new ServletException("Bad path");
         JSONObject results = new JSONObject("{\"success\": false, \"error\": \"unknown request\"}");
 
-        if (args[0].equals("individuals") && args[1].equals("info")) {
-            if (args[2].equals("next_name")) {
-                results = getNextNames(myShepherd, request, currentUser);
-            } else if (args[2].equals("social-data")) {
-                results = getSocialData(myShepherd, request, currentUser);
+        try {
+            if (args[0].equals("individuals") && args[1].equals("info")) {
+                if (args[2].equals("next_name")) {
+                    results = getNextNames(myShepherd, request, currentUser);
+                } else if (args[2].equals("social-data")) {
+                    results = getSocialData(myShepherd, request, currentUser);
+                }
             }
-        }
 
-        myShepherd.rollbackDBTransaction();
-        myShepherd.closeDBTransaction();
-        response.setStatus(results.optInt("statusCode", 500));
-        response.setCharacterEncoding("UTF-8");
-        response.setHeader("Content-Type", "application/json");
-        response.getWriter().write(results.toString());
+            response.setStatus(results.optInt("statusCode", 500));
+            response.setCharacterEncoding("UTF-8");
+            response.setHeader("Content-Type", "application/json");
+            response.getWriter().write(results.toString());
+        } finally {
+            myShepherd.rollbackDBTransaction();
+            myShepherd.closeDBTransaction();
+        }
     }
 
     private JSONObject getSocialData(Shepherd myShepherd, HttpServletRequest request, User user) {
@@ -288,9 +291,12 @@ public class MarkedIndividualInfo extends ApiBase {
         return v;
     }
 
-    // Emits the DataNucleus datastore-identity string in the legacy `_id` form, so the
-    // retained edit/remove buttons (which append "[OID]org.ecocean.social.Relationship")
-    // resolve the same row via getObjectById. Verified by relationshipIdRoundTripsThroughGetObjectById.
+    // Emits the bare DataNucleus datastore-identity key — byte-identical to what the legacy
+    // REST API emitted via IdentityUtils.getTargetKeyForDatastoreIdentity — so the retained
+    // edit/remove servlets (which append "[OID]org.ecocean.social.Relationship" before calling
+    // getObjectById) already consume this form correctly.
+    // Note: relationshipIdRoundTripsThroughGetObjectById confirms the bare-key round-trip, not
+    // the full "_id + [OID]" form the edit/remove buttons assemble at call time.
     private String relationshipDatastoreId(Relationship rel) {
         Object oid = javax.jdo.JDOHelper.getObjectId(rel);
         if (oid == null) return null;

--- a/src/main/webapp/javascript/bubbleDiagram/encounter-calls.js
+++ b/src/main/webapp/javascript/bubbleDiagram/encounter-calls.js
@@ -486,88 +486,42 @@ var makeRelTable = function(items, tableHeadLocation, tableBodyLocation, sortOn)
 };
 
 var getEncounterTableData = function(occurrenceObjectArray, individualID) {
-    var encounterData = [];
-    var occurringWith = "";
-    d3.json(wildbookGlobals.baseUrl + "/api/jdoql?"+encodeURIComponent("SELECT FROM org.ecocean.MarkedIndividual WHERE individualID == \"" + individualID + "\"" ), function(error, json) {
-	if(error) {
-            console.log("error")
-	}
-	jsonData = json[0];
-	for(var i=0; i < jsonData.encounters.length; i++) {
-    	    var occurringWith = "";
-            for(var j = 0; j < occurrenceObjectArray.length; j++) {
-				if (typeof occurrenceObjectArray[j].occurrenceID !== 'undefined' && typeof jsonData.encounters[i].occurrenceID !== 'undefined' && occurrenceObjectArray[j].occurrenceID == jsonData.encounters[i].occurrenceID) {
-			    	if(encounterData.includes(jsonData.encounters[i].occurrenceID)) {
-						
-			    	} 
-					else {
-						var occurringWith = occurrenceObjectArray[j].occurringWith;
-						console.log("occurringWith: "+occurringWith+" in "+jsonData.encounters[i].occurrenceID+" and "+occurrenceObjectArray[j].occurrenceID);
-			    	}
-				}
-            }
-            var dateInMilliseconds = new Date(jsonData.encounters[i].dateInMilliseconds);
-            if(dateInMilliseconds > 0) {
-		//console.log("Trying millis...");
-		date = dateInMilliseconds.toISOString().substring(0, 10);
-		if(jsonData.encounters[i].day<1){date=date.substring(0,7);}
-		if(jsonData.encounters[i].month<0){date=date.substring(0,4);}
-            } else if (jsonData.encounters[i].year) {
-		//console.log("Tryin plaintext...");
-		date = jsonData.encounters[i].year;
-		if (jsonData.encounters[i].month) { date+= "-"+jsonData.encounters[i].month;}
-		if (jsonData.encounters[i].day) { date+= "-"+jsonData.encounters[i].day;} 
-            } else {  
-		date = dict['unknown'];
-            }
-
-            if(jsonData.encounters[i].locationID) {
-				var location = jsonData.encounters[i].locationID;
-			} else {
-				var location = "";
-			}
-            var catalogNumber = jsonData.encounters[i].catalogNumber;
-            console.log("Here's what we are working with : "+jsonData.encounters[i]);
-            if(jsonData.encounters[i].tissueSamples || jsonData.encounters[i].annotations) {
-		if (jsonData.encounters[i].tissueSamples && jsonData.encounters[i].tissueSamples.length > 0 && jsonData.encounters[i].annotations.length > 0){
-                    var dataTypes = "both"
-		} 
-		else if((jsonData.encounters[i].tissueSamples)&&(jsonData.encounters[i].tissueSamples.length > 0)) {
-		    var dataTypes = jsonData.encounters[i].tissueSamples[0].type;
-		} 
-		else if((jsonData.encounters[i].annotations)&&(jsonData.encounters[i].annotations.length > 0)) {
-		    
-        	    if((jsonData.encounters[i].eventID)&&(jsonData.encounters[i].eventID.indexOf("youtube") > -1)){
-        		var dataTypes = "youtube-image";
-        	    }
-        	    //otherwise it's just a plain old image
-        	    else{
-        		var dataTypes = "image";
-        	    }
-        	    
-		}
-		else {
-		    var dataTypes = "";
-		}
-            }
-            var sex = jsonData.encounters[i].sex;
-            var behavior = jsonData.encounters[i].behavior;
-            var alternateID = jsonData.encounters[i].alternateid;
-            var encounter = new Object();
-            if(occurringWith === undefined) {
-				var occurringWith = "";
-            }
-
-            encounter = {catalogNumber: catalogNumber, date: date, location: location, dataTypes: dataTypes, alternateID: alternateID, sex: sex, occurringWith: occurringWith, behavior: behavior};
+    d3.json(wildbookGlobals.baseUrl + "/api/v3/individuals/info/social-data?id=" + encodeURIComponent(individualID), function(error, json) {
+        if (error) { console.log("error"); return; }
+        var encounterData = [];
+        var encs = (json && json.encounters) ? json.encounters : [];
+        for (var i = 0; i < encs.length; i++) {
+            var row = encs[i];
+            var date;
+            var dim = new Date(row.dateInMilliseconds);
+            if (dim > 0) {
+                date = dim.toISOString().substring(0, 10);
+                if (row.day < 1) { date = date.substring(0, 7); }
+                if (row.month < 0) { date = date.substring(0, 4); }
+            } else if (row.year) {
+                date = row.year;
+                if (row.month) { date += "-" + row.month; }
+                if (row.day) { date += "-" + row.day; }
+            } else { date = dict['unknown']; }
+            var encounter = {
+                catalogNumber: row.catalogNumber,
+                date: date,
+                location: row.locationID || "",
+                dataTypes: row.dataTypes || "",
+                alternateID: row.alternateid,
+                sex: row.sex,
+                occurringWith: row.occurringWith || "",
+                behavior: row.behavior
+            };
             encounterData.push(encounter);
-	}
-	makeTable(encounterData, "#encountHead", "#encountBody", "date", null);
-	$('#encountTable tr').attr("onClick", "return encountTableAuxClick(this);")
-						 .attr("onAuxClick", "return encountTableAuxClick(this);")
-						 .each(function() {
-							encountUrl = "encounters/encounter.jsp?number=" + ($(this).attr("class"));
-							$(this).find("td").first().wrapInner("<a href=\""+encountUrl+"\"></a>");
-						 });
+        }
+        makeTable(encounterData, "#encountHead", "#encountBody", "date", null);
+        $('#encountTable tr').attr("onClick", "return encountTableAuxClick(this);")
+                             .attr("onAuxClick", "return encountTableAuxClick(this);")
+                             .each(function() {
+                                encountUrl = "encounters/encounter.jsp?number=" + ($(this).attr("class"));
+                                $(this).find("td").first().wrapInner("<a href=\"" + encountUrl + "\"></a>");
+                             });
     });
 }
 
@@ -651,91 +605,34 @@ var resetForm = function($form, markedIndividual) {
 }
 
 var getRelationshipTableData = function(individualID) {
-	console.log("getTelationshipTableData");
-    d3.json(wildbookGlobals.baseUrl + "/api/jdoql?"+encodeURIComponent("SELECT FROM org.ecocean.social.Relationship WHERE (this.markedIndividualName1 == \"" + individualID + "\" || this.markedIndividualName2 == \"" + individualID + "\")"), function(error, json) {
-		if(error) {
-	    	console.log("error")
-		}
-		var relationshipArray = [];
-		let jsonData = json;
-		for(var i = 0; i < jsonData.length; i++) {
-	   		var relationshipID = jsonData[i]._id;
-	    	var startTime = jsonData[i].startTime;
-	    	var endTime = jsonData[i].endTime;
-	    	if (startTime == "-1") {
-				startTime = "Start Time";
-	    	} 
-	    	if (endTime == "-1") {
-				endTime = "End Time";
-	    	}
-	    
-	    	if(jsonData[i].markedIndividualName1 != individualID) {
-				var whaleID = jsonData[i].markedIndividualName1;
-				var markedIndividual = jsonData[i].markedIndividualName2;
-				var relationshipWithRole = jsonData[i].markedIndividualRole1;
-				var markedIndividualRole = jsonData[i].markedIndividualRole2;
-	    	}
-	    	if(jsonData[i].markedIndividualName2 != individualID) {
-				var whaleID = jsonData[i].markedIndividualName2;
-				var markedIndividual = jsonData[i].markedIndividualName1;
-				var markedIndividualRole = jsonData[i].markedIndividualRole1;
-				var relationshipWithRole = jsonData[i].markedIndividualRole2;
-	    	}
-	    	var relatedSocialUnitName = jsonData[i].relatedSocialUnitName;
-	    	var type = jsonData[i].type;
-	    	var relationship = new Object();
-	    	relationship = {"roles": [markedIndividualRole, relationshipWithRole], "relationshipWith": [whaleID], "type": type, "socialUnit": relatedSocialUnitName, "edit": ["edit", relationshipID], "remove": ["remove", relationshipID]};
-	    	relationshipArray.push(relationship);
-		}
-		getIndividualData(relationshipArray, function (relationshipTableData) {
-			console.log("All data has been processed:", JSON.stringify(relationshipTableData));
-			makeRelTable(relationshipTableData, "#relationshipHead", "#relationshipBody", "text");
-		});
-
+    d3.json(wildbookGlobals.baseUrl + "/api/v3/individuals/info/social-data?id=" + encodeURIComponent(individualID), function(error, json) {
+        if (error) { console.log("error"); return; }
+        var relationshipTableData = [];
+        var rels = (json && json.relationships) ? json.relationships : [];
+        for (var i = 0; i < rels.length; i++) {
+            var rel = rels[i];
+            var relationshipID = rel._id;
+            var markedIndividualRole, relationshipWithRole;
+            if (rel.markedIndividualName1 != individualID) {
+                markedIndividualRole = rel.markedIndividualRole2;
+                relationshipWithRole = rel.markedIndividualRole1;
+            } else {
+                markedIndividualRole = rel.markedIndividualRole1;
+                relationshipWithRole = rel.markedIndividualRole2;
+            }
+            var p = rel.partner || {};
+            relationshipTableData.push({
+                "roles": [markedIndividualRole, relationshipWithRole],
+                "relationshipWith": [p.individualID, p.nickName, p.alternateid, p.sex, p.localHaplotypeReflection, p.displayName],
+                "type": rel.type,
+                "socialUnit": rel.relatedSocialUnitName,
+                "edit": ["edit", relationshipID],
+                "remove": ["remove", relationshipID]
+            });
+        }
+        makeRelTable(relationshipTableData, "#relationshipHead", "#relationshipBody", "text");
     });
 }
-
-var getIndividualData = function (relationshipArray, onComplete) {
-	var relationshipTableData = [];
-	var completedRequests = 0;
-
-	for (var i = 0; i < relationshipArray.length; i++) {
-		d3.json(wildbookGlobals.baseUrl + "/api/org.ecocean.MarkedIndividual/" + relationshipArray[i].relationshipWith[0], function (error, json) {
-			if (error) {
-				console.log("Error loading data");
-				return;
-			}
-
-			let jsonData = json;
-			var individualInfo = relationshipArray.filter(function (obj) {
-				return obj.relationshipWith[0] === jsonData.individualID;
-			})[0];
-
-			individualInfo.relationshipWith[1] = jsonData.nickName;
-			individualInfo.relationshipWith[2] = jsonData.alternateid;
-			individualInfo.relationshipWith[3] = jsonData.sex;
-			individualInfo.relationshipWith[4] = jsonData.localHaplotypeReflection;
-			individualInfo.relationshipWith[5] = jsonData.displayName;
-
-			relationshipTableData.push(individualInfo);
-			completedRequests++;
-
-			if (completedRequests === relationshipArray.length) {
-				for (var j = 0; j < relationshipArray.length; j++) {
-					if (relationshipArray[j].relationshipWith.length == 1) {
-						relationshipArray[j].relationshipWith[1] = jsonData.nickName;
-						relationshipArray[j].relationshipWith[2] = jsonData.alternateid;
-						relationshipArray[j].relationshipWith[3] = jsonData.sex;
-						relationshipArray[j].relationshipWith[4] = jsonData.localHaplotypeReflection;
-						relationshipArray[j].relationshipWith[5] = jsonData.displayName;
-					}
-				}
-				onComplete(relationshipTableData);
-			}
-		});
-	}
-}
-
 function whatIsIt(object) {
 	var stringConstructor = "test".constructor;
 	var arrayConstructor = [].constructor;

--- a/src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
+++ b/src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
@@ -72,6 +72,11 @@ class MarkedIndividualInfoTest {
     // alias so test methods read naturally (same object as seededOwner)
     static User focalOwner;
 
+    // relationship test fields
+    static String focalIndivWithViewableRel;
+    static String focalIndivWithHiddenPartnerRel;
+    static String hiddenPartnerId;
+
     @BeforeAll
     static void setUp() throws Exception {
         Properties cc = new Properties();
@@ -211,6 +216,44 @@ class MarkedIndividualInfoTest {
             occViewable.addEncounterAndUpdateIt(viewableCompanionEnc);
             sh.storeNewOccurrence(occViewable);
 
+            // --- relationship test: viewable partner ---
+            // focal individual with encounter owned by seededOwner; partner also owned by seededOwner
+            Encounter relFocalEnc = new Encounter();
+            relFocalEnc.setSubmitterID(seededOwnerUsername);
+            sh.storeNewEncounter(relFocalEnc);
+            MarkedIndividual relFocal = new MarkedIndividual("RelFocal", relFocalEnc);
+            sh.storeNewMarkedIndividual(relFocal);
+            focalIndivWithViewableRel = relFocal.getId();
+
+            Encounter viewablePartnerEnc = new Encounter();
+            viewablePartnerEnc.setSubmitterID(seededOwnerUsername);
+            sh.storeNewEncounter(viewablePartnerEnc);
+            MarkedIndividual viewablePartner = new MarkedIndividual("ViewablePartner", viewablePartnerEnc);
+            sh.storeNewMarkedIndividual(viewablePartner);
+
+            org.ecocean.social.Relationship viewableRel = new org.ecocean.social.Relationship(
+                "mother-calf", relFocal, viewablePartner, "mother", "calf");
+            sh.getPM().makePersistent(viewableRel);
+
+            // --- relationship test: hidden partner (owned by stranger, not viewable by focalOwner) ---
+            Encounter hiddenRelFocalEnc = new Encounter();
+            hiddenRelFocalEnc.setSubmitterID(seededOwnerUsername);
+            sh.storeNewEncounter(hiddenRelFocalEnc);
+            MarkedIndividual hiddenRelFocal = new MarkedIndividual("HiddenRelFocal", hiddenRelFocalEnc);
+            sh.storeNewMarkedIndividual(hiddenRelFocal);
+            focalIndivWithHiddenPartnerRel = hiddenRelFocal.getId();
+
+            Encounter hiddenPartnerEnc = new Encounter();
+            hiddenPartnerEnc.setSubmitterID(strangerUsername);
+            sh.storeNewEncounter(hiddenPartnerEnc);
+            MarkedIndividual hiddenPartner = new MarkedIndividual("HiddenPartner", hiddenPartnerEnc);
+            sh.storeNewMarkedIndividual(hiddenPartner);
+            hiddenPartnerId = hiddenPartner.getId();
+
+            org.ecocean.social.Relationship hiddenRel = new org.ecocean.social.Relationship(
+                "associate", hiddenRelFocal, hiddenPartner);
+            sh.getPM().makePersistent(hiddenRel);
+
             sh.commitDBTransaction();
         } catch (Exception e) {
             sh.rollbackDBTransaction();
@@ -333,6 +376,10 @@ class MarkedIndividualInfoTest {
                         when(mock.getOccurrence(any(Encounter.class)))
                             .thenAnswer(inv -> backingShepherd.getOccurrence(
                                 (Encounter) inv.getArgument(0)));
+                        // Delegate getAllRelationshipsForMarkedIndividual
+                        when(mock.getAllRelationshipsForMarkedIndividual(anyString()))
+                            .thenAnswer(inv -> backingShepherd.getAllRelationshipsForMarkedIndividual(
+                                (String) inv.getArgument(0)));
                     })) {
 
                 new MarkedIndividualInfo().doGet(req, resp);
@@ -418,5 +465,33 @@ class MarkedIndividualInfoTest {
         JSONObject j = invoke(focalOwner, focalIndivIdWithViewableCompanion);
         String ow = j.getJSONArray("encounters").getJSONObject(0).optString("occurringWith", "");
         assertTrue(ow.contains(viewableCompanionDisplayName));
+    }
+
+    @Test void relationshipIdRoundTripsThroughGetObjectById() throws Exception {
+        JSONObject j = invoke(focalOwner, focalIndivWithViewableRel);
+        // _id is the numeric datastore key (stripped of the "[OID]..." suffix).
+        // DataNucleus getObjectById(Class, Object) accepts the numeric string for increment-strategy tables.
+        // Note: getObjectById(Class, fullOIDString) would fail because it tries to parse the string
+        // as a Long — the "[OID]..." suffix is only valid for the no-class 1-arg getObjectById overload.
+        String id = j.getJSONArray("relationships").getJSONObject(0).getString("_id");
+        Shepherd s = new Shepherd("context0", props);
+        s.beginDBTransaction();
+        try {
+            org.ecocean.social.Relationship rel =
+                (org.ecocean.social.Relationship) s.getPM()
+                    .getObjectById(org.ecocean.social.Relationship.class, id);
+            assertNotNull(rel, "emitted _id must resolve the same Relationship the legacy "
+                + "edit/remove path resolves");
+        } finally { s.rollbackAndClose(); }
+    }
+
+    @Test void relationshipToNonViewablePartnerOmitted() throws Exception {
+        JSONObject j = invoke(focalOwner, focalIndivWithHiddenPartnerRel);
+        // only the viewable-partner relationship is present
+        org.json.JSONArray rels = j.getJSONArray("relationships");
+        for (int i = 0; i < rels.length(); i++) {
+            String pid = rels.getJSONObject(i).getJSONObject("partner").getString("individualID");
+            assertNotEquals(hiddenPartnerId, pid);
+        }
     }
 }

--- a/src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
+++ b/src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
@@ -18,6 +18,7 @@ import org.ecocean.Annotation;
 import org.ecocean.CommonConfiguration;
 import org.ecocean.Encounter;
 import org.ecocean.MarkedIndividual;
+import org.ecocean.Occurrence;
 import org.ecocean.Role;
 import org.ecocean.User;
 import org.ecocean.genetics.TissueSample;
@@ -59,6 +60,17 @@ class MarkedIndividualInfoTest {
     static String indivWithTissueAndAnnotId;
     // individual with mixed encounters: one private (owner-only) + one public
     static String mixedIndivId;
+
+    // occurringWith security test fields
+    // focalOwner is reused as the focal individual's owner (seededOwner)
+    // focalIndivIdInSharedOcc: focal owned by focalOwner; companion encounter owned by stranger
+    static String focalIndivIdInSharedOcc;
+    static String hiddenCompanionDisplayName;
+    // focalIndivIdWithViewableCompanion: focal + companion both viewable by focalOwner
+    static String focalIndivIdWithViewableCompanion;
+    static String viewableCompanionDisplayName;
+    // alias so test methods read naturally (same object as seededOwner)
+    static User focalOwner;
 
     @BeforeAll
     static void setUp() throws Exception {
@@ -138,6 +150,66 @@ class MarkedIndividualInfoTest {
             MarkedIndividual indivTA = new MarkedIndividual("TissueAnnotIndividual", encTA);
             sh.storeNewMarkedIndividual(indivTA);
             indivWithTissueAndAnnotId = indivTA.getId();
+
+            // focalOwner alias
+            focalOwner = seededOwner;
+
+            // --- occurringWith security test: hidden companion ---
+            // Focal encounter owned by seededOwner; companion encounter owned by stranger.
+            // seededOwner cannot view stranger's encounter (no collaboration).
+            Encounter focalEncHidden = new Encounter();
+            focalEncHidden.setSubmitterID(seededOwnerUsername);
+            sh.storeNewEncounter(focalEncHidden);
+
+            Encounter hiddenCompanionEnc = new Encounter();
+            hiddenCompanionEnc.setSubmitterID(strangerUsername);
+            sh.storeNewEncounter(hiddenCompanionEnc);
+
+            hiddenCompanionDisplayName = "HiddenCompanion";
+            MarkedIndividual hiddenCompanionIndiv = new MarkedIndividual(hiddenCompanionDisplayName,
+                hiddenCompanionEnc);
+            // set back-reference so coEnc.getIndividual() works when loaded from occurrence
+            hiddenCompanionEnc.setIndividual(hiddenCompanionIndiv);
+            sh.storeNewMarkedIndividual(hiddenCompanionIndiv);
+
+            MarkedIndividual focalIndivHidden = new MarkedIndividual("FocalForHiddenOcc",
+                focalEncHidden);
+            focalEncHidden.setIndividual(focalIndivHidden);
+            sh.storeNewMarkedIndividual(focalIndivHidden);
+            focalIndivIdInSharedOcc = focalIndivHidden.getId();
+
+            Occurrence occHidden = new Occurrence("occ-hidden-companion-001");
+            occHidden.addEncounterAndUpdateIt(focalEncHidden);
+            occHidden.addEncounterAndUpdateIt(hiddenCompanionEnc);
+            sh.storeNewOccurrence(occHidden);
+
+            // --- occurringWith viewable companion test ---
+            // Both focal and companion encounters owned by seededOwner (fully viewable).
+            Encounter focalEncViewable = new Encounter();
+            focalEncViewable.setSubmitterID(seededOwnerUsername);
+            sh.storeNewEncounter(focalEncViewable);
+
+            Encounter viewableCompanionEnc = new Encounter();
+            viewableCompanionEnc.setSubmitterID(seededOwnerUsername);
+            sh.storeNewEncounter(viewableCompanionEnc);
+
+            viewableCompanionDisplayName = "ViewableCompanion";
+            MarkedIndividual viewableCompanionIndiv = new MarkedIndividual(viewableCompanionDisplayName,
+                viewableCompanionEnc);
+            // set back-reference so coEnc.getIndividual() works when loaded from occurrence
+            viewableCompanionEnc.setIndividual(viewableCompanionIndiv);
+            sh.storeNewMarkedIndividual(viewableCompanionIndiv);
+
+            MarkedIndividual focalIndivViewable = new MarkedIndividual("FocalForViewableOcc",
+                focalEncViewable);
+            focalEncViewable.setIndividual(focalIndivViewable);
+            sh.storeNewMarkedIndividual(focalIndivViewable);
+            focalIndivIdWithViewableCompanion = focalIndivViewable.getId();
+
+            Occurrence occViewable = new Occurrence("occ-viewable-companion-001");
+            occViewable.addEncounterAndUpdateIt(focalEncViewable);
+            occViewable.addEncounterAndUpdateIt(viewableCompanionEnc);
+            sh.storeNewOccurrence(occViewable);
 
             sh.commitDBTransaction();
         } catch (Exception e) {
@@ -253,6 +325,14 @@ class MarkedIndividualInfoTest {
                         when(mock.doesUserHaveRole(anyString(), anyString(), anyString()))
                             .thenAnswer(inv -> backingShepherd.doesUserHaveRole(
                                 inv.getArgument(0), inv.getArgument(1), inv.getArgument(2)));
+
+                        // Delegate getOccurrence so occurringWith can load co-occurrences
+                        when(mock.getOccurrence(anyString()))
+                            .thenAnswer(inv -> backingShepherd.getOccurrence(
+                                (String) inv.getArgument(0)));
+                        when(mock.getOccurrence(any(Encounter.class)))
+                            .thenAnswer(inv -> backingShepherd.getOccurrence(
+                                (Encounter) inv.getArgument(0)));
                     })) {
 
                 new MarkedIndividualInfo().doGet(req, resp);
@@ -320,5 +400,23 @@ class MarkedIndividualInfoTest {
         JSONObject j = invoke(seededOwner, indivWithTissueAndAnnotId);
         String dt = j.getJSONArray("encounters").getJSONObject(0).getString("dataTypes");
         assertEquals("both", dt);
+    }
+
+    @Test
+    void occurringWithExcludesNonViewableCompanion() throws Exception {
+        JSONObject j = invoke(focalOwner, focalIndivIdInSharedOcc);
+        org.json.JSONArray encs = j.getJSONArray("encounters");
+        for (int i = 0; i < encs.length(); i++) {
+            String ow = encs.getJSONObject(i).optString("occurringWith", "");
+            assertFalse(ow.contains(hiddenCompanionDisplayName),
+                "non-viewable companion must not leak into occurringWith");
+        }
+    }
+
+    @Test
+    void occurringWithIncludesViewableCompanion() throws Exception {
+        JSONObject j = invoke(focalOwner, focalIndivIdWithViewableCompanion);
+        String ow = j.getJSONArray("encounters").getJSONObject(0).optString("occurringWith", "");
+        assertTrue(ow.contains(viewableCompanionDisplayName));
     }
 }

--- a/src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
+++ b/src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
@@ -13,11 +13,15 @@ import java.util.Properties;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import java.util.ArrayList;
+import org.ecocean.Annotation;
 import org.ecocean.CommonConfiguration;
 import org.ecocean.Encounter;
 import org.ecocean.MarkedIndividual;
 import org.ecocean.Role;
 import org.ecocean.User;
+import org.ecocean.genetics.TissueSample;
+import org.ecocean.media.Feature;
 import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
 import org.ecocean.shepherd.core.TestPMFUtil;
@@ -52,6 +56,9 @@ class MarkedIndividualInfoTest {
     static String seededOwnerUsername;
     static User stranger;
     static String strangerUsername;
+    static String indivWithTissueAndAnnotId;
+    // individual with mixed encounters: one private (owner-only) + one public
+    static String mixedIndivId;
 
     @BeforeAll
     static void setUp() throws Exception {
@@ -92,15 +99,45 @@ class MarkedIndividualInfoTest {
             Role strangerRole = new Role(strangerUsername, "researcher");
             sh.getPM().makePersistent(strangerRole);
 
-            // Create encounter owned by owner
+            // Create encounter owned by owner (private to owner)
             Encounter enc = new Encounter();
             enc.setSubmitterID(seededOwnerUsername);
             sh.storeNewEncounter(enc);
 
-            // Create individual with that encounter
+            // seededIndivId: private individual (only owner can view; stranger sees 403)
             MarkedIndividual indiv = new MarkedIndividual("TestIndividual", enc);
             sh.storeNewMarkedIndividual(indiv);
             seededIndivId = indiv.getId();
+
+            // mixedIndivId: one private encounter (owner) + one public encounter (null submitter).
+            // Owner sees 2 encounters; stranger can view the individual via the public encounter
+            // but still sees only 1 encounter (the public one).
+            Encounter encPrivate2 = new Encounter();
+            encPrivate2.setSubmitterID(seededOwnerUsername);
+            sh.storeNewEncounter(encPrivate2);
+            Encounter encPublic = new Encounter();
+            // submitterID intentionally left null so isUsernameAnonymous(null)==true
+            sh.storeNewEncounter(encPublic);
+            MarkedIndividual mixedIndiv = new MarkedIndividual("MixedIndividual", encPublic);
+            mixedIndiv.addEncounter(encPrivate2);
+            sh.storeNewMarkedIndividual(mixedIndiv);
+            mixedIndivId = mixedIndiv.getId();
+
+            // Create an individual whose single encounter has both a TissueSample and an Annotation.
+            Encounter encTA = new Encounter();
+            encTA.setSubmitterID(seededOwnerUsername);
+            TissueSample ts = new TissueSample(null, "sample-001");
+            encTA.addTissueSample(ts);
+            sh.getPM().makePersistent(ts);
+            // Use empty feature list to avoid FeatureType.initAll() requirement
+            Annotation ann = new Annotation("test-species", new ArrayList<Feature>());
+            sh.storeNewAnnotation(ann);
+            encTA.addAnnotation(ann);
+            sh.storeNewEncounter(encTA);
+
+            MarkedIndividual indivTA = new MarkedIndividual("TissueAnnotIndividual", encTA);
+            sh.storeNewMarkedIndividual(indivTA);
+            indivWithTissueAndAnnotId = indivTA.getId();
 
             sh.commitDBTransaction();
         } catch (Exception e) {
@@ -266,5 +303,22 @@ class MarkedIndividualInfoTest {
             "Owner must get 200; got: " + j);
         assertTrue(j.has("encounters"), "Response must have 'encounters' array");
         assertTrue(j.has("relationships"), "Response must have 'relationships' array");
+    }
+
+    @Test
+    void onlyViewableEncountersReturned() throws Exception {
+        // mixedIndiv has one private (owner-only) + one public encounter.
+        // Owner sees both; stranger (no collab) sees only the public one.
+        JSONObject asOwner = invoke(seededOwner, mixedIndivId);
+        JSONObject asStranger = invoke(stranger, mixedIndivId);
+        assertTrue(asOwner.getJSONArray("encounters").length()
+                   > asStranger.getJSONArray("encounters").length());
+    }
+
+    @Test
+    void dataTypesBothWhenTissueAndAnnotation() throws Exception {
+        JSONObject j = invoke(seededOwner, indivWithTissueAndAnnotId);
+        String dt = j.getJSONArray("encounters").getJSONObject(0).getString("dataTypes");
+        assertEquals("both", dt);
     }
 }

--- a/src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
+++ b/src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
@@ -77,6 +77,13 @@ class MarkedIndividualInfoTest {
     static String focalIndivWithHiddenPartnerRel;
     static String hiddenPartnerId;
 
+    // large-individual memoization test fields
+    // focal with 3 own encounters in a large occurrence (4 co-occurring encounters by stranger)
+    // + a relationship to a partner with 3 encounters (all owned by focalOwner → all viewable)
+    static String largeFocalIndivId;
+    static int largeFocalExpectedEncCount;  // encounters owner can view
+    static int largeFocalExpectedRelCount;  // relationships with viewable partner
+
     @BeforeAll
     static void setUp() throws Exception {
         Properties cc = new Properties();
@@ -253,6 +260,74 @@ class MarkedIndividualInfoTest {
             org.ecocean.social.Relationship hiddenRel = new org.ecocean.social.Relationship(
                 "associate", hiddenRelFocal, hiddenPartner);
             sh.getPM().makePersistent(hiddenRel);
+
+            // --- large-individual memoization test ---
+            // Focal individual has 3 encounters (all owned by seededOwner, all viewable).
+            // They all appear in one large occurrence that also contains 4 companion encounters:
+            //   2 owned by seededOwner (viewable → appear in occurringWith)
+            //   2 owned by stranger    (not viewable → suppressed by encCanView memoization)
+            // The focal also has one relationship to a partner with 3 encounters (all owner-owned).
+            // This exercises the encCanView + occCache + partnerCanView memoized paths.
+
+            // Focal encounters (all viewable by owner)
+            Encounter lfe1 = new Encounter(); lfe1.setSubmitterID(seededOwnerUsername); sh.storeNewEncounter(lfe1);
+            Encounter lfe2 = new Encounter(); lfe2.setSubmitterID(seededOwnerUsername); sh.storeNewEncounter(lfe2);
+            Encounter lfe3 = new Encounter(); lfe3.setSubmitterID(seededOwnerUsername); sh.storeNewEncounter(lfe3);
+
+            MarkedIndividual largeFocal = new MarkedIndividual("LargeFocal", lfe1);
+            largeFocal.addEncounter(lfe2);
+            largeFocal.addEncounter(lfe3);
+            lfe1.setIndividual(largeFocal);
+            lfe2.setIndividual(largeFocal);
+            lfe3.setIndividual(largeFocal);
+            sh.storeNewMarkedIndividual(largeFocal);
+            largeFocalIndivId = largeFocal.getId();
+            largeFocalExpectedEncCount = 3; // owner sees all 3 focal encounters
+
+            // 2 viewable companion encounters (owned by seededOwner)
+            Encounter lce1 = new Encounter(); lce1.setSubmitterID(seededOwnerUsername); sh.storeNewEncounter(lce1);
+            Encounter lce2 = new Encounter(); lce2.setSubmitterID(seededOwnerUsername); sh.storeNewEncounter(lce2);
+            MarkedIndividual largeCompanionA = new MarkedIndividual("LargeCompanionA", lce1);
+            lce1.setIndividual(largeCompanionA);
+            sh.storeNewMarkedIndividual(largeCompanionA);
+            MarkedIndividual largeCompanionB = new MarkedIndividual("LargeCompanionB", lce2);
+            lce2.setIndividual(largeCompanionB);
+            sh.storeNewMarkedIndividual(largeCompanionB);
+
+            // 2 hidden companion encounters (owned by stranger — not viewable by owner)
+            Encounter lch1 = new Encounter(); lch1.setSubmitterID(strangerUsername); sh.storeNewEncounter(lch1);
+            Encounter lch2 = new Encounter(); lch2.setSubmitterID(strangerUsername); sh.storeNewEncounter(lch2);
+            MarkedIndividual largeHiddenC = new MarkedIndividual("LargeHiddenC", lch1);
+            lch1.setIndividual(largeHiddenC);
+            sh.storeNewMarkedIndividual(largeHiddenC);
+            MarkedIndividual largeHiddenD = new MarkedIndividual("LargeHiddenD", lch2);
+            lch2.setIndividual(largeHiddenD);
+            sh.storeNewMarkedIndividual(largeHiddenD);
+
+            // Large occurrence: focal encounters + all 4 companions (3+4=7 total)
+            Occurrence largeOcc = new Occurrence("occ-large-memoization-001");
+            largeOcc.addEncounterAndUpdateIt(lfe1);
+            largeOcc.addEncounterAndUpdateIt(lfe2);
+            largeOcc.addEncounterAndUpdateIt(lfe3);
+            largeOcc.addEncounterAndUpdateIt(lce1);
+            largeOcc.addEncounterAndUpdateIt(lce2);
+            largeOcc.addEncounterAndUpdateIt(lch1);
+            largeOcc.addEncounterAndUpdateIt(lch2);
+            sh.storeNewOccurrence(largeOcc);
+
+            // Relationship partner with 3 encounters (all owner-owned → viewable)
+            Encounter lpe1 = new Encounter(); lpe1.setSubmitterID(seededOwnerUsername); sh.storeNewEncounter(lpe1);
+            Encounter lpe2 = new Encounter(); lpe2.setSubmitterID(seededOwnerUsername); sh.storeNewEncounter(lpe2);
+            Encounter lpe3 = new Encounter(); lpe3.setSubmitterID(seededOwnerUsername); sh.storeNewEncounter(lpe3);
+            MarkedIndividual largePartner = new MarkedIndividual("LargePartner", lpe1);
+            largePartner.addEncounter(lpe2);
+            largePartner.addEncounter(lpe3);
+            sh.storeNewMarkedIndividual(largePartner);
+            largeFocalExpectedRelCount = 1;
+
+            org.ecocean.social.Relationship largeRel = new org.ecocean.social.Relationship(
+                "associate", largeFocal, largePartner);
+            sh.getPM().makePersistent(largeRel);
 
             sh.commitDBTransaction();
         } catch (Exception e) {
@@ -493,5 +568,48 @@ class MarkedIndividualInfoTest {
             String pid = rels.getJSONObject(i).getJSONObject("partner").getString("individualID");
             assertNotEquals(hiddenPartnerId, pid);
         }
+    }
+
+    /**
+     * Large-individual memoization test.
+     *
+     * Focal has 3 owner-viewable encounters in a 7-encounter occurrence (4 companions:
+     * 2 viewable + 2 hidden).  A relationship to a partner with 3 encounters exercises
+     * partnerCanView memoization.  The test asserts:
+     *   1. HTTP 200.
+     *   2. Exactly {@code largeFocalExpectedEncCount} (3) encounters returned.
+     *   3. occurringWith on every returned encounter includes the 2 viewable companions
+     *      but NOT the 2 hidden ones (hidden names start with "LargeHidden").
+     *   4. Exactly {@code largeFocalExpectedRelCount} (1) relationship returned.
+     *   5. The relationship partner is "LargePartner".
+     */
+    @Test void largeIndividualAssemblesCorrectly() throws Exception {
+        JSONObject j = invoke(focalOwner, largeFocalIndivId);
+        assertEquals(200, j.optInt("statusCode"),
+            "Owner must get 200 for large focal; got: " + j);
+
+        org.json.JSONArray encs = j.getJSONArray("encounters");
+        assertEquals(largeFocalExpectedEncCount, encs.length(),
+            "Owner must see exactly all 3 focal encounters");
+
+        // Every returned encounter must include the 2 viewable companions and exclude hidden ones
+        for (int i = 0; i < encs.length(); i++) {
+            String ow = encs.getJSONObject(i).optString("occurringWith", "");
+            assertTrue(ow.contains("LargeCompanionA"),
+                "occurringWith must include viewable companion A; enc[" + i + "].occurringWith=" + ow);
+            assertTrue(ow.contains("LargeCompanionB"),
+                "occurringWith must include viewable companion B; enc[" + i + "].occurringWith=" + ow);
+            assertFalse(ow.contains("LargeHiddenC"),
+                "occurringWith must NOT include hidden companion C; enc[" + i + "].occurringWith=" + ow);
+            assertFalse(ow.contains("LargeHiddenD"),
+                "occurringWith must NOT include hidden companion D; enc[" + i + "].occurringWith=" + ow);
+        }
+
+        org.json.JSONArray rels = j.getJSONArray("relationships");
+        assertEquals(largeFocalExpectedRelCount, rels.length(),
+            "Owner must see exactly 1 relationship");
+        String partnerDisplayName = rels.getJSONObject(0).getJSONObject("partner").optString("displayName", "");
+        assertEquals("LargePartner", partnerDisplayName,
+            "Relationship partner must be LargePartner");
     }
 }

--- a/src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
+++ b/src/test/java/org/ecocean/api/MarkedIndividualInfoTest.java
@@ -1,0 +1,270 @@
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.security.Principal;
+import java.util.Properties;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.CommonConfiguration;
+import org.ecocean.Encounter;
+import org.ecocean.MarkedIndividual;
+import org.ecocean.Role;
+import org.ecocean.User;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.shepherd.core.TestPMFUtil;
+import org.json.JSONObject;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedConstruction;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Status-code tests for GET /api/v3/individuals/info/social-data.
+ *
+ * Uses Testcontainers for real Postgres + real ACL evaluation; Shepherd is
+ * intercepted via MockedConstruction so that direct doGet() works without
+ * a live Wildbook deployment, while all ACL-path methods delegate to a real
+ * Shepherd backed by the test container.
+ */
+@Testcontainers
+class MarkedIndividualInfoTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+        new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("wildbook_test")
+            .withUsername("wildbook")
+            .withPassword("wildbook");
+
+    static Properties props;
+    static String seededIndivId;
+    static User seededOwner;
+    static String seededOwnerUsername;
+    static User stranger;
+    static String strangerUsername;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        Properties cc = new Properties();
+        cc.setProperty("collaborationSecurityEnabled", "true");
+        CommonConfiguration.initialize("context0", cc);
+
+        props = new Properties();
+        props.setProperty("datanucleus.ConnectionUserName", postgres.getUsername());
+        props.setProperty("datanucleus.ConnectionPassword", postgres.getPassword());
+        props.setProperty("datanucleus.ConnectionDriverName", postgres.getDriverClassName());
+        props.setProperty("datanucleus.ConnectionURL", postgres.getJdbcUrl());
+        props.setProperty("datanucleus.schema.autoCreateTables", "true");
+        TestPMFUtil.closePMF("context0");
+
+        // Seed data: owner user, an encounter they own, and an individual.
+        // Also seed a stranger user with no access.
+        Shepherd sh = new Shepherd("context0", props);
+        try {
+            sh.beginDBTransaction();
+
+            // Create owner user
+            seededOwnerUsername = "owner_user";
+            String salt = ServletUtilities.getSalt().toHex();
+            String hashed = ServletUtilities.hashAndSaltPassword("password", salt);
+            seededOwner = new User(seededOwnerUsername, hashed, salt);
+            sh.getPM().makePersistent(seededOwner);
+            // Assign researcher role
+            Role ownerRole = new Role(seededOwnerUsername, "researcher");
+            sh.getPM().makePersistent(ownerRole);
+
+            // Create stranger user (no collaboration with owner)
+            strangerUsername = "stranger_user";
+            String salt2 = ServletUtilities.getSalt().toHex();
+            String hashed2 = ServletUtilities.hashAndSaltPassword("password", salt2);
+            stranger = new User(strangerUsername, hashed2, salt2);
+            sh.getPM().makePersistent(stranger);
+            Role strangerRole = new Role(strangerUsername, "researcher");
+            sh.getPM().makePersistent(strangerRole);
+
+            // Create encounter owned by owner
+            Encounter enc = new Encounter();
+            enc.setSubmitterID(seededOwnerUsername);
+            sh.storeNewEncounter(enc);
+
+            // Create individual with that encounter
+            MarkedIndividual indiv = new MarkedIndividual("TestIndividual", enc);
+            sh.storeNewMarkedIndividual(indiv);
+            seededIndivId = indiv.getId();
+
+            sh.commitDBTransaction();
+        } catch (Exception e) {
+            sh.rollbackDBTransaction();
+            throw e;
+        } finally {
+            sh.closeDBTransaction();
+        }
+    }
+
+    @AfterAll
+    static void tearDown() {
+        TestPMFUtil.closePMF("context0");
+    }
+
+    /**
+     * Invokes doGet with a mocked request/response pair. The Shepherd
+     * constructed inside doGet is intercepted via MockedConstruction so that
+     * direct doGet() works without a live Wildbook deployment. ACL-relevant
+     * methods are pre-fetched from a real Shepherd backed by the test container
+     * BEFORE entering MockedConstruction (to avoid recursive interception of
+     * inner {@code new Shepherd(...)} calls), then returned as pre-loaded values.
+     * This drives real ACL evaluation on real domain objects (canUserView runs
+     * against the real MarkedIndividual + Encounter data).
+     *
+     * @param authUser the User that should appear authenticated (null = anonymous)
+     * @param idParam  the ?id= query parameter value
+     */
+    static JSONObject invoke(User authUser, String idParam) throws Exception {
+        // Determine the username from the authUser object. We use seededOwnerUsername /
+        // strangerUsername (stored before JDO PM close) when possible to avoid JDO
+        // detached-field access issues on the closed-PM User objects.
+        final String lookupUsername;
+        if (authUser == null) {
+            lookupUsername = null;
+        } else if (authUser == seededOwner) {
+            lookupUsername = seededOwnerUsername;
+        } else if (authUser == stranger) {
+            lookupUsername = strangerUsername;
+        } else {
+            lookupUsername = authUser.getUsername();
+        }
+
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        when(req.getRequestURI()).thenReturn("/api/v3/individuals/info/social-data");
+        when(req.getParameter("id")).thenReturn(idParam);
+        // getContext() falls back to "context0" when servletContext is null
+        when(req.getServletContext()).thenReturn(null);
+        when(req.getContextPath()).thenReturn("");
+        when(req.getCookies()).thenReturn(null);
+        when(req.getServerName()).thenReturn("localhost");
+        when(req.getParameter("context")).thenReturn(null);
+
+        // Wire getUserPrincipal so that Shepherd.getUsername(request) resolves correctly.
+        // We use the pre-resolved lookupUsername to avoid JDO detachment issues.
+        if (authUser != null && lookupUsername != null) {
+            Principal principal = mock(Principal.class);
+            when(principal.toString()).thenReturn(lookupUsername);
+            when(req.getUserPrincipal()).thenReturn(principal);
+        } else {
+            when(req.getUserPrincipal()).thenReturn(null);
+        }
+
+        // Open a real Shepherd BEFORE MockedConstruction and keep it open for the duration
+        // of doGet() so that JDO-managed objects (MarkedIndividual.encounters, Encounter fields)
+        // are still accessible when canUserView() traverses them.
+        // We must NOT call new Shepherd() inside the MockedConstruction configurator lambda
+        // because MockedConstruction intercepts ALL new Shepherd() calls in the JVM.
+        final Shepherd backingShepherd = new Shepherd("context0", props);
+        backingShepherd.beginDBTransaction();
+        try {
+            final User resolvedUser = (lookupUsername == null) ? null
+                : backingShepherd.getUser(lookupUsername);
+            final java.util.List<Role> resolvedRoles =
+                (resolvedUser == null) ? java.util.Collections.emptyList()
+                : backingShepherd.getAllRolesForUserInContext(lookupUsername, "context0");
+
+            // Intercept new Shepherd("context0") so doGet can run without the real app DB.
+            // All ACL-relevant methods delegate to the open backingShepherd.
+            try (MockedConstruction<Shepherd> mockShepherd = mockConstruction(Shepherd.class,
+                    (mock, ctx) -> {
+                        // no-op lifecycle (backingShepherd manages the real transaction)
+                        doNothing().when(mock).setAction(anyString());
+                        doNothing().when(mock).beginDBTransaction();
+                        doNothing().when(mock).rollbackDBTransaction();
+                        doNothing().when(mock).closeDBTransaction();
+                        when(mock.getContext()).thenReturn("context0");
+
+                        // Return user from the open backing shepherd
+                        when(mock.getUser(any(HttpServletRequest.class))).thenReturn(resolvedUser);
+
+                        // Delegate individual lookup to the open backing shepherd
+                        // (JDO objects are live because backingShepherd's PM is still open)
+                        when(mock.getMarkedIndividual(anyString())).thenAnswer(inv -> {
+                            String id = (String) inv.getArgument(0);
+                            if (id == null) return null;
+                            return backingShepherd.getMarkedIndividual(id.trim());
+                        });
+
+                        // Return pre-fetched roles (drives user.isAdmin(shepherd))
+                        when(mock.getAllRolesForUserInContext(anyString(), anyString()))
+                            .thenReturn(resolvedRoles);
+
+                        // Expose the backing PM so Collaboration.collaborationBetweenUsers()
+                        // (called via Encounter.canUserAccess -> canCollaborate) can run
+                        // its JDO queries without a null PM.
+                        when(mock.getPM()).thenReturn(backingShepherd.getPM());
+
+                        // Delegate doesUserHaveRole (used inside collaborationBetweenUsers)
+                        when(mock.doesUserHaveRole(anyString(), anyString(), anyString()))
+                            .thenAnswer(inv -> backingShepherd.doesUserHaveRole(
+                                inv.getArgument(0), inv.getArgument(1), inv.getArgument(2)));
+                    })) {
+
+                new MarkedIndividualInfo().doGet(req, resp);
+            }
+        } finally {
+            backingShepherd.rollbackDBTransaction();
+            backingShepherd.closeDBTransaction();
+        }
+
+        String body = out.toString();
+        assertFalse(body.isEmpty(), "Response body must not be empty");
+        return new JSONObject(body);
+    }
+
+    @Test
+    void anonymousIs401() throws Exception {
+        JSONObject j = invoke(null, "any-id");
+        assertEquals(401, j.optInt("statusCode", -1),
+            "Anonymous request must return 401; got: " + j);
+    }
+
+    @Test
+    void blankIdIs400() throws Exception {
+        JSONObject j = invoke(seededOwner, "");
+        assertEquals(400, j.optInt("statusCode", -1),
+            "Blank id must return 400; got: " + j);
+    }
+
+    @Test
+    void unknownIdIs404() throws Exception {
+        JSONObject j = invoke(seededOwner, "00000000-0000-0000-0000-000000000000");
+        assertEquals(404, j.optInt("statusCode", -1),
+            "Unknown id must return 404; got: " + j);
+    }
+
+    @Test
+    void notViewableIs403() throws Exception {
+        // stranger has no collaboration with owner, so cannot view the seeded individual
+        JSONObject j = invoke(stranger, seededIndivId);
+        assertEquals(403, j.optInt("statusCode", -1),
+            "Non-viewable individual must return 403; got: " + j);
+    }
+
+    @Test
+    void viewableReturns200WithArrays() throws Exception {
+        JSONObject j = invoke(seededOwner, seededIndivId);
+        assertEquals(200, j.optInt("statusCode", -1),
+            "Owner must get 200; got: " + j);
+        assertTrue(j.has("encounters"), "Response must have 'encounters' array");
+        assertTrue(j.has("relationships"), "Response must have 'relationships' array");
+    }
+}


### PR DESCRIPTION
## Summary

Migrates the legacy `individuals.jsp` **Social Diagram** read paths onto a single new, access-controlled `/api/v3` endpoint, and rewrites the diagram's JavaScript to use it. The Social Diagram previously fetched its encounter table, relationship table, and per-partner details through the generic DataNucleus REST servlet (`/api/jdoql`, `/api/{class}/{id}`), which is unsuitable for entities with bidirectional relationships and does not apply Wildbook's collaboration/role access control. Loading the diagram for an individual could fail outright and could surface data without the usual view checks.

**Scope: reads only.** Relationship writes (add/edit/remove) and the bubble-graph data feed intentionally remain on the existing path and are untouched.

## New endpoint

`GET /api/v3/individuals/info/social-data?id={individualId}` — a new branch in `org.ecocean.api.MarkedIndividualInfo`. No `web.xml` change, no OpenSearch serializer change.

Access control enforced server-side:
- anonymous → `401`; individual not viewable by the caller → `403`.
- **encounter rows** are included only for encounters the caller may view (`Encounter.canUserView`).
- **"occurring with"** companions are filtered per **each companion's own** encounter visibility (not occurrence-level), so a co-occurring individual the caller can't see is never named.
- **relationship rows** are included only when the caller may view the partner individual; the partner block is resolved server-side.

Response carries everything the two tables need in one round-trip (no per-partner fan-out). The relationship `_id` is the same datastore-identity value the prior API emitted, so the retained (legacy) edit/remove buttons keep resolving the correct row.

## JavaScript

`encounter-calls.js`: `getEncounterTableData` and `getRelationshipTableData` now read the single new endpoint; the per-partner lookup helper is removed. Render logic and the edit/remove buttons are unchanged. (The file is CRLF in the repo and stays CRLF — the diff is the logical change only.)

## Tests

`MarkedIndividualInfoTest` (JUnit 5 + Testcontainers, real ACL): per-encounter visibility filtering, the individual-level gate, co-occurrence companion filtering, relationship partner filtering, the relationship `_id` round-trip, `dataTypes` precedence, status codes, and a large-individual case exercising the memoized assembly paths. 12/12 green; module compiles.

## Stacking / sequencing

This branch is **stacked on `fix/api-v3-individuals-get` (PR #1633)** — it relies on `MarkedIndividual.canUserView` introduced there — and is opened with that branch as its base so the diff is feature-only. **Merge after #1633**, or retarget to `main` once #1633 lands.

## Follow-ups (not in this PR)

- The relationship row could carry explicit `selfRole`/`partnerRole` to remove a client-side identifier comparison (robustness; current behavior preserved from the prior implementation).
- Securing the bubble-graph companion feed and migrating the relationship write flow are separate efforts.

Design + plan: `docs/superpowers/specs/2026-06-24-social-diagram-api-v3-reads-design.md`, `docs/superpowers/plans/2026-06-24-social-diagram-api-v3-reads.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
