### PR TITLE
Annotation index: add encounterDateMillis (denormalized sighting date)

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -179,6 +179,8 @@ public class Annotation extends Base implements java.io.Serializable {
         map.put("encounterLocationId", keywordType);
         map.put("encounterTaxonomy", keywordType);
         map.put("encounterProjectIds", keywordType);
+        // parent encounter's sighting date, denormalized so temporal analyses need no encounter join
+        map.put("encounterDateMillis", new JSONObject("{\"type\": \"date\", \"format\": \"epoch_millis\"}"));
 
         // ACL fields (viewUsers is inherited from Base.opensearchMapping())
         map.put("publiclyReadable", new JSONObject("{\"type\": \"boolean\"}"));
@@ -225,6 +227,10 @@ public class Annotation extends Base implements java.io.Serializable {
             jgen.writeStringField("encounterSubmitterId", enc.getSubmitterID());
             jgen.writeStringField("encounterLocationId", enc.getLocationID());
             jgen.writeStringField("encounterTaxonomy", enc.getTaxonomyString());
+            // denormalize the sighting date so temporal re-ID analyses avoid a second round-trip to
+            // the encounter index (mirrors Encounter's own dateMillis serialization)
+            Long encDateMillis = enc.getDateInMillisecondsFallback();
+            if (encDateMillis != null) jgen.writeNumberField("encounterDateMillis", encDateMillis);
             // per discussion on issue 874, including this in indexing, but not (yet) using in matchingSet
             jgen.writeStringField("encounterLivingStatus", enc.getLivingStatus());
             User owner = enc.getSubmitterUser(myShepherd);

--- a/src/test/java/org/ecocean/AnnotationDateIndexTest.java
+++ b/src/test/java/org/ecocean/AnnotationDateIndexTest.java
@@ -1,0 +1,74 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.StringWriter;
+import java.util.Collections;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The annotation OpenSearch document denormalizes its parent encounter's sighting date as
+ * encounterDateMillis, so temporal re-ID analyses (e.g. reliability by time-between-sightings)
+ * do not need a second round-trip to the encounter index. Guards Annotation.opensearchMapping()
+ * and opensearchDocumentSerializer().
+ */
+class AnnotationDateIndexTest {
+
+    private JSONObject serialize(Annotation ann, Shepherd sh) throws Exception {
+        StringWriter sw = new StringWriter();
+        JsonGenerator jg = new JsonFactory().createGenerator(sw);
+        jg.writeStartObject();
+        ann.opensearchDocumentSerializer(jg, sh);
+        jg.writeEndObject();
+        jg.close();
+        return new JSONObject(sw.toString());
+    }
+
+    private Annotation annotationWithEncounter(Shepherd sh, Encounter enc) {
+        Annotation ann = spy(new Annotation());
+        ann.setId("ann-1");
+        doReturn(enc).when(ann).findEncounter(sh);
+        doReturn(Collections.emptyList()).when(ann).parentEncounters(sh); // writeAclFields: fail-closed
+        return ann;
+    }
+
+    @Test void mapping_declares_encounterDateMillis_as_date() {
+        JSONObject map = new Annotation().opensearchMapping();
+        assertTrue(map.has("encounterDateMillis"), "mapping must declare encounterDateMillis");
+        assertEquals("date", map.getJSONObject("encounterDateMillis").getString("type"),
+            "encounterDateMillis must be indexed as a date");
+        assertEquals("epoch_millis", map.getJSONObject("encounterDateMillis").getString("format"),
+            "encounterDateMillis must accept epoch-millis values");
+    }
+
+    @Test void serializer_writes_encounter_date_millis() throws Exception {
+        long when = 1609459200000L; // 2021-01-01T00:00:00Z
+        Shepherd sh = mock(Shepherd.class);
+        Encounter enc = mock(Encounter.class);
+        when(enc.getId()).thenReturn("enc-1");
+        when(enc.getDateInMillisecondsFallback()).thenReturn(when);
+
+        JSONObject out = serialize(annotationWithEncounter(sh, enc), sh);
+
+        assertEquals(when, out.getLong("encounterDateMillis"),
+            "serialized annotation must carry the parent encounter's dateMillis");
+        assertEquals("enc-1", out.getString("encounterId"));
+    }
+
+    @Test void serializer_omits_date_when_encounter_has_none() throws Exception {
+        Shepherd sh = mock(Shepherd.class);
+        Encounter enc = mock(Encounter.class);
+        when(enc.getId()).thenReturn("enc-2");
+        when(enc.getDateInMillisecondsFallback()).thenReturn(null);
+
+        JSONObject out = serialize(annotationWithEncounter(sh, enc), sh);
+
+        assertFalse(out.has("encounterDateMillis"), "no encounter date -> field omitted");
+        assertEquals("enc-2", out.getString("encounterId"));
+    }
+}


### PR DESCRIPTION
Part of the API-feedback series (MMF/Sharkbook). The annotation OpenSearch document carried **no sighting date**, so temporal re-ID analyses (e.g. matching reliability by time-between-sightings) needed a second round-trip to the encounter index for every annotation.

## Change
Denormalize the parent encounter's date onto the annotation document as **`encounterDateMillis`**:
- `Annotation.opensearchDocumentSerializer` writes `encounterDateMillis` from `enc.getDateInMillisecondsFallback()` (the same source `Encounter` uses for its own `dateMillis`), inside the existing `enc != null` block, only when non-null.
- `Annotation.opensearchMapping` declares it as `{"type":"date","format":"epoch_millis"}` so date-range queries work directly.
- Naming follows the existing `encounter*` prefix convention on the annotation document.

## Notes
- Populated on (re)index; existing indices need the mapping applied + a reindex to query it. The `encounterId` → encounter join remains a valid fallback for un-reindexed instances (the agent-skill docs already document that fallback; a follow-up doc touch-up will note `encounterDateMillis` as the preferred path once both land).
- Safe for annotations with no encounter or no encounter date (field is skipped) and multi-parent annotations (`findEncounter` first parent, as elsewhere).

## Testing / review
`AnnotationDateIndexTest` (mapping type/format; serializer writes when present; omits when absent) + existing `AnnotationAclSerializerTest`/`AnnotationTest`/`OpenSearchAnnotationMatchableQueryTest` green. Codex-reviewed: converged, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
