### PR TITLE
fix(bulk-import): preserve table page across polling refreshes (#1637)

### DIFF
--- a/frontend/src/__tests__/components/SimpleDataTable.test.jsx
+++ b/frontend/src/__tests__/components/SimpleDataTable.test.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SimpleDataTable from "../../components/SimpleDataTable";
+
+// Regression coverage for issue #1637: while a bulk-import task polls,
+// SimpleDataTable receives a fresh `data` array on every poll. It must
+// keep the reviewer on their current page instead of resetting to the
+// first page on each refresh.
+describe("SimpleDataTable pagination preservation", () => {
+  const columns = [
+    {
+      name: "ID",
+      selector: (row) => row.id,
+      cell: (row) => row.id,
+    },
+  ];
+
+  const makeRows = (count) =>
+    Array.from({ length: count }, (_, index) => ({ id: `row-${index + 1}` }));
+
+  test("keeps the current page when a new data array arrives (poll)", () => {
+    // 25 rows / 10 per page => 3 pages.
+    const { rerender } = render(
+      <SimpleDataTable columns={columns} data={makeRows(25)} perPage={10} />,
+    );
+
+    // Navigate to page 3 (rows 21-25).
+    fireEvent.click(screen.getByText("3"));
+    expect(screen.getByText("row-21")).toBeInTheDocument();
+    expect(screen.queryByText("row-1")).not.toBeInTheDocument();
+
+    // A poll hands us a brand-new array reference with identical content.
+    rerender(
+      <SimpleDataTable columns={columns} data={makeRows(25)} perPage={10} />,
+    );
+
+    // Still on page 3 — not reset to page 1.
+    expect(screen.getByText("row-21")).toBeInTheDocument();
+    expect(screen.queryByText("row-1")).not.toBeInTheDocument();
+  });
+
+  test("clamps to the last page when the row count shrinks", () => {
+    const { rerender } = render(
+      <SimpleDataTable columns={columns} data={makeRows(25)} perPage={10} />,
+    );
+
+    fireEvent.click(screen.getByText("3"));
+    expect(screen.getByText("row-21")).toBeInTheDocument();
+
+    // Data shrinks to a single page; page index 2 is now out of range.
+    rerender(
+      <SimpleDataTable columns={columns} data={makeRows(5)} perPage={10} />,
+    );
+
+    // Clamped to the only remaining page rather than rendering a blank page.
+    expect(screen.getByText("row-1")).toBeInTheDocument();
+    expect(screen.getByText("row-5")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SimpleDataTable.jsx
+++ b/frontend/src/components/SimpleDataTable.jsx
@@ -14,16 +14,29 @@ const SimpleDataTable = ({ columns = [], data = [], perPage = 10 }) => {
   const pageCount = Math.ceil(data.length / safePerPage);
 
   useEffect(() => {
-    // Always rebuild dataset from the incoming `data` prop so updates
+    // Rebuild dataset from the incoming `data` prop so updates
     // (e.g. polling progress) are reflected. Any active user sort is
     // discarded on each new snapshot.
+    //
+    // Preserve the user's current page across refreshes instead of
+    // resetting to the first page. A bulk-import task polls every few
+    // seconds while detection/identification run (and for a short
+    // window after), handing this component a fresh `data` array on
+    // every poll. Resetting here knocked a reviewer back to page 1 on
+    // every poll while they were reviewing matches (issue #1637).
+    // Clamp to the last available page so a shrinking row count never
+    // strands us on an out-of-range page; the second effect recomputes
+    // the visible rows from the clamped page.
     const indexedData = data.map((row, index) => ({
       ...row,
       tableID: row.tableID ?? index + 1,
     }));
     setDataset(indexedData);
-    setCurrentPage(0);
-    setPagedData([...indexedData].slice(0, safePerPage));
+    const lastPage = Math.max(
+      0,
+      Math.ceil(indexedData.length / safePerPage) - 1,
+    );
+    setCurrentPage((prev) => Math.min(prev, lastPage));
   }, [data, safePerPage]);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

Closes #1637.

The bulk-import task page (`/react/bulk-import-task`) polls the task every few seconds while detection/identification run (and for a short window after, while the per-encounter match-result links finish aggregating). Each poll hands `SimpleDataTable` a brand-new `data` array reference. `SimpleDataTable`'s data-sync `useEffect` called `setCurrentPage(0)` on every `data` change, so a researcher reviewing matches on, say, page 3 was knocked back to page 1 on every refresh — exactly the behavior reported in the issue and on the [community forum](https://community.wildme.org/t/bulk-import-table-is-refreshing-page-view/5631/2).

## Fix

`frontend/src/components/SimpleDataTable.jsx` now **preserves the current page** across data updates instead of resetting it, clamping to the last available page so a shrinking row count never lands on an out-of-range (blank) page:

```js
setCurrentPage((prev) => Math.min(prev, lastPage));
```

The component's existing second effect (deps `[dataset, currentPage, safePerPage]`) already recomputes the visible rows, so the page-0 slice was dropped from the first effect with no flash or stale rows.

Scope note: this fixes the user-visible harm (losing your place). The polling itself already terminates once detection/ID settle and the match-result links finish populating — that bounded post-ID poll is intentional (it's what makes the "Class" column links appear), so this change deliberately makes the refresh *harmless* rather than suppressing it.

`SimpleDataTable`'s only consumer is `BulkImportTask`.

## Tests

Added `frontend/src/__tests__/components/SimpleDataTable.test.jsx`:
- page is preserved when a new (identical-content) `data` array arrives, as on a poll
- page clamps to the last page when the row count shrinks

Both pass; ESLint clean. Reviewed by Codex (no findings; edge cases for empty/shrinking data, large per-page, and the `sortServer` sort path all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)