### PR TITLE
Bump annotation version when embeddings change so OpenSearch reindexes them into _source

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -156,7 +156,10 @@ public class Annotation extends Base implements java.io.Serializable {
     }
 
     public long setVersion() {
-        version = System.currentTimeMillis();
+        // Monotonic: the OpenSearch reconciler treats an annotation as stale only when DB version is
+        // strictly greater than the indexed version, so two bumps within the same millisecond must
+        // still advance the value (otherwise a change could silently fail to reindex).
+        version = Math.max(version + 1, System.currentTimeMillis());
         return version;
     }
 
@@ -1907,6 +1910,8 @@ public class Annotation extends Base implements java.io.Serializable {
                 " deleting " + emb);
             myShepherd.getPM().deletePersistent(emb);
         }
+        // bump version so the reconciler reindexes and the now-removed vector(s) leave the _source
+        this.setVersion();
         return rtn;
     }
 
@@ -2091,8 +2096,17 @@ public class Annotation extends Base implements java.io.Serializable {
     public Set<Embedding> addEmbedding(Embedding emb) {
         if (embeddings == null) embeddings = new HashSet<Embedding>();
         if (emb == null) return embeddings;
-        embeddings.add(emb);
-        if (!this.equals(emb.getAnnotation())) emb.setAnnotation(this);
+        boolean added = embeddings.add(emb);
+        boolean linked = false;
+        if (!this.equals(emb.getAnnotation())) {
+            emb.setAnnotation(this);
+            linked = true;
+        }
+        // bump version only on a real change so the OpenSearch reconciler reindexes this annotation
+        // and writes the embedding vector into the document _source (otherwise the vector is
+        // kNN-searchable but never surfaces in the token-readable _source). Skipping no-op duplicate
+        // adds avoids needless reconciler churn.
+        if (added || linked) this.setVersion();
         return embeddings;
     }
 

--- a/src/main/java/org/ecocean/ia/MlServiceProcessor.java
+++ b/src/main/java/org/ecocean/ia/MlServiceProcessor.java
@@ -421,14 +421,13 @@ public class MlServiceProcessor {
                     // model produced an identical box). Reuse it. If it has no
                     // embedding for THIS (method, version), attach one so a
                     // later model run does not leave the box unmatchable for
-                    // that method. setVersion() forces the parent Annotation to
-                    // reindex its nested embeddings — the Embedding persist and
-                    // Annotation.addEmbedding alone do not bump the parent.
+                    // that method. Annotation.addEmbedding() bumps the parent's
+                    // version, so the reconciler reindexes its nested embeddings
+                    // into the document _source.
                     if (existing.getEmbeddingByMethod(mv[0], mv[1]) == null) {
                         Embedding emb = new Embedding(existing, mv[0], mv[1],
                             result.getJSONArray("embedding"));
                         shep.getPM().makePersistent(emb);
-                        existing.setVersion();
                     }
                     // Self-heal a reused annotation's iaClass when we now have a
                     // better value. Two cases, both guarded so a legitimately

--- a/src/test/java/org/ecocean/AnnotationEmbeddingVersionTest.java
+++ b/src/test/java/org/ecocean/AnnotationEmbeddingVersionTest.java
@@ -1,0 +1,78 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.pgvector.PGvector;
+import javax.jdo.PersistenceManager;
+import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Attaching or removing an embedding must bump the annotation's version, so the OpenSearch
+ * reconciler (Base.opensearchSyncIndex) treats the annotation as stale and reindexes it —
+ * which re-serializes the embedding vector into the document _source. Without the bump, a freshly
+ * embedded annotation is searchable for kNN matching but its vector never appears in the
+ * token-readable _source. Guards the fix in Annotation.addEmbedding()/deleteEmbeddings().
+ *
+ * Annotation/Embedding identity (equals/hashCode) is id-based, so both objects are given ids here
+ * (as persisted objects always have) — without ids the reciprocal addEmbedding/setAnnotation wiring
+ * cannot settle.
+ */
+class AnnotationEmbeddingVersionTest {
+
+    private static Annotation annotationWithId() {
+        Annotation ann = new Annotation();
+        ann.setId(Util.generateUUID());
+        return ann;
+    }
+
+    // An embedding with a stable id, not yet wired to any annotation (passing null avoids the
+    // constructor's own addEmbedding call).
+    private static Embedding looseEmbedding() {
+        return new Embedding(null, "miewid", "msv4.1", (PGvector) null);
+    }
+
+    @Test void addEmbedding_bumps_version() {
+        Annotation ann = annotationWithId();
+        long before = ann.getVersion();
+
+        ann.addEmbedding(looseEmbedding());
+
+        assertEquals(1, ann.numberEmbeddings(), "embedding was attached");
+        assertTrue(ann.getVersion() > before,
+            "addEmbedding() must bump the annotation version so the reconciler reindexes it");
+    }
+
+    @Test void addEmbedding_duplicate_does_not_rebump() {
+        Annotation ann = annotationWithId();
+        Embedding emb = looseEmbedding();
+        ann.addEmbedding(emb);
+        long afterFirst = ann.getVersion();
+
+        ann.addEmbedding(emb); // same embedding, already attached -> no-op
+
+        assertEquals(1, ann.numberEmbeddings(), "still one embedding");
+        assertEquals(afterFirst, ann.getVersion(),
+            "re-adding the same embedding must not bump the version (avoids reconciler churn)");
+    }
+
+    @Test void deleteEmbeddings_bumps_version() {
+        Annotation ann = annotationWithId();
+        ann.addEmbedding(looseEmbedding());
+        assertEquals(1, ann.numberEmbeddings(), "precondition: one embedding attached");
+
+        PersistenceManager pm = mock(PersistenceManager.class);
+        Shepherd sh = mock(Shepherd.class);
+        when(sh.getPM()).thenReturn(pm);
+
+        long before = ann.getVersion();
+
+        int removed = ann.deleteEmbeddings(sh);
+
+        assertEquals(1, removed, "deleteEmbeddings() returns the count removed");
+        verify(pm).deletePersistent(any());
+        assertTrue(ann.getVersion() > before,
+            "deleteEmbeddings() must bump the annotation version so the reconciler reindexes it");
+    }
+}


### PR DESCRIPTION
## The bug

`Annotation.addEmbedding()` (and `deleteEmbeddings()`) did **not** call `setVersion()`. The background OpenSearch reconciler (`Base.opensearchSyncIndex`) only reindexes an annotation when its DB `VERSION` exceeds the indexed version, and reindexing is what re-serializes the embedding vector into the document `_source`.

So when the ml-service computes an embedding and attaches it, the annotation isn't marked stale → it's never reindexed → the vector is **indexed for kNN matching but never written into `_source`**. The token-scoped API (`/api/v3/search/*`, `media/resolve`) reads `_source`, so the agent-skill suite — and any token consumer — can't see the vectors even though matching works.

## Live-observed

While testing the agent-skill suite across instances:
- **giraffespotter / zebra** — embeddings present in `_source`, suite works.
- **whiskerbook** — vectors fully indexed for kNN (95,182, matching the `EMBEDDING` table) but **absent from `_source`** (0/100 matchable in `_source`), so the suite was blind. A manual `UPDATE "ANNOTATION" SET "VERSION"=…` forced a reindex and `_source` began filling in — confirming the version bump is the right trigger.

This PR makes that automatic going forward.

## Changes

- **`addEmbedding()` / `deleteEmbeddings()` call `setVersion()`** on a real change, so a freshly embedded (or re-embedded) annotation auto-reindexes and its vector lands in `_source`. The add path bumps only when the set or the reciprocal link actually changed — no bump on a no-op duplicate add (avoids reconciler churn).
- **`setVersion()` is now monotonic** (`max(version + 1, now)`). The reconciler compares strictly (`DB version > indexed version`), so two bumps within the same millisecond must still advance the value or a change could silently fail to reindex.
- **Removes a now-redundant local workaround** in `MlServiceProcessor` (the dedup-reuse path manually bumped the parent *because* `addEmbedding` didn't) and corrects its comment.
- **Adds `AnnotationEmbeddingVersionTest`** — add bumps version, delete bumps version, duplicate add is a no-op.

## Scope note

Embedding changes flow only through add/delete (both now versioned). The in-place vector setters (`setVector`/`setMethod`/`setMethodVersion`) and the SQL `storeVector`/`loadVector` path are unused / commented-out, so no setter-level version propagation is needed today; if that path is ever revived it should bump the owning annotation.

## Testing

`AnnotationEmbeddingVersionTest` 3/3 green; existing `AnnotationTest` / `AnnotationAclSerializerTest` / `AnnotationMiewIDScoreTest` / `OpenSearchAnnotationMatchableQueryTest` pass; `mvn -o compile` clean. Reviewed by Codex (2 rounds, converged — no Major findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
