### PR TITLE
Token search: safe terms aggregations (+ explicit 400 for unsupported aggs)

### DIFF
--- a/docs/superpowers/specs/2026-06-28-token-search-aggregations.md
+++ b/docs/superpowers/specs/2026-06-28-token-search-aggregations.md
@@ -1,0 +1,141 @@
+# Token Search Aggregations — Design
+
+**Date:** 2026-06-28
+**Branch:** `feature/search-aggregations`
+**Driver:** Live API feedback (MMF/Sharkbook) — per-location counts required ~190 separate queries; "one
+server-side terms aggregation on `encounterLocationId` would replace the entire loop." Also: aggregations
+currently **return empty rather than erroring**, which silently misleads callers.
+
+## Problem
+
+`POST /api/v3/search/{index}` forwards the full query body (including `aggs`) to OpenSearch via
+`queryPit`, so OpenSearch *computes* aggregations — but `SearchApi` only reads `queryRes.hits` and never
+surfaces `queryRes.aggregations`. Result: aggregations silently come back empty.
+
+Naively surfacing `aggregations` is unsafe. The token API is a security boundary. Risks:
+1. **Value leak** — a `terms` aggregation's bucket keys expose field *values*. A terms agg on a hidden
+   field (e.g. `viewUsers`, `submitterUserIds`, `gpsLatitude`) would leak data the caller can't see in
+   `_source`.
+2. **Count leak** — bucket `doc_count`s could reveal counts of records the caller can't access.
+3. **Cost** — unbounded bucket counts / `cardinality` / scripted aggs are expensive and a DoS vector.
+
+## Goal
+
+Enable **bounded, ACL-safe `terms` aggregations on an allow-list of non-sensitive fields**, and make any
+other aggregation request an **explicit 400** (never silent empty).
+
+## Design
+
+### Accepted shape (everything else rejected)
+A request may include a top-level `aggs` (or `aggregations`) object. It is accepted only if **every**
+named aggregation is:
+- type **`terms`** only (no `cardinality`, `date_histogram`, `script`, metric aggs, etc.);
+- on a `field` in the per-index **agg allow-list** (below);
+- with optional integer `size` in `[1, AGG_MAX_BUCKETS=1000]` (reject `>max`; if omitted, OpenSearch's
+  own terms default applies — pass an explicit `size` to widen);
+- with **no sub-aggregations** (no nested `aggs` inside a bucket) and **no `script`**.
+
+Any aggregation that is present but violates the above → **HTTP 400** with a specific message
+(e.g. `"aggregation not allowed: only terms on {allowed fields}, size<=1000, no sub-aggs/scripts"`).
+This replaces today's silent-empty behavior.
+
+### Per-index agg allow-list (only fields CONFIRMED explicitly keyword-mapped → terms-aggregatable)
+Verified against `opensearchMapping()`; a dynamically-mapped string becomes `text` (with a `.keyword`
+sub-field) and is NOT directly terms-aggregatable, so such fields are excluded.
+- **encounter**: `locationId`, `taxonomy`, `country`, `lifeStage` (all explicit keyword). *Excluded:*
+  `sex`, `livingStatus` (not explicitly mapped → dynamic `text`).
+- **annotation**: `viewpoint`, `iaClass`, `encounterLocationId`, `encounterTaxonomy` (all explicit
+  keyword). *Excluded:* `matchAgainst` (relies on dynamic boolean mapping; not requested — drop to stay
+  strictly within confirmed-keyword fields).
+- **individual**: `taxonomy`, `sex` (both explicit keyword). For non-admin, individual aggregations are
+  additionally blocked by the existing identity-field gate. Never include identity/PII or ACL fields.
+
+The allow-list is a hard deny-by-default; no field outside it is ever aggregatable. ACL field names
+(`viewUsers`, `editUsers`, `publiclyReadable`, `submitterUserId(s)`) are never on it.
+
+### ACL scoping (the safety hinge)
+For a non-admin token, `applyAclFilter` already wraps the request's `query` clause in a bool whose filter
+enforces the encounter ACL. OpenSearch aggregations run over the **query-matched** documents, so the
+aggregation is automatically scoped to ACL-visible records — **provided** `applyAclFilter` continues to
+wrap only the `query` (leaving `aggs` top-level) and runs BEFORE execution. Validation of the agg shape
+runs first (reject early), then `applyAclFilter`, then execute. Admins are unfiltered (as today).
+
+### Response
+When a valid aggregation ran, surface it: `res.put("aggregations", queryRes.optJSONObject("aggregations"))`.
+Hits are still returned per the caller's `?from=/?size=` URL params (for counts only, pass `?size=0`).
+`X-Wildbook-Total-Hits` continues to reflect the (ACL-scoped) match count.
+
+### Order of operations in SearchApi (token path)
+1. Resolve index (existing allow-list).
+2. Parse body.
+3. **Validate aggregations** (new): if `aggs`/`aggregations` present, enforce the accepted shape → 400 on violation.
+4. Existing non-admin individual identity-field gate (already 400s any `aggs` on individual for non-admin).
+5. `applyAclFilter` for non-admin.
+6. Execute via `queryPit`; surface `hits` + (new) `aggregations`.
+
+## Out of scope (future)
+- Nested/multi-level aggregations; metric aggs (`avg`/`sum`); `date_histogram` (useful for temporal
+  rollups — candidate next); `cardinality` (count-distinct; deferred — leak/cost review needed).
+- A dedicated `/aggregate` endpoint; for now it rides on `search`.
+
+## Testing
+- Valid `terms` on an allowed field → 200, `aggregations` present with buckets; hits honor `size`.
+- `terms` on a **non-allowed** field (e.g. `viewUsers`, `gpsLatitude`) → **400** (value-leak guard).
+- Non-`terms` agg (`cardinality`, `date_histogram`, scripted) → 400.
+- Sub-aggregation present → 400.
+- `size` over max → 400 (or clamp — open question).
+- Non-admin: aggregation runs ACL-filtered — buckets/counts reflect only visible docs (mock OpenSearch
+  to assert the agg request rode alongside the ACL-filtered query; and that `applyAclFilter` wrapped
+  `query` while leaving `aggs` intact).
+- Non-admin **individual** with `aggs` → still 400 via the existing identity gate.
+- No-agg request → unchanged behavior.
+
+## Resolved open questions (design review)
+1. **Size over max → reject with 400, do NOT clamp.** This is a security boundary; silent mutation is
+   harder to reason about.
+2. **Uniform validator for admin too.** Admin token is still the token boundary; one code path. (A
+   broader admin field list can come later.)
+3. **`matchAgainst` excluded** — it relies on dynamic boolean mapping (not an explicit mapping);
+   dropped to stay strictly within confirmed-keyword fields. Revisit if it is ever explicitly mapped.
+
+## Hardening from design review (BINDING — validator must enforce all)
+
+The basic ACL approach is sound (a direct top-level `terms` runs over the ACL-filtered query). The risk
+is validator gaps. The validator is **deny-by-default** and must:
+
+**A. Agg-bearing request → strict whole-body top-level allow-list.** When `aggs`/`aggregations` is
+present, the body's top-level keys must be a subset of `{ query, aggs | aggregations }`. Pagination is
+via the `?from=/?size=` URL params (execution ignores body `from`/`size`), so body `from`/`size` are
+**rejected** on an agg request rather than silently dropped; for counts-only pass `?size=0` on the URL.
+Reject (400) any other top-level key — especially **`runtime_mappings`** (can redefine/script an
+allow-listed field), and also `post_filter`, `script_fields`, `fields`, `_source`, body `sort`,
+`collapse`, `rescore`, `suggest`, caller `pit`, and any unknown key. Reject if BOTH `aggs` and
+`aggregations` are present (ambiguous).
+
+**B. Each named aggregation must be EXACTLY one direct `terms`.** The agg object's keys must be exactly
+`{"terms"}` — no sibling `aggs`/`aggregations` (sub-aggregations), and no other agg type. Explicitly
+reject `global`, `filter`, `filters`, `nested`, `reverse_nested`, `children`, `composite`, pipeline aggs
+(`bucket_*`), and any metric/`script`/`date_histogram`/`cardinality`/`multi_terms`. Do not recursively
+search for a valid terms agg — validate the exact shape.
+
+**C. `terms` params → exact allow-list `{ field, size }` only.** `field` (required, String) must be an
+**exact** member of the per-index allow-list (no `.keyword` suffixes, no root-field/prefix matching).
+Optional `size` must be an integer in `[1, AGG_MAX_BUCKETS=1000]` (>max → 400). Reject every other terms
+param: `script`, `missing`, `include`, `exclude`, `order`, `shard_size`, `min_doc_count`,
+`execution_hint`, `value_type`, `collect_mode`, `meta`, etc.
+
+**D. Validate BEFORE persisting.** Run the validator on the parsed direct-POST body **before**
+`OpenSearch.queryStore`, so invalid agg bodies are never stored.
+
+**E. Scope of the feature.** Validation + surfacing apply on the **tokenAuth path only** (admin: full
+access; non-admin: `applyAclFilter` already wraps `query`, so aggs are ACL-scoped). Non-token callers
+keep today's behavior (aggs not surfaced) — out of scope. Stored-query replay drops aggs in
+`queryScrubStored` (keeps only `query`), so replay can't reintroduce an agg post-validation.
+
+**F. Accepted residual (documented).** An agg-bearing query may still filter its `query` clause on
+arbitrary fields, turning a hidden-field predicate into grouped counts — but only over **ACL-visible**
+docs (the agg never sees docs the filter+ACL exclude), i.e. no wider than what `hits` already expose.
+This is pre-existing token-search query freedom; not widened here.
+
+**Per-field mapping note:** every allow-listed field is a keyword/boolean with doc-values in the
+index mapping (terms-aggregatable). Confirm against `opensearchMapping()` during implementation.

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -1033,6 +1033,89 @@ public class OpenSearch {
     private static final java.util.Set<String> ALLOWED_TOP_LEVEL_KEYS =
         new java.util.HashSet<>(java.util.Arrays.asList("query", "from", "size"));
 
+    // ---- Token search aggregations (deny-by-default; see docs/superpowers/specs/2026-06-28-token-search-aggregations.md)
+    /** Max terms buckets a caller may request. */
+    public static final int AGG_MAX_BUCKETS = 1000;
+    // Only these top-level body keys may accompany an aggregation request (blocks runtime_mappings,
+    // post_filter, script_fields, fields, _source, body sort/from/size, collapse, rescore, suggest,
+    // caller pit, ...). Pagination is via the ?from=/?size= URL params (queryPit ignores body
+    // from/size), so reject body from/size on an agg request rather than silently dropping it; for a
+    // counts-only request pass ?size=0 on the URL.
+    private static final java.util.Set<String> AGG_BODY_TOP_LEVEL = new java.util.HashSet<>(
+        java.util.Arrays.asList("query", "aggs", "aggregations"));
+    // Per-index allow-list of fields a terms aggregation may bucket on. ONLY fields confirmed to be
+    // explicitly keyword-mapped (terms-aggregatable) in opensearchMapping(); never identity/PII/ACL.
+    private static final java.util.Map<String, java.util.Set<String>> AGG_ALLOWED_FIELDS;
+    static {
+        java.util.Map<String, java.util.Set<String>> m = new java.util.HashMap<>();
+        m.put("encounter", new java.util.HashSet<>(java.util.Arrays.asList(
+            "locationId", "taxonomy", "country", "lifeStage")));
+        m.put("annotation", new java.util.HashSet<>(java.util.Arrays.asList(
+            "viewpoint", "iaClass", "encounterLocationId", "encounterTaxonomy")));
+        m.put("individual", new java.util.HashSet<>(java.util.Arrays.asList(
+            "taxonomy", "sex")));
+        AGG_ALLOWED_FIELDS = java.util.Collections.unmodifiableMap(m);
+    }
+
+    /**
+     * Validate an aggregation-bearing token-search body, deny-by-default. Returns null when the body
+     * has NO aggregation (a normal search) OR a fully-valid one; otherwise returns a human-readable
+     * reason to reject with HTTP 400 (so an unsupported aggregation is an explicit error, never a
+     * silent empty result). Permits ONLY a direct `terms` aggregation on an allow-listed keyword field
+     * with an optional bounded integer `size` — no wrappers (global/filter/nested/...), no
+     * sub-aggregations, no pipeline/metric/script aggregations, no extra terms params, and no other
+     * top-level body keys. The caller surfaces `aggregations` from the response only on success.
+     */
+    public static String aggregationError(JSONObject body, String indexName) {
+        if (body == null) return null;
+        boolean hasAggs = body.has("aggs");
+        boolean hasAggregations = body.has("aggregations");
+        if (!hasAggs && !hasAggregations) return null; // no aggregation requested
+        if (hasAggs && hasAggregations) return "specify only one of 'aggs' or 'aggregations'";
+        // (A) strict whole-body top-level allow-list
+        for (String key : body.keySet()) {
+            if (!AGG_BODY_TOP_LEVEL.contains(key)) {
+                return "top-level field '" + key + "' is not allowed alongside an aggregation";
+            }
+        }
+        JSONObject aggs = body.optJSONObject(hasAggs ? "aggs" : "aggregations");
+        if ((aggs == null) || (aggs.length() == 0)) return "aggregation must be a non-empty object";
+        java.util.Set<String> allowedFields = AGG_ALLOWED_FIELDS.get(indexName);
+        if (allowedFields == null) return "aggregations are not supported for this index";
+        for (String name : aggs.keySet()) {
+            JSONObject named = aggs.optJSONObject(name);
+            if (named == null) return "aggregation '" + name + "' must be an object";
+            // (B) exactly one direct 'terms' — no sub-aggs, no wrapper/other agg type
+            if ((named.length() != 1) || !named.has("terms")) {
+                return "aggregation '" + name
+                    + "' must be exactly a 'terms' aggregation (no sub-aggregations or other types)";
+            }
+            JSONObject terms = named.optJSONObject("terms");
+            if (terms == null) return "aggregation '" + name + "' has an invalid 'terms' body";
+            // (C) terms params allow-list: field (required) + optional bounded integer size
+            for (String tk : terms.keySet()) {
+                if (!"field".equals(tk) && !"size".equals(tk)) {
+                    return "terms parameter '" + tk + "' is not allowed (only 'field' and 'size')";
+                }
+            }
+            Object field = terms.opt("field");
+            if (!(field instanceof String) || !allowedFields.contains((String) field)) {
+                return "terms field '" + field + "' is not allowed for index '" + indexName + "'";
+            }
+            if (terms.has("size")) {
+                Object sz = terms.opt("size");
+                long size;
+                if (sz instanceof Integer) size = (Integer) sz;
+                else if (sz instanceof Long) size = (Long) sz;
+                else return "terms 'size' must be an integer";
+                if ((size < 1) || (size > AGG_MAX_BUCKETS)) {
+                    return "terms 'size' must be between 1 and " + AGG_MAX_BUCKETS;
+                }
+            }
+        }
+        return null;
+    }
+
     /**
      * Fail-closed: returns true ONLY if every field the query/sort/aggs could reference is in `allowed`.
      * Used to constrain non-admin token individual searches to identity fields (so a caller can't

--- a/src/main/java/org/ecocean/api/SearchApi.java
+++ b/src/main/java/org/ecocean/api/SearchApi.java
@@ -123,14 +123,25 @@ public class SearchApi extends ApiBase {
                     int pageSize = 10;
                     try { numFrom = Integer.parseInt(fromStr); } catch (Exception ex) {}
                     try { pageSize = Integer.parseInt(sizeStr); } catch (Exception ex) {}
-                    if (query == null) { // must be body (new query, needs storing)
+                    boolean newQueryToStore = false;
+                    String aggError = null;
+                    if (query == null) { // must be body (a new query, stored after it passes all gates)
                         query = ServletUtilities.jsonFromHttpServletRequest(request);
-                        // we store this *before* we sanitize
-                        searchQueryId = OpenSearch.queryStore(query, indexName, currentUser);
+                        // Validate aggregations (token path) up front so an invalid aggregation body
+                        // is rejected (400). Deny-by-default: only a bounded terms agg on an
+                        // allow-listed field is permitted.
+                        if (tokenAuth) aggError = OpenSearch.aggregationError(query, indexName);
+                        // Persist only AFTER all token gates pass (below), so a rejected body is never
+                        // stored, and before applyAclFilter mutates the query.
+                        newQueryToStore = (aggError == null);
                     } else { // stored query, so:
                         indexName = query.optString("indexName", null);
                         query = OpenSearch.queryScrubStored(query);
                     }
+                    if (aggError != null) {
+                        response.setStatus(400);
+                        res.put("error", aggError);
+                    } else {
                     query = OpenSearch.querySanitize(query, currentUser, myShepherd);
                     // Non-admin token individual search may only QUERY/SORT identity fields.
                     // Fail-closed: if we cannot prove the query touches only allowlisted fields,
@@ -148,6 +159,11 @@ public class SearchApi extends ApiBase {
                         response.setStatus(400);
                         res.put("error", "individual token search may only query/sort identity fields");
                     } else {
+                    // all token validation gates passed -> persist the clean new query now (before
+                    // applyAclFilter embeds ACL fields into it); rejected bodies were never stored
+                    if (newQueryToStore) {
+                        searchQueryId = OpenSearch.queryStore(query, indexName, currentUser);
+                    }
                     if (tokenAuth && !isAdmin) {
                         // Java is the hard boundary: scope totals + pagination + hits before execution
                         query = OpenSearch.applyAclFilter(query, currentUser.getId(), indexName);
@@ -186,6 +202,13 @@ public class SearchApi extends ApiBase {
                         res.put("success", true);
                         res.put("searchQueryId", searchQueryId);
                         res.put("hits", hitsArr);
+                        // Surface a (validated, ACL-scoped) aggregation result on the token path.
+                        // Validation gated execution above, so only an allow-listed terms agg reaches
+                        // here; for a non-admin the agg ran over the applyAclFilter-wrapped query.
+                        if (tokenAuth) {
+                            JSONObject aggsOut = queryRes.optJSONObject("aggregations");
+                            if (aggsOut != null) res.put("aggregations", aggsOut);
+                        }
                         // On the token path `query` has been mutated by applyAclFilter to embed the
                         // ACL filter (internal ACL field names + the caller's UUID). Don't echo it back.
                         if (!tokenAuth) res.put("query", query);
@@ -196,6 +219,7 @@ public class SearchApi extends ApiBase {
                         ex.printStackTrace();
                     }
                     } // end individual-token field-gate else
+                    } // end aggError else
                 }
             }
         }

--- a/src/main/resources/agent-skills/api-reference.md
+++ b/src/main/resources/agent-skills/api-reference.md
@@ -33,8 +33,26 @@ fields, which are never returned to you.
 { "query": { "term": { "taxonomy": "Salamandra salamandra" } } }
 ```
 Pagination via `?from=&size=` query params; total hits in the `X-Wildbook-Total-Hits` response header.
-Non-admin `individual` search may only query/sort identity fields. Aggregations, scripted queries, and
-cross-index term lookups are rejected.
+Non-admin `individual` search may only query/sort identity fields. Scripted queries and cross-index
+term lookups are rejected.
+
+**Counting with aggregations.** A single bounded `terms` aggregation is supported — e.g. to count
+records per location without paging them all:
+```json
+{ "query": { "term": { "taxonomy": "Equus quagga" } },
+  "aggs": { "byLoc": { "terms": { "field": "encounterLocationId", "size": 1000 } } } }
+```
+The response includes an `aggregations` object alongside `hits`. Rules (anything else → **400**, never a
+silent empty result):
+- exactly one **`terms`** aggregation per name — no sub-aggregations, no other aggregation type
+  (`cardinality`, `date_histogram`, scripted, pipeline, `global`/`filter`/`nested` wrappers, …);
+- `terms` may set only `field` (required) and integer `size` (1–1000); no `script`/`include`/`order`/etc.;
+- `field` must be one of the allow-listed keyword fields — **encounter**: `locationId`, `taxonomy`,
+  `country`, `lifeStage`; **annotation**: `viewpoint`, `iaClass`, `encounterLocationId`,
+  `encounterTaxonomy`; **individual** (admin): `taxonomy`, `sex`;
+- the only other top-level body key allowed with an aggregation is `query`. For counts only, request
+  `?size=0` (URL param) so no hits are returned. Counts are access-controlled to your account, exactly
+  like `hits`.
 
 ### Media resolve — `POST /api/v3/media/resolve`
 Resolve up to 100 annotation IDs you are allowed to see into displayable image references:

--- a/src/test/java/org/ecocean/OpenSearchAggregationValidatorTest.java
+++ b/src/test/java/org/ecocean/OpenSearchAggregationValidatorTest.java
@@ -1,0 +1,157 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Deny-by-default validator for token-search aggregations (OpenSearch.aggregationError). null == accept
+ * (no agg, or a valid bounded terms agg on an allow-listed field); non-null == reject (400). Guards the
+ * security boundary: only a direct terms aggregation, exact param/field allow-list, no wrappers /
+ * sub-aggs / scripts / runtime_mappings / extra top-level keys.
+ */
+class OpenSearchAggregationValidatorTest {
+
+    private JSONObject terms(String field, Integer size) {
+        JSONObject t = new JSONObject().put("field", field);
+        if (size != null) t.put("size", size.intValue());
+        return t;
+    }
+
+    private JSONObject aggBody(String aggsKey, String name, JSONObject termsBody) {
+        return new JSONObject().put(aggsKey,
+            new JSONObject().put(name, new JSONObject().put("terms", termsBody)));
+    }
+
+    // ---- accept cases (null) ----
+
+    @Test void noAggregation_isAccepted() {
+        assertNull(OpenSearch.aggregationError(new JSONObject().put("query",
+            new JSONObject().put("match_all", new JSONObject())), "encounter"));
+        assertNull(OpenSearch.aggregationError(null, "encounter"));
+    }
+
+    @Test void validTermsOnAllowedField_isAccepted() {
+        assertNull(OpenSearch.aggregationError(aggBody("aggs", "byLoc", terms("locationId", 50)),
+            "encounter"));
+        assertNull(OpenSearch.aggregationError(aggBody("aggregations", "byVp", terms("viewpoint", null)),
+            "annotation"), "the 'aggregations' alias is accepted too");
+        assertNull(OpenSearch.aggregationError(aggBody("aggs", "byTax", terms("taxonomy", 1000)),
+            "individual"), "size at the max is accepted");
+        // an agg alongside a query is fine (pagination is via URL params, not the body)
+        JSONObject withQuery = aggBody("aggs", "byLoc", terms("encounterLocationId", 10))
+            .put("query", new JSONObject().put("term", new JSONObject().put("iaClass", "zebra")));
+        assertNull(OpenSearch.aggregationError(withQuery, "annotation"));
+    }
+
+    @Test void sizeAsLongWithinRange_isAccepted() {
+        JSONObject t = new JSONObject().put("field", "locationId").put("size", 5L);
+        assertNull(OpenSearch.aggregationError(
+            new JSONObject().put("aggs", new JSONObject().put("a", new JSONObject().put("terms", t))),
+            "encounter"));
+    }
+
+    // ---- reject cases (non-null) ----
+
+    @Test void bothAggsAndAggregations_rejected() {
+        JSONObject body = aggBody("aggs", "a", terms("locationId", 5))
+            .put("aggregations", new JSONObject());
+        assertNotNull(OpenSearch.aggregationError(body, "encounter"));
+    }
+
+    @Test void extraTopLevelKey_rejected() {
+        for (String bad : new String[] { "runtime_mappings", "post_filter", "sort", "_source",
+                "script_fields", "fields", "collapse", "pit", "rescore", "suggest", "whatever",
+                "from", "size" }) { // body from/size rejected with aggs (pagination is via URL params)
+            JSONObject body = aggBody("aggs", "a", terms("locationId", 5)).put(bad, new JSONObject());
+            assertNotNull(OpenSearch.aggregationError(body, "encounter"),
+                "top-level '" + bad + "' must be rejected alongside an aggregation");
+        }
+    }
+
+    @Test void subAggregations_rejected() {
+        JSONObject named = new JSONObject()
+            .put("terms", terms("locationId", 5))
+            .put("aggs", new JSONObject().put("sub", new JSONObject().put("terms", terms("taxonomy", 5))));
+        JSONObject body = new JSONObject().put("aggs", new JSONObject().put("a", named));
+        assertNotNull(OpenSearch.aggregationError(body, "encounter"), "sub-aggregations are rejected");
+    }
+
+    @Test void nonTermsAggTypes_rejected() {
+        for (String type : new String[] { "global", "filter", "filters", "nested", "reverse_nested",
+                "cardinality", "date_histogram", "composite", "multi_terms", "avg", "value_count",
+                "significant_terms", "bucket_selector" }) {
+            JSONObject named = new JSONObject().put(type, new JSONObject().put("field", "locationId"));
+            JSONObject body = new JSONObject().put("aggs", new JSONObject().put("a", named));
+            assertNotNull(OpenSearch.aggregationError(body, "encounter"),
+                "non-terms aggregation '" + type + "' must be rejected");
+        }
+    }
+
+    @Test void termsExtraParams_rejected() {
+        for (String param : new String[] { "script", "missing", "include", "exclude", "order",
+                "shard_size", "min_doc_count", "execution_hint", "value_type", "collect_mode" }) {
+            JSONObject t = terms("locationId", 5).put(param, "anything");
+            JSONObject body = new JSONObject().put("aggs", new JSONObject().put("a",
+                new JSONObject().put("terms", t)));
+            assertNotNull(OpenSearch.aggregationError(body, "encounter"),
+                "terms parameter '" + param + "' must be rejected");
+        }
+    }
+
+    @Test void fieldNotOnAllowList_rejected() {
+        for (String field : new String[] { "viewUsers", "submitterUserIds", "gpsLatitude", "sex",
+                "livingStatus", "behavior", "id", "individualId" }) {
+            assertNotNull(OpenSearch.aggregationError(aggBody("aggs", "a", terms(field, 5)), "encounter"),
+                "field '" + field + "' is not on the encounter agg allow-list");
+        }
+    }
+
+    @Test void fieldAllowedOnWrongIndex_rejected() {
+        // locationId is allowed for encounter, not for individual
+        assertNotNull(OpenSearch.aggregationError(aggBody("aggs", "a", terms("locationId", 5)),
+            "individual"));
+        // viewpoint is annotation-only
+        assertNotNull(OpenSearch.aggregationError(aggBody("aggs", "a", terms("viewpoint", 5)),
+            "encounter"));
+    }
+
+    @Test void unsupportedIndex_rejected() {
+        assertNotNull(OpenSearch.aggregationError(aggBody("aggs", "a", terms("locationId", 5)),
+            "occurrence"), "aggregations unsupported for non-allow-listed index");
+    }
+
+    @Test void badSize_rejected() {
+        assertNotNull(OpenSearch.aggregationError(
+            aggBody("aggs", "a", terms("locationId", OpenSearch.AGG_MAX_BUCKETS + 1)), "encounter"),
+            "size over max rejected (no clamp)");
+        assertNotNull(OpenSearch.aggregationError(aggBody("aggs", "a", terms("locationId", 0)),
+            "encounter"), "size 0 rejected");
+        // non-integer size (double / string)
+        JSONObject tDouble = new JSONObject().put("field", "locationId").put("size", 5.5);
+        assertNotNull(OpenSearch.aggregationError(
+            new JSONObject().put("aggs", new JSONObject().put("a",
+                new JSONObject().put("terms", tDouble))), "encounter"), "non-integer size rejected");
+        JSONObject tStr = new JSONObject().put("field", "locationId").put("size", "50");
+        assertNotNull(OpenSearch.aggregationError(
+            new JSONObject().put("aggs", new JSONObject().put("a",
+                new JSONObject().put("terms", tStr))), "encounter"), "string size rejected");
+    }
+
+    @Test void nonStringField_rejected() {
+        JSONObject t = new JSONObject().put("field", 5).put("size", 5);
+        assertNotNull(OpenSearch.aggregationError(
+            new JSONObject().put("aggs", new JSONObject().put("a", new JSONObject().put("terms", t))),
+            "encounter"), "non-string field rejected");
+        JSONObject tMissing = new JSONObject().put("size", 5); // no field
+        assertNotNull(OpenSearch.aggregationError(
+            new JSONObject().put("aggs", new JSONObject().put("a",
+                new JSONObject().put("terms", tMissing))), "encounter"), "missing field rejected");
+    }
+
+    @Test void emptyAggObject_rejected() {
+        assertNotNull(OpenSearch.aggregationError(new JSONObject().put("aggs", new JSONObject()),
+            "encounter"), "empty aggs object rejected");
+    }
+}

--- a/src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java
@@ -277,4 +277,56 @@ class SearchApiTokenAuthTest {
         }
         verify(response).setStatus(200);
     }
+
+    @Test void tokenAgg_validTerms_surfacesAggregations_aclScoped_aggsTopLevel() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/annotation");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any())).thenReturn(new JSONObject(
+            "{\"query\":{\"term\":{\"iaClass\":\"zebra\"}},"
+            + "\"aggs\":{\"byLoc\":{\"terms\":{\"field\":\"encounterLocationId\",\"size\":10}}}}"));
+        User user = mockUser("u1", false);
+        JSONObject withAggs = new JSONObject(
+            "{\"hits\":{\"total\":{\"value\":3},\"hits\":[]},"
+            + "\"aggregations\":{\"byLoc\":{\"buckets\":[{\"key\":\"SiteA\",\"doc_count\":2}]}}}");
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenAnswer(inv -> {
+                        JSONObject q = inv.getArgument(1);
+                        assertTrue(q.has("aggs"), "aggs left top-level for OpenSearch to compute");
+                        assertTrue(q.getJSONObject("query").getJSONObject("bool").has("filter"),
+                            "non-admin aggregation runs over the ACL-filtered query");
+                        return withAggs;
+                    });
+            })) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+        JSONObject res = new JSONObject(out.toString());
+        assertTrue(res.has("aggregations"), "valid aggregation is surfaced to the caller");
+        assertEquals("SiteA", res.getJSONObject("aggregations").getJSONObject("byLoc")
+            .getJSONArray("buckets").getJSONObject(0).getString("key"));
+    }
+
+    @Test void tokenAgg_disallowedField_returns400_andNotExecuted() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any())).thenReturn(new JSONObject(
+            "{\"aggs\":{\"leak\":{\"terms\":{\"field\":\"viewUsers\"}}}}"));
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) ->
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(), any(), any()))
+                    .thenReturn(EMPTY_HITS))) {
+            new SearchApi().doPost(request, response);
+            assertTrue(os.constructed().isEmpty(),
+                "an invalid aggregation is rejected before any OpenSearch execution");
+        }
+        verify(response).setStatus(400);
+        assertFalse(new JSONObject(out.toString()).optString("error", "").isEmpty(),
+            "400 carries an explanatory error");
+    }
 }


### PR DESCRIPTION
Part of the API-feedback series (MMF/Sharkbook). Token search forwarded `aggs` to OpenSearch but `SearchApi` never surfaced the `aggregations` result, so aggregations silently came back **empty** — the feedback needed ~190 separate queries to get per-location counts.

## Change — bounded, ACL-safe `terms` aggregations (deny-by-default)
`OpenSearch.aggregationError()` validates an agg-bearing token body; `SearchApi` surfaces the result on success and returns an explicit **400** otherwise (no more silent empty).

Permitted: exactly one **`terms`** aggregation per name, on a per-index allow-list of **confirmed keyword fields** — encounter `locationId/taxonomy/country/lifeStage`; annotation `viewpoint/iaClass/encounterLocationId/encounterTaxonomy`; individual (admin) `taxonomy/sex` — with only `field` + integer `size` (1–1000). Rejected (400): any other agg type, sub-aggregations, pipeline/metric/script aggs, `global`/`filter`/`nested` wrappers, extra `terms` params, `runtime_mappings` or any other top-level body key, and both `aggs`+`aggregations`.

## Security
- **No value/count leak:** validated before storing; runs on the token path; for a non-admin the agg rides the `applyAclFilter`-wrapped query (which re-copies the body and replaces only `query`, leaving `aggs` top-level), so buckets and counts are ACL-scoped. Field allow-list is confirmed-keyword only; never identity/PII/ACL fields.
- **Rejected bodies are never stored** (store deferred until after all token gates pass, before `applyAclFilter`).
- Pagination stays on `?from=/?size=` URL params (body `from`/`size` rejected with aggs); for counts-only pass `?size=0`.

## Process / tests
Design **Codex-reviewed first** (spec at `docs/superpowers/specs/2026-06-28-token-search-aggregations.md`), then code Codex-reviewed (2 rounds, converged). `OpenSearchAggregationValidatorTest` (14: escape hatches, field/param/size/index allow-lists, aliases, top-level keys) + 2 `SearchApiTokenAuthTest` integration tests (valid agg surfaced & ACL-scoped with aggs top-level; disallowed field → 400, not executed). All green.

## Merge note
Updates the `agent-skills/api-reference.md` aggregations text. This **supersedes** the "aggregations are not supported / silently empty" note in PR #1644; if #1644 merges first, resolve the api-reference conflict in favor of this PR's "supported" text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
