### PR TITLE
media/resolve: explicit per-ID status (identified/unidentified/no_image/unavailable/error)

### DIFF
--- a/src/main/java/org/ecocean/api/MediaResolveApi.java
+++ b/src/main/java/org/ecocean/api/MediaResolveApi.java
@@ -92,10 +92,40 @@ public class MediaResolveApi extends ApiBase {
             }
             boolean isAdmin = currentUser.isAdmin(myShepherd);
             Set<String> visible = isAdmin ? ids : gatedVisibleIds(ids, currentUser.getId());
+            // One result per unique requested id (ids was de-duplicated above), each with an explicit
+            // status, so the caller can tell a
+            // legitimate absence ("unavailable") from a retryable failure ("error") and from a record
+            // that resolved but has no named animal ("unidentified"). We iterate the requested ids
+            // (not just the visible subset) so nothing is silently dropped — while preserving the
+            // no-existence-oracle property: a not-visible id and a nonexistent id both report
+            // "unavailable" and neither triggers a DB lookup for an id the caller may not see.
             JSONArray results = new JSONArray();
-            for (String id : visible) {
-                JSONObject entry = resolveOne(id, myShepherd);
-                if (entry != null) results.put(entry);
+            for (String id : ids) {
+                JSONObject entry;
+                try {
+                    if (!visible.contains(id)) {
+                        // not visible to this caller, OR does not exist — deliberately the same status
+                        entry = statusOnly(id, "unavailable");
+                    } else {
+                        JSONObject resolved = resolveOne(id, myShepherd);
+                        if (resolved != null) {
+                            resolved.put("status",
+                                resolved.isNull("individualId") ? "unidentified" : "identified");
+                            entry = resolved;
+                        } else {
+                            // a visible/known id that produced no displayable image, vs a rare
+                            // index/DB drift where it has vanished. Only ever checks existence for an
+                            // id already proven visible, so this is not an existence oracle.
+                            boolean exists = (myShepherd.getAnnotation(id) != null);
+                            entry = statusOnly(id, exists ? "no_image" : "unavailable");
+                        }
+                    }
+                } catch (Exception perId) {
+                    // transient/unexpected failure for THIS id — the caller may retry just this one
+                    entry = statusOnly(id, "error");
+                    perId.printStackTrace();
+                }
+                results.put(entry);
             }
             response.setStatus(200);
             writeBody(response, results.toString());
@@ -107,6 +137,10 @@ public class MediaResolveApi extends ApiBase {
         } finally {
             if (myShepherd != null) myShepherd.rollbackAndClose();
         }
+    }
+
+    private static JSONObject statusOnly(String id, String status) {
+        return new JSONObject().put("id", id).put("status", status);
     }
 
     private void writeError(HttpServletResponse response, int status, String msg) throws IOException {

--- a/src/main/resources/agent-skills/api-reference.md
+++ b/src/main/resources/agent-skills/api-reference.md
@@ -41,11 +41,25 @@ Resolve up to 100 annotation IDs you are allowed to see into displayable image r
 ```json
 { "annotationIds": ["<uuid>", "<uuid>"] }
 ```
-Returns an array of `{ id, imageUrl, imageWidth, imageHeight, bbox: [x,y,w,h], theta, viewpoint,
-encounterId, individualId, methodVersion }`. The `bbox` is in the `imageWidth`×`imageHeight`
-coordinate space. **Fetch `imageUrl`, read its real pixel dimensions, and scale `bbox` by
-`realW/imageWidth`, `realH/imageHeight` before cropping** (usually a no-op). IDs you can't see (or that
-don't exist) are simply absent — the response never reveals which.
+Returns an array with **one entry per unique requested ID** (duplicate IDs collapse to one), each
+carrying a `status`:
+- `identified` — resolved; full image reference present **and** assigned to a named animal
+  (`individualId` set).
+- `unidentified` — resolved; full image reference present but **not yet assigned** to a named animal
+  (`individualId` is `null`). This is a legitimate state, not an error.
+- `no_image` — the annotation is visible to you and exists, but has no displayable image to return.
+- `unavailable` — the ID is not visible to your account **or** does not exist. These two are
+  deliberately reported the same way and the response never reveals which (no existence oracle).
+- `error` — a transient failure while resolving this one ID; the rest of the batch is unaffected, so
+  **retry just this ID** (with backoff). Distinct from `unavailable`, which you should not retry.
+
+A resolved entry (`identified`/`unidentified`) has the shape `{ id, status, imageUrl, imageWidth,
+imageHeight, bbox: [x,y,w,h], theta, viewpoint, encounterId, individualId, methodVersion }`; the others
+are just `{ id, status }`. **Branch on `status`: only `identified` and `unidentified` entries carry an
+`imageUrl`** — skip image handling for `no_image`/`unavailable`, and retry `error` entries. For an
+entry that has an image: the `bbox` is in the `imageWidth`×`imageHeight` coordinate space; **fetch
+`imageUrl`, read its real pixel dimensions, and scale `bbox` by `realW/imageWidth`, `realH/imageHeight`
+before cropping** (usually a no-op).
 
 ## OpenSearch schema (token-exposed fields)
 Key indices and fields:
@@ -80,8 +94,8 @@ does not return `individualId`.
 1. `POST /api/v3/search/encounter` with `{"query":{"term":{"taxonomy":"Salamandra salamandra"}}}`.
 2. Collect annotation IDs (search `annotation`, or via the encounters), then
    `POST /api/v3/media/resolve` with those IDs.
-3. For each result, fetch `imageUrl`, scale `bbox` to the fetched pixels, crop, and present
-   side-by-side.
+3. For each entry whose `status` is `identified` or `unidentified`, fetch `imageUrl`, scale `bbox`
+   to the fetched pixels, crop, and present side-by-side. Skip `no_image`/`unavailable`; retry `error`.
 
 **Comparing embeddings for missed matches:** only compare embeddings within the **same `viewpoint` and
 same `methodVersion`** — different viewpoints/versions live in different latent spaces and are not

--- a/src/test/java/org/ecocean/api/MediaResolveApiTest.java
+++ b/src/test/java/org/ecocean/api/MediaResolveApiTest.java
@@ -124,6 +124,15 @@ class MediaResolveApiTest {
                             .put("hits", hits));
     }
 
+    /** Find the status reported for a given requested id, or null if the id is absent from results. */
+    private static String statusOf(JSONArray arr, String id) {
+        for (int i = 0; i < arr.length(); i++) {
+            JSONObject o = arr.getJSONObject(i);
+            if (id.equals(o.optString("id", null))) return o.optString("status", null);
+        }
+        return null;
+    }
+
     @Test void gatedVisibleIds_returnsOnlyAclPassingSubset() throws Exception {
         java.util.Set<String> requested = new java.util.LinkedHashSet<>(
             java.util.Arrays.asList("ann-0", "ann-1", "ann-hidden"));
@@ -198,9 +207,10 @@ class MediaResolveApiTest {
         assertEquals("up", e.getString("viewpoint"), "viewpoint passed through");
         assertEquals("enc-A", e.getString("encounterId"), "first-parent encounter id");
         assertEquals("ind-A", e.getString("individualId"), "individual id");
+        assertEquals("identified", e.getString("status"), "resolved + has individual -> identified");
     }
 
-    @Test void resolve_omits_unresolvable_and_is_not_an_existence_oracle() throws Exception {
+    @Test void resolve_garbageId_reportsUnavailable_notAnExistenceOracle() throws Exception {
         Annotation good = fullAnnotation("ann-good", "enc-1", "ind-1");
         HttpServletRequest request = tokenRequest();
         HttpServletResponse resp = mock(HttpServletResponse.class);
@@ -224,8 +234,10 @@ class MediaResolveApiTest {
         }
         verify(resp).setStatus(200);
         JSONArray arr = new JSONArray(out.toString());
-        assertEquals(1, arr.length(), "garbage/nonexistent id is silently absent (no existence oracle)");
-        assertEquals("ann-good", arr.getJSONObject(0).getString("id"), "only the resolvable id returned");
+        assertEquals(2, arr.length(), "every requested id is accounted for");
+        assertEquals("identified", statusOf(arr, "ann-good"), "resolvable id -> identified");
+        assertEquals("unavailable", statusOf(arr, "ann-garbage"),
+            "nonexistent id reports 'unavailable' (not a distinct not-found status) -> no existence oracle");
     }
 
     @Test void resolve_dedups_repeated_ids() throws Exception {
@@ -285,8 +297,11 @@ class MediaResolveApiTest {
         }
         verify(resp).setStatus(200);
         JSONArray arr = new JSONArray(out.toString());
-        assertEquals(1, arr.length(), "non-admin sees only gate-passed ids; hidden/garbage absent (no oracle)");
-        assertEquals("ann-vis", arr.getJSONObject(0).getString("id"), "only the visible id resolved");
+        assertEquals(3, arr.length(), "every requested id is accounted for");
+        assertEquals("identified", statusOf(arr, "ann-vis"), "the gate-visible id resolves");
+        assertEquals("unavailable", statusOf(arr, "ann-hidden"), "hidden id -> unavailable");
+        assertEquals("unavailable", statusOf(arr, "ann-garbage"), "garbage id -> unavailable");
+        // hidden and garbage are indistinguishable (both 'unavailable') -> no existence oracle
     }
 
     @Test void resolve_nonAdmin_moreThan10VisibleAllResolve() throws Exception {
@@ -453,8 +468,11 @@ class MediaResolveApiTest {
             new MediaResolveApi().doPostForTest(request, resp);
         }
         verify(resp).setStatus(200);
-        assertEquals(0, new JSONArray(out.toString()).length(),
-            "source webURL throwing -> entry omitted, batch still 200");
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(1, arr.length(), "id accounted for, batch still 200");
+        assertEquals("no_image", statusOf(arr, "ann-x"),
+            "existing annotation whose asset URL is unservable -> no_image (not a transient error)");
+        assertFalse(arr.getJSONObject(0).has("imageUrl"), "no_image entry carries no image reference");
     }
 
     @Test void resolve_emptyEncounterId_serializedAsNull() throws Exception {
@@ -506,7 +524,8 @@ class MediaResolveApiTest {
             new MediaResolveApi().doPostForTest(request, resp);
         }
         verify(resp).setStatus(200);
-        assertEquals(0, new JSONArray(out.toString()).length(), "null bbox -> omit");
+        assertEquals("no_image", statusOf(new JSONArray(out.toString()), "ann-nb"),
+            "existing annotation with null bbox -> no_image");
     }
 
     @Test void resolve_originalSource_servedViaMasterChild() throws Exception {
@@ -654,6 +673,93 @@ class MediaResolveApiTest {
               .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-oob")));
             new MediaResolveApi().doPostForTest(request, resp);
         }
-        assertEquals(0, new JSONArray(out.toString()).length(), "fully out-of-bounds bbox -> omit");
+        assertEquals("no_image", statusOf(new JSONArray(out.toString()), "ann-oob"),
+            "existing annotation with fully out-of-bounds bbox -> no_image");
+    }
+
+    @Test void resolve_visibleButNoIndividual_reportsUnidentified() throws Exception {
+        // resolvable image, but the encounter has no marked individual -> 'unidentified', not an error
+        Annotation ann = fullAnnotation("ann-u", "enc-u", "ind-u");
+        Encounter noIndiv = mock(Encounter.class);
+        when(noIndiv.getId()).thenReturn("enc-u");
+        when(noIndiv.hasMarkedIndividual()).thenReturn(false);
+        when(ann.findEncounter(any(Shepherd.class))).thenReturn(noIndiv);
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin");
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-u")).thenReturn(ann);
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-u")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        JSONArray arr = new JSONArray(out.toString());
+        JSONObject e = arr.getJSONObject(0);
+        assertEquals("unidentified", e.getString("status"), "resolved but no named animal -> unidentified");
+        assertTrue(e.isNull("individualId"), "unidentified entry has null individualId");
+        assertTrue(e.getString("imageUrl").length() > 0, "unidentified still carries the image reference");
+    }
+
+    @Test void batchLevelFailure_before_loop_is_500() throws Exception {
+        // a failure in the pre-loop setup (here: admin check throws) is a batch-level error -> 500,
+        // distinct from a per-ID 'error' inside the loop
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("someone");
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenThrow(new RuntimeException("db down during setup"));
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds", new JSONArray().put("ann-1")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(500);
+    }
+
+    @Test void resolve_transientFailure_reportsError_notAbsent() throws Exception {
+        // getAnnotation throwing for one id -> that id reports 'error' (retryable); batch stays 200
+        Annotation good = fullAnnotation("ann-ok", "enc-ok", "ind-ok");
+        HttpServletRequest request = tokenRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(resp.getWriter()).thenReturn(new PrintWriter(out));
+        try (MockedStatic<ServletUtilities> su = mockStatic(ServletUtilities.class);
+             MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+                 doNothing().when(m).beginDBTransaction();
+                 doNothing().when(m).setAction(anyString());
+                 doNothing().when(m).rollbackAndClose();
+                 User u = mockUser("admin");
+                 when(m.getUser(any(HttpServletRequest.class))).thenReturn(u);
+                 when(u.isAdmin(m)).thenReturn(true);
+                 when(m.getAnnotation("ann-ok")).thenReturn(good);
+                 when(m.getAnnotation("ann-boom")).thenThrow(new RuntimeException("transient db blip"));
+             })) {
+            su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+              .thenReturn(new JSONObject().put("annotationIds",
+                  new JSONArray().put("ann-ok").put("ann-boom")));
+            new MediaResolveApi().doPostForTest(request, resp);
+        }
+        verify(resp).setStatus(200);
+        JSONArray arr = new JSONArray(out.toString());
+        assertEquals(2, arr.length(), "both ids accounted for; one bad id does not 500 the batch");
+        assertEquals("identified", statusOf(arr, "ann-ok"), "the good id still resolves");
+        assertEquals("error", statusOf(arr, "ann-boom"),
+            "a transient failure reports 'error' (retryable), distinct from 'unavailable'");
     }
 }


### PR DESCRIPTION
Part of the API-feedback series (MMF/Sharkbook). `media/resolve` previously **silently omitted** annotation IDs it couldn't resolve, so a caller couldn't tell a legitimate absence from a transient failure — nor an unidentified record from an error (the feedback measured 250 genuinely-unidentified vs 3 transient errors, conflated).

## Change
Return **one entry per unique requested ID**, each with an explicit `status`:
- `identified` — resolved + assigned to a named animal (full image reference).
- `unidentified` — resolved + no `individualId` yet (full image reference; a legitimate state).
- `no_image` — visible & exists but no displayable image.
- `unavailable` — not visible to you **or** does not exist (deliberately indistinguishable).
- `error` — transient failure for this one ID; retry just this ID (with backoff).

A per-ID `try/catch` means one bad ID yields `error` for that ID instead of 500-ing the whole batch; genuine batch-level failures (auth, gate) still 500.

## Security — no-existence-oracle preserved
The original design deliberately made *not-visible* and *not-found* indistinguishable. That's kept: for a non-admin, IDs outside the ACL-gated `visible` set go straight to `unavailable` **with no DB lookup**, so hidden and nonexistent IDs are response-identical; `no_image` is only ever emitted for IDs already proven visible. The test still asserts `getAnnotation` is never called for hidden/garbage IDs.

## Backward-compat
Still a JSON array. Resolved entries gain a `status` field (additive); unresolvable IDs now appear as `{id, status}` stubs instead of being absent. `api-reference.md` updated (incl. worked example) to branch on `status` and only fetch `imageUrl` for `identified`/`unidentified`.

## Testing / review
`MediaResolveApiTest` 24/24 (updated the former silent-omission tests to the status contract; added `unidentified`, `error`, `no_image`, and a batch-level-500 test; oracle/no-DB-load assertions intact) + `AgentSkillContentTest` green. Codex-reviewed (2 rounds, converged; oracle safety explicitly verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
