### PR TITLE
Agent-skill docs: address live API feedback (token TTL, response shape, limits, time-decay)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ shepherd_derby_database
 /outputPackage.txt
 src/main/webapp/encounters/*20*
 /log
+/logs/
 /changed
 /changedfiles.txt
 /buildExam.txt

--- a/src/main/resources/agent-skills/api-reference.md
+++ b/src/main/resources/agent-skills/api-reference.md
@@ -13,7 +13,10 @@ what that user is permitted to see (everything is access-controlled to their acc
 - The user generates a short-lived **bearer token** in Wildbook's UI (Account menu → **API Access**)
   and pastes **only the token** to you.
 - Treat the token as a secret: never log or persist it, never send it anywhere except Wildbook over
-  HTTPS. It expires (typically ~30 minutes). When it expires, ask the user to paste a fresh one.
+  HTTPS. It expires after a fixed lifetime that is **configured per Wildbook instance** (commonly
+  several hours) — do **not** assume any particular duration. The token-mint response's
+  `expiresInSeconds` is the authoritative lifetime; rely on it (this matters for long, unattended
+  runs). When the token expires, ask the user to paste a fresh one.
 
 ## Authentication
 Send the token as a bearer header on every request:
@@ -33,8 +36,15 @@ fields, which are never returned to you.
 { "query": { "term": { "taxonomy": "Salamandra salamandra" } } }
 ```
 Pagination via `?from=&size=` query params; total hits in the `X-Wildbook-Total-Hits` response header.
-Non-admin `individual` search may only query/sort identity fields. Aggregations, scripted queries, and
-cross-index term lookups are rejected.
+Non-admin `individual` search may only query/sort identity fields. Scripted queries and cross-index
+term lookups are rejected. **Aggregations are not supported** — and today an `aggs` body is silently
+dropped and returns an empty aggregation rather than an error, so never infer counts from an
+aggregation. To count, read `X-Wildbook-Total-Hits` from a filtered query (with `size=0`) instead.
+
+**Response shape (important):** the body is a *flat* envelope — `{ "hits": [ {…document fields…}, … ] }`
+— where each element is the document's fields directly. It is **not** the standard OpenSearch
+`{"hits":{"hits":[{"_source":…}]}}` shape, and the hit total lives only in the `X-Wildbook-Total-Hits`
+header, never in the body.
 
 ### Media resolve — `POST /api/v3/media/resolve`
 Resolve up to 100 annotation IDs you are allowed to see into displayable image references:
@@ -53,7 +63,10 @@ Key indices and fields:
   `sex`, `lifeStage`, `livingStatus`, `country`, `behavior`, ...
 - **individual** — `id`, `displayName`, `names`/`nameMap`, `sex`, `taxonomy`, `timeOfBirth`/`timeOfDeath`.
 - **annotation** — `id`, `encounterId`, `viewpoint`, `iaClass`, `matchAgainst`, `mediaAssetId`, and
-  `embeddings` (nested: `method`, `methodVersion`, and the MiewID `vector`).
+  `embeddings` (nested: `method`, `methodVersion`, and the MiewID `vector`). The annotation document
+  carries **no sighting date** — to analyse by time, collect the `encounterId`s and look them up in the
+  encounter index (a `terms` query) to read `date`/`dateMillis`. MiewID `vector`s are **L2-normalised**
+  (unit length), so cosine similarity between two of them is just their dot product.
 
 Access-control fields exist server-side but are **never** returned.
 
@@ -74,6 +87,17 @@ To turn annotation IDs into a catalog-animal label and a croppable image, call
 `encounterId`, `viewpoint`, `bbox`, `imageUrl`, and `methodVersion`. The annotation search itself
 does not return `individualId`.
 
+For whole-population work that would exceed 10,000 records, split the query into sub-scopes that each
+stay under the ceiling and combine the results yourself. For **encounter** searches, split by date
+range (`dateMillis`) or site (`locationId`). For **annotation** searches — which carry no date — split
+by `viewpoint`, or first fetch the encounter IDs for a date band and then query annotations by those
+`encounterId`s. This is the reliable pattern for large catalogues today.
+
+**Transient errors:** retrieving large pages (especially with the heavy embedding `vector`s) is slow,
+and under sustained paging the API may intermittently return HTTP `500` (`"query failed"`). These are
+transient — retry the same request with a short backoff (e.g. wait 1s, then 2s, then 4s, up to ~4
+attempts) before giving up, and pace large sweeps rather than firing requests back-to-back.
+
 ## Worked examples
 
 **Find an individual's salamander encounters, then view two annotations:**
@@ -86,6 +110,11 @@ does not return `individualId`.
 **Comparing embeddings for missed matches:** only compare embeddings within the **same `viewpoint` and
 same `methodVersion`** — different viewpoints/versions live in different latent spaces and are not
 directly comparable. Calibrate similarity against known same-individual pairs before trusting a score.
+Similarity baselines are **species-specific** — e.g. same-individual cosine similarity runs around
+~0.50 for whale sharks but ~0.35 for grey nurse sharks — so calibrate per species and never reuse a
+threshold across species. Similarity also **decays as the time between two sightings grows**; when
+judging a match or measuring reliability, factor in the elapsed time between the photos being compared
+(join via `encounterId` to the encounter `dateMillis`).
 
 ## References
 - **Wildbook documentation** — https://wildbook.docs.wildme.org/ — background on the data model

--- a/src/main/resources/agent-skills/how-good-is-our-matching.md
+++ b/src/main/resources/agent-skills/how-good-is-our-matching.md
@@ -38,6 +38,10 @@ narrow very large scopes.
    `individualId` and the croppable image for each annotation.
 3. Discard annotations with no `individualId` — only confirmed-identity photos can serve as
    test cases or catalog references.
+3a. To break reliability down by how much time has passed (recommended — see below), also fetch each
+    photo's sighting date: the annotation has no date, so collect the `encounterId`s and look them up
+    in the encounter index (`POST /api/v3/search/encounter` with a `terms` query on the IDs) and read
+    `dateMillis` for each.
 4. Group strictly by `viewpoint` + `methodVersion`. Never compare photos across viewpoints or
    across model versions; the similarity scores are not comparable.
 5. For each group, conduct a leave-one-out evaluation:
@@ -49,11 +53,18 @@ narrow very large scopes.
    c. Rank all catalog animals in the reference set by their highest cosine similarity to the
       query photo.
    d. Record: (i) whether the correct animal ranked first (Rank-1 hit), and (ii) whether the
-      correct animal appeared anywhere in the top five (Top-5 hit).
+      correct animal appeared anywhere in the top five (Top-5 hit). If you fetched dates (step 3a),
+      also record the elapsed time between the query photo's sighting and the sighting of the
+      correct animal's nearest reference photo.
    e. Repeat for every photo in the group that has at least three independent reference photos
       remaining after exclusion; skip and note photos that fall below that threshold.
 6. Aggregate Rank-1 and Top-5 counts and divide by the total number of evaluated photos to get
    percentages.
+7. **Stratify by elapsed time (strongly recommended).** Also aggregate Rank-1 and Top-5 separately
+   within elapsed-time bands — for example under 1 year, 1–3 years, and over 3 years between the
+   query and its reference. Matching reliability decays as the gap between sightings grows, and a
+   single overall number hides that decline. For population monitoring (where animals are re-sighted
+   years apart) the long-interval bands are the ones that matter most.
 
 ## How to report results
 Speak plainly. Lead with the headline numbers, then add context. For example:
@@ -65,15 +76,24 @@ Speak plainly. Lead with the headline numbers, then add context. For example:
 Always state the sample size (number of test photos and number of individuals covered). If the
 sample is below 30 photos or 10 individuals, add a clear caveat: "These numbers are based on a
 small sample and may not reflect performance on the full catalog — treat them as indicative only."
+If you broke the results down by the time between sightings, report how the accuracy changes as that
+gap grows — for example: "when two sightings of the same animal were within a year of each other the
+right animal came up first 92% of the time, but when they were three or more years apart that fell to
+61%." Call out this trend plainly, because that long-term decline is what matters most for tracking a
+population over many years.
+
 Break results out by viewpoint or model version if those subgroups tell meaningfully different
 stories. Produce a brief summary table if it helps clarity. Never imply precision the sample size
 does not support.
 
 ## Cautions
 Results apply only to the viewpoint and model version you evaluated — do not generalise across
-them. Results describe accuracy for *this* scope (species, site, date range), not the whole
-catalog; other scopes may perform differently. Small samples are unreliable — state the sample
-size and flag low counts prominently. You only see catalog data the person's account is permitted
+them. Reliability also differs markedly **between species**, so figures from one species never
+transfer to another — always measure each species on its own. Results describe accuracy for *this*
+scope (species, site, date range), not the whole catalog; other scopes may perform differently.
+Reliability tends to fade as the time between sightings grows, so an overall figure can look healthy
+while matching across long gaps is weak — prefer the breakdown by time between sightings. Small samples are
+unreliable — state the sample size and flag low counts prominently. You only see catalog data the person's account is permitted
 to view, so the evaluation is bounded by that visibility. This skill is read-only: it produces an
 accuracy report and makes no changes to any records.
 


### PR DESCRIPTION
First of a series addressing real field feedback on the read-only token API + agent-skill suite (a Claude Code agent assisting Simon Pierce / Marine Megafauna Foundation). This PR is **docs/skills only** — the fast, high-relief items. Code/endpoint changes follow as separate PRs.

## Changes (`agent-skills/api-reference.md` + `how-good-is-our-matching.md`)

- **Token lifetime** — stop claiming "~30 minutes". The lifetime is configured per Wildbook instance (commonly several hours); `expiresInSeconds` from the mint response is authoritative. This was actively confusing for unattended runs.
- **Response shape** — document that search returns a **flat** `{"hits":[…document fields…]}` envelope (not OpenSearch's `{"hits":{"hits":[{"_source":…}]}}`), and that the hit total is only in the `X-Wildbook-Total-Hits` header.
- **Aggregations** — clarify they're unsupported and currently return an **empty** result rather than an error (so never infer counts from one; count via `X-Wildbook-Total-Hits` with `size=0`).
- **Vectors are L2-normalised** — cosine similarity == dot product.
- **Annotation has no date** — to analyse by time, join `encounterId` → encounter `date`/`dateMillis`.
- **>10k populations** — sub-scope chunking pattern, correctly split for encounter (by date/site) vs annotation (by viewpoint or via encounterId date-band).
- **Transient 500s** — retry-with-backoff guidance under sustained paging.
- **Calibration** — similarity is species-specific (~0.50 whale shark vs ~0.35 grey nurse) and decays with time between sightings.
- **`how-good-is-our-matching`** — add a **time-between-sightings breakdown** (reliability decays with the gap; the long-interval bands matter most for population monitoring) and a per-species caution. Plain-language for the field-biologist audience.

## Testing / review
`AgentSkillContentTest` 7/7 (jargon/leak/drift/api-reference contract) + `AgentSkillTest` green. Codex-reviewed (2 rounds, converged): fixed directional temporal wording, removed user-facing "stratified" jargon, and qualified the chunking guidance for the dateless annotation index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
