### PR TITLE
refactor(api-access): read JWT keys from a dedicated apiAccessKeys.properties

### DIFF
--- a/docs/superpowers/runbooks/jwt-keypair-setup.md
+++ b/docs/superpowers/runbooks/jwt-keypair-setup.md
@@ -20,14 +20,24 @@ openssl pkcs8 -topk8 -nocrypt -in jwt_private.pem -outform DER | base64 -w0
 openssl rsa -in jwt_private.pem -pubout -outform DER | base64 -w0
 ```
 
-Copy the output of steps 2 and 3 into `commonConfiguration.properties` (see below).
+Copy the output of steps 2 and 3 into `apiAccessKeys.properties` (see below).
 **Immediately restrict the PEM file permissions** (`chmod 600 jwt_private.pem`).
 
 ---
 
-## 2. `commonConfiguration.properties` Keys
+## 2. `apiAccessKeys.properties` Keys
 
-Add these to the Docker-mounted `commonConfiguration.properties` (never to the git-tracked one):
+JWT keys live in their own file, `apiAccessKeys.properties` — a peer of
+`commonConfiguration.properties` — so the signing key stays private and out of git.
+Place a copy with real values in the data-dir override location (NOT the in-git template):
+
+```
+webapps/<dataDir>/WEB-INF/classes/bundles/apiAccessKeys.properties
+```
+
+where `<dataDir>` defaults to `wildbook_data_dir` (overridable per context via
+`<context>DataDir`). Only the keys you set here are needed; the in-git template ships
+with every key unset (token service disabled). Add:
 
 ```properties
 # Required — Base64(PKCS8 DER) of the RSA-2048 private key (Wildbook signs tokens)
@@ -53,7 +63,8 @@ jwtTtlSeconds=1800
 # jwtContext=context0
 ```
 
-All keys are read via `CommonConfiguration.getProperty(key, context)`.
+All keys are read via `CommonConfiguration.getApiAccessProperty(key, context)`, which reads
+only `apiAccessKeys.properties` — never `commonConfiguration.properties`.
 
 ---
 
@@ -80,7 +91,7 @@ All keys are read via `CommonConfiguration.getProperty(key, context)`.
    the old (`v1`) and new (`v2`) public keys, selected by the `kid` JWT header claim.
    The kernel must keep the old public key for **at least one full TTL** after the new key
    is deployed so that in-flight tokens minted with the old key continue to verify.
-3. **Update Wildbook** `commonConfiguration.properties`: set `jwtPrivateKeyBase64` to the
+3. **Update Wildbook** `apiAccessKeys.properties`: set `jwtPrivateKeyBase64` to the
    new private key and set `jwtKeyId=v2`. Reload/restart Wildbook.
 4. After the old TTL window has elapsed (all tokens signed with `v1` have expired), remove
    the old public key from the kernel configuration.
@@ -90,7 +101,7 @@ All keys are read via `CommonConfiguration.getProperty(key, context)`.
 ## 5. Secret Hygiene
 
 - **NEVER commit** the private key (PEM or Base64) to git. It belongs only in the
-  Docker-mounted `commonConfiguration.properties`, which is excluded from version control.
+  data-dir override `apiAccessKeys.properties`, which is excluded from version control.
 - **chmod 600** any `.pem` or key file on disk immediately after creation.
 - **Never log** the `jwtPrivateKeyBase64` value, the raw PEM, or any minted token string.
   Wildbook's logging does not emit these, but verify any custom log lines before adding them.

--- a/src/main/java/org/ecocean/CommonConfiguration.java
+++ b/src/main/java/org/ecocean/CommonConfiguration.java
@@ -24,6 +24,9 @@ import javax.servlet.http.HttpServletRequest;
 public class CommonConfiguration {
     private static final String COMMON_CONFIGURATION_PROPERTIES = "commonConfiguration.properties";
     private static final String GOOGLE_CONFIGURATION_PROPERTIES = "googleKeys.properties";
+    // API-access (JWT) settings live in their own file so the signing key can be held privately
+    // in the data-dir override and kept out of git. See getApiAccessProperty().
+    private static final String API_ACCESS_KEYS_PROPERTIES = "apiAccessKeys.properties";
 
     // class setup
     // private static Properties props = new Properties();
@@ -33,6 +36,8 @@ public class CommonConfiguration {
     // private static String currentContext;
 
     private static Map<String, Properties> contextToPropsCache = new HashMap<String, Properties>();
+    // Only ever populated by initializeApiAccess() (a test seam). Production reads the file fresh.
+    private static Map<String, Properties> apiAccessPropsCache = new HashMap<String, Properties>();
 
     public static void initialize(String context, Properties overrideProps) {
         contextToPropsCache.put(context, overrideProps);
@@ -592,6 +597,29 @@ public class CommonConfiguration {
     public static String getGoogleAnalyticsId(String context) {
         return ShepherdProperties.getProperties(GOOGLE_CONFIGURATION_PROPERTIES, "",
                 context).getProperty("ga_id", context);
+    }
+
+    /**
+     * Reads an API-access (JWT) setting from apiAccessKeys.properties -- a peer of
+     * commonConfiguration.properties -- so the signing key can be kept private in the data-dir
+     * override and out of git. NOT read from commonConfiguration.properties. Returns null when
+     * the key is unset (callers treat null as "not configured").
+     */
+    public static String getApiAccessProperty(String name, String context) {
+        Properties seeded = apiAccessPropsCache.get(context);
+        if (seeded != null) return seeded.getProperty(name);
+        return ShepherdProperties.getProperties(API_ACCESS_KEYS_PROPERTIES, "", context)
+                .getProperty(name);
+    }
+
+    /** Test seam: seed in-memory API-access props for a context (mirrors initialize(String, Properties)). */
+    public static void initializeApiAccess(String context, Properties overrideProps) {
+        apiAccessPropsCache.put(context, overrideProps);
+    }
+
+    /** Test cleanup: clear seeded API-access props to avoid cross-test contamination. */
+    public static void clearApiAccessCache() {
+        apiAccessPropsCache.clear();
     }
 
     public static String getDefaultGoogleMapsCenter(String context) {

--- a/src/main/java/org/ecocean/api/AuthToken.java
+++ b/src/main/java/org/ecocean/api/AuthToken.java
@@ -56,7 +56,7 @@ public class AuthToken extends ApiBase {
                 writeError(response, 401, "invalid credentials");
                 return;
             }
-            String tokenContext = org.ecocean.CommonConfiguration.getProperty("jwtContext", context);
+            String tokenContext = org.ecocean.CommonConfiguration.getApiAccessProperty("jwtContext", context);
             if (!Util.stringExists(tokenContext)) tokenContext = "context0";
             JwtService jwt = JwtService.fromConfig(tokenContext);
             if (!jwt.isEnabled()) {
@@ -97,7 +97,7 @@ public class AuthToken extends ApiBase {
     }
 
     private long ttlFromConfig(String context) {
-        String v = org.ecocean.CommonConfiguration.getProperty("jwtTtlSeconds", context);
+        String v = org.ecocean.CommonConfiguration.getApiAccessProperty("jwtTtlSeconds", context);
         if (Util.stringExists(v)) {
             try {
                 long secs = Long.parseLong(v.trim());

--- a/src/main/java/org/ecocean/api/auth/JwtService.java
+++ b/src/main/java/org/ecocean/api/auth/JwtService.java
@@ -23,7 +23,8 @@ import org.ecocean.Util;
  * the external scoped-access kernel holds the public key.
  *
  * Keys are RSA, supplied as Base64 of the encoded key bytes (private = PKCS8,
- * public = X.509), via commonConfiguration.properties:
+ * public = X.509), via apiAccessKeys.properties (a peer of commonConfiguration.properties,
+ * kept private in the data-dir override and out of git):
  *   jwtPrivateKeyBase64=...   (signing; required to mint tokens)
  *   jwtPublicKeyBase64=...    (verify; optional Wildbook-side)
  *   jwtIssuer=wildbook
@@ -75,12 +76,12 @@ public class JwtService {
 
     public static JwtService fromConfig(String context) {
         return fromBase64Keys(
-            CommonConfiguration.getProperty("jwtPrivateKeyBase64", context),
-            CommonConfiguration.getProperty("jwtPublicKeyBase64", context),
-            orDefault(CommonConfiguration.getProperty("jwtIssuer", context), "wildbook"),
-            orDefault(CommonConfiguration.getProperty("jwtAudience", context),
+            CommonConfiguration.getApiAccessProperty("jwtPrivateKeyBase64", context),
+            CommonConfiguration.getApiAccessProperty("jwtPublicKeyBase64", context),
+            orDefault(CommonConfiguration.getApiAccessProperty("jwtIssuer", context), "wildbook"),
+            orDefault(CommonConfiguration.getApiAccessProperty("jwtAudience", context),
                 "wildbook-scoped-api"),
-            CommonConfiguration.getProperty("jwtKeyId", context)); // may be null
+            CommonConfiguration.getApiAccessProperty("jwtKeyId", context)); // may be null
     }
 
     private static String orDefault(String v, String d) {

--- a/src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java
+++ b/src/main/java/org/ecocean/security/WildbookTokenAuthenticationFilter.java
@@ -135,7 +135,7 @@ public class WildbookTokenAuthenticationFilter extends OncePerRequestFilter {
     // ----- protected seams (overridden in unit tests) -----
 
     protected String expectedContext() {
-        String c = CommonConfiguration.getProperty("jwtContext", "context0");
+        String c = CommonConfiguration.getApiAccessProperty("jwtContext", "context0");
         return Util.stringExists(c) ? c : "context0";
     }
 

--- a/src/main/resources/bundles/apiAccessKeys.properties
+++ b/src/main/resources/bundles/apiAccessKeys.properties
@@ -1,0 +1,30 @@
+# API Access (JWT) keys for the /api/v3/auth/token endpoint and token-scoped API access.
+#
+# These are security-sensitive and are kept in this dedicated file -- a peer of
+# commonConfiguration.properties -- so the signing key can be held PRIVATELY and out of git.
+# Place a copy of this file, with real values, in the data-dir override location, e.g.:
+#   <data dir>/wildbook_data_dir/WEB-INF/classes/bundles/apiAccessKeys.properties
+# Only the keys you set there are needed; anything unset falls back to this (in-git) template.
+#
+# With every key left unset (as shipped), the token service is DISABLED: POST /api/v3/auth/token
+# returns 503 "token issuance not configured" and no token-scoped access is granted.
+
+# Base64 (PKCS8) RSA private key used to SIGN tokens. REQUIRED to mint tokens.
+# If unset, the token service is disabled. Keep this PRIVATE -- never commit a real value.
+#jwtPrivateKeyBase64 =
+
+# Base64 (X.509) RSA public key used to VERIFY tokens Wildbook-side. Optional.
+#jwtPublicKeyBase64 =
+
+# JWT issuer / audience claims. Defaults (when unset): wildbook / wildbook-scoped-api.
+#jwtIssuer = wildbook
+#jwtAudience = wildbook-scoped-api
+
+# Optional JWT 'kid' header, for key rotation.
+#jwtKeyId =
+
+# Context whose keys are used to mint/verify tokens. Defaults to context0 when unset.
+#jwtContext = context0
+
+# Token lifetime in seconds (clamped to 60 .. 86400). Defaults to 1800 when unset.
+#jwtTtlSeconds = 1800

--- a/src/main/resources/bundles/apiAccessKeys.properties
+++ b/src/main/resources/bundles/apiAccessKeys.properties
@@ -2,8 +2,9 @@
 #
 # These are security-sensitive and are kept in this dedicated file -- a peer of
 # commonConfiguration.properties -- so the signing key can be held PRIVATELY and out of git.
-# Place a copy of this file, with real values, in the data-dir override location, e.g.:
-#   <data dir>/wildbook_data_dir/WEB-INF/classes/bundles/apiAccessKeys.properties
+# Place a copy of this file, with real values, in the data-dir override location:
+#   webapps/<dataDir>/WEB-INF/classes/bundles/apiAccessKeys.properties
+# where <dataDir> defaults to wildbook_data_dir (overridable per context via <context>DataDir).
 # Only the keys you set there are needed; anything unset falls back to this (in-git) template.
 #
 # With every key left unset (as shipped), the token service is DISABLED: POST /api/v3/auth/token

--- a/src/test/java/org/ecocean/api/AuthTokenTest.java
+++ b/src/test/java/org/ecocean/api/AuthTokenTest.java
@@ -139,8 +139,8 @@ class AuthTokenTest {
                      doNothing().when(mock).rollbackAndClose();
                      when(mock.getUser("alice")).thenReturn(alice);
                  })) {
-            // All CommonConfiguration.getProperty calls return null → JwtService disabled
-            mockConfig.when(() -> org.ecocean.CommonConfiguration.getProperty(
+            // All API-access key lookups return null → JwtService disabled
+            mockConfig.when(() -> org.ecocean.CommonConfiguration.getApiAccessProperty(
                 anyString(), anyString())).thenReturn(null);
 
             AuthToken servlet = new AuthToken();

--- a/src/test/java/org/ecocean/api/SearchTokenScopeChildIndexTest.java
+++ b/src/test/java/org/ecocean/api/SearchTokenScopeChildIndexTest.java
@@ -109,12 +109,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         commonConfiguration.setProperty("collaborationSecurityEnabled", "true");
         commonConfiguration.setProperty("releaseDateFormat", "yyyy-MM-dd");
         commonConfiguration.setProperty("htmlTitle", "Unit Test");
-        commonConfiguration.setProperty("jwtPrivateKeyBase64", privB64);
-        commonConfiguration.setProperty("jwtPublicKeyBase64", pubB64);
-        commonConfiguration.setProperty("jwtIssuer", "wildbook");
-        commonConfiguration.setProperty("jwtAudience", "wildbook-scoped-api");
-        commonConfiguration.setProperty("jwtContext", "context0");
         CommonConfiguration.initialize("context0", commonConfiguration);
+
+        // JWT keys now live in their own file (apiAccessKeys.properties), seeded via this seam.
+        Properties apiAccessKeys = new Properties();
+        apiAccessKeys.setProperty("jwtPrivateKeyBase64", privB64);
+        apiAccessKeys.setProperty("jwtPublicKeyBase64", pubB64);
+        apiAccessKeys.setProperty("jwtIssuer", "wildbook");
+        apiAccessKeys.setProperty("jwtAudience", "wildbook-scoped-api");
+        apiAccessKeys.setProperty("jwtContext", "context0");
+        CommonConfiguration.initializeApiAccess("context0", apiAccessKeys);
 
         testJwtService = JwtService.fromBase64Keys(privB64, pubB64, "wildbook",
             "wildbook-scoped-api");
@@ -166,6 +170,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         org.ecocean.shepherd.core.TestPMFUtil.closePMF("context0");
         OpenSearch.INDEX_EXISTS_CACHE.clear();
         OpenSearch.PIT_CACHE.clear();
+        CommonConfiguration.clearApiAccessCache();
     }
 
     // =========================================================================

--- a/src/test/java/org/ecocean/api/SearchTokenScopeTest.java
+++ b/src/test/java/org/ecocean/api/SearchTokenScopeTest.java
@@ -107,12 +107,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         commonConfiguration.setProperty("collaborationSecurityEnabled", "true");
         commonConfiguration.setProperty("releaseDateFormat", "yyyy-MM-dd");
         commonConfiguration.setProperty("htmlTitle", "Unit Test");
-        commonConfiguration.setProperty("jwtPrivateKeyBase64", privB64);
-        commonConfiguration.setProperty("jwtPublicKeyBase64", pubB64);
-        commonConfiguration.setProperty("jwtIssuer", "wildbook");
-        commonConfiguration.setProperty("jwtAudience", "wildbook-scoped-api");
-        commonConfiguration.setProperty("jwtContext", "context0");
         CommonConfiguration.initialize("context0", commonConfiguration);
+
+        // JWT keys now live in their own file (apiAccessKeys.properties), seeded via this seam.
+        Properties apiAccessKeys = new Properties();
+        apiAccessKeys.setProperty("jwtPrivateKeyBase64", privB64);
+        apiAccessKeys.setProperty("jwtPublicKeyBase64", pubB64);
+        apiAccessKeys.setProperty("jwtIssuer", "wildbook");
+        apiAccessKeys.setProperty("jwtAudience", "wildbook-scoped-api");
+        apiAccessKeys.setProperty("jwtContext", "context0");
+        CommonConfiguration.initializeApiAccess("context0", apiAccessKeys);
 
         testJwtService = JwtService.fromBase64Keys(privB64, pubB64, "wildbook",
             "wildbook-scoped-api");
@@ -164,6 +168,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         org.ecocean.shepherd.core.TestPMFUtil.closePMF("context0");
         OpenSearch.INDEX_EXISTS_CACHE.clear();
         OpenSearch.PIT_CACHE.clear();
+        CommonConfiguration.clearApiAccessCache();
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

API-access (JWT) settings were read from `commonConfiguration.properties` via `CommonConfiguration.getProperty(...)`. Since `commonConfiguration.properties` is tracked in git, the signing key (`jwtPrivateKeyBase64`) could not be held privately without editing a git-managed file.

This moves all `jwt*` keys into their own file, **`apiAccessKeys.properties`** — a peer of `commonConfiguration.properties`, mirroring the existing `googleKeys.properties` pattern. It overrides privately from the data-dir, and the in-git template ships with every key unset (token service disabled by default).

## Keys moved

`jwtPrivateKeyBase64`, `jwtPublicKeyBase64`, `jwtIssuer`, `jwtAudience`, `jwtKeyId`, `jwtContext`, `jwtTtlSeconds`.

## Changes

- **New** `src/main/resources/bundles/apiAccessKeys.properties` — documented template; every key commented out (service disabled by default → `POST /api/v3/auth/token` returns 503, identical to current behavior).
- **`CommonConfiguration`** — `getApiAccessProperty(name, context)` reads the new file (resolved by `ShepherdProperties`, including the private data-dir override at `webapps/<dataDir>/WEB-INF/classes/bundles/`). Adds an `initializeApiAccess(...)` test seam + `clearApiAccessCache()`.
- **`JwtService`, `AuthToken`, `WildbookTokenAuthenticationFilter`** — read via `getApiAccessProperty` instead of `getProperty`. **Clean move: no fallback** to `commonConfiguration.properties`.
- **Tests** — seed JWT keys via `initializeApiAccess` and clear the seam in `tearDown`.
- **Docs** — `jwt-keypair-setup.md` runbook updated to point at the new file/accessor/override path.

## Deployment / migration note

⚠️ **Breaking for any deployment that already placed `jwt*` keys in its (override) `commonConfiguration.properties`.** Those keys must be moved into `apiAccessKeys.properties` in the data-dir override, or token issuance stops (503). The token feature is recent and not widely deployed, so impact is expected to be minimal. This clean-move (no silent fallback) was an explicit choice.

## Verification

- `mvn test-compile` clean (main + test).
- `AuthTokenTest` 3/3 and `SearchTokenScopeTest` 5/5 (real mint + token-scoped search verify through the relocated keys) pass.
- Reviewed by Codex (converged; 3 Minor findings all addressed — runbook staleness, template path wording, and a test-parallelism note verified moot since surefire runs `forkCount=1` with no JUnit parallelism).
- Line endings normalized to LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)