### PR TITLE
feat(header): add API Access link to JSP profile dropdown

### DIFF
--- a/src/main/webapp/header.jsp
+++ b/src/main/webapp/header.jsp
@@ -789,6 +789,7 @@ if(request.getUserPrincipal()!=null){
                                   <ul class="dropdown-menu">
                                       <li><a href="<%=urlLoc %>/react/">Landing Page</a></li>
                                       <li><a href="<%=urlLoc %>/myAccount.jsp">User Profile</a></li>
+                                      <li><a href="<%=urlLoc %>/react/api-access">API Access</a></li>
                                       <li><a href="#" onclick="logoutAndRedirect()">Logout</a></li>
                                   </ul>   
                                 </div>              


### PR DESCRIPTION
## Summary

The React header's avatar/profile dropdown (`AvatarAndUserProfile.jsx`) exposes an **API Access** link that routes to the `/api-access` React page (where users mint API tokens). The JSP header (`header.jsp`) profile dropdown was missing this option. This PR adds the equivalent link so both headers offer the same menu item.

## Change

A single `<li>` added to the JSP profile dropdown, between **User Profile** and **Logout**, matching the React item's ordering:

```jsp
<li><a href="<%=urlLoc %>/react/api-access">API Access</a></li>
```

`<%=urlLoc %>/react/api-access` resolves to the React `/api-access` route (the React app is mounted under `/react/`), consistent with the sibling `<%=urlLoc %>/react/` link in the same dropdown.

## Security parity

The item lives inside the existing `if(user != null && !loggingOut)` block, so it is shown **only to logged-in users with no role gate** — exactly matching the React item, which renders only inside the authenticated avatar dropdown and applies no role restriction. Token issuance itself remains protected by the step-up password auth enforced at `/api/v3/auth/token`. No over- or under-restriction relative to React.

## Notes

- Label is hardcoded `API Access`, matching both the React item (also un-internationalized) and the sibling JSP items in this dropdown (`Landing Page`, `User Profile`, `Logout` are all hardcoded English).
- Line endings normalized to LF.
- Reviewed by Codex: converged, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)