### PR TITLE
Fix MiewID vector matching on OpenSearch 3.x (HNSW engine + de-nest for filtered ANN)

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -310,11 +310,12 @@ public class Annotation extends Base implements java.io.Serializable {
                     matchEmb = emb;
                     continue;
                 }
-                if (emb.getCreated() > matchEmb.getCreated()) {
-                    matchEmb = emb;
-                } else if ((emb.getCreated() == matchEmb.getCreated())
-                    && (emb.getId() != null) && (matchEmb.getId() != null)
-                    && (emb.getId().compareTo(matchEmb.getId()) > 0)) {
+                // Total order: created desc, then a null-safe id/method/version
+                // key desc, so selection is deterministic even when created ties
+                // and an id is null (HashSet iteration order never decides).
+                if (emb.getCreated() > matchEmb.getCreated()
+                    || (emb.getCreated() == matchEmb.getCreated()
+                        && embeddingSortKey(emb).compareTo(embeddingSortKey(matchEmb)) > 0)) {
                     matchEmb = emb;
                 }
             }
@@ -330,6 +331,15 @@ public class Annotation extends Base implements java.io.Serializable {
             }
             jgen.writeEndArray();
         }
+    }
+
+    // Stable, null-safe key for choosing the deterministic top-level match
+    // embedding when created timestamps tie (see opensearchDocumentSerializer).
+    private static String embeddingSortKey(Embedding emb) {
+        String id = (emb.getId() == null) ? "" : emb.getId();
+        String method = (emb.getMethod() == null) ? "" : emb.getMethod();
+        String version = (emb.getMethodVersion() == null) ? "" : emb.getMethodVersion();
+        return id + "|" + method + "|" + version;
     }
 
     // TODO should this also be limited by matchAgainst and acmId?

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -199,7 +199,21 @@ public class Annotation extends Base implements java.io.Serializable {
         // https://docs.opensearch.org/docs/latest/vector-search/creating-vector-index/
         embVect.put("type", "knn_vector");
         embVect.put("dimension", Embedding.getVectorDimension());
-        embVect.put("space_type", "cosinesimil");
+        // An explicit HNSW method is REQUIRED: without it, OpenSearch builds no
+        // approximate-nearest-neighbor graph and every kNN match silently
+        // degrades to an exact brute-force scan. On a large annotation corpus
+        // that scan exceeds the match query timeout, getMatches() swallows the
+        // failure, and identification returns 0 prospects. OpenSearch 3.x also
+        // removed the nmslib engine, so an index relying on the old default
+        // loses its graph on upgrade. The Lucene engine supports cosinesimil at
+        // this dimension and preserves the (1 + cos) / 2 score that
+        // osHitScore() relies on for vector/WBIA-MiewID parity. (space_type is
+        // set inside method for compatibility across OpenSearch 2.x and 3.x.)
+        JSONObject embVectMethod = new JSONObject();
+        embVectMethod.put("name", "hnsw");
+        embVectMethod.put("engine", "lucene");
+        embVectMethod.put("space_type", "cosinesimil");
+        embVect.put("method", embVectMethod);
         embProps.put("vector", embVect);
         embMap.put("properties", embProps);
         map.put("embeddings", embMap);

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -156,7 +156,10 @@ public class Annotation extends Base implements java.io.Serializable {
     }
 
     public long setVersion() {
-        version = System.currentTimeMillis();
+        // Monotonic: the OpenSearch reconciler treats an annotation as stale only when DB version is
+        // strictly greater than the indexed version, so two bumps within the same millisecond must
+        // still advance the value (otherwise a change could silently fail to reindex).
+        version = Math.max(version + 1, System.currentTimeMillis());
         return version;
     }
 
@@ -179,6 +182,8 @@ public class Annotation extends Base implements java.io.Serializable {
         map.put("encounterLocationId", keywordType);
         map.put("encounterTaxonomy", keywordType);
         map.put("encounterProjectIds", keywordType);
+        // parent encounter's sighting date, denormalized so temporal analyses need no encounter join
+        map.put("encounterDateMillis", new JSONObject("{\"type\": \"date\", \"format\": \"epoch_millis\"}"));
 
         // ACL fields (viewUsers is inherited from Base.opensearchMapping())
         map.put("publiclyReadable", new JSONObject("{\"type\": \"boolean\"}"));
@@ -195,39 +200,14 @@ public class Annotation extends Base implements java.io.Serializable {
         JSONObject embProps = new JSONObject();
         embProps.put("method", keywordType);
         embProps.put("methodVersion", keywordType);
-        // NOTE: embeddings.vector is deliberately NOT mapped. The serializer
-        // still writes it, so with dynamic:false it remains in _source for API
-        // consumers that read vectors directly (e.g. agent-skill diagnostics)
-        // -- but it is not indexed, so NO per-nested HNSW graph is built. The
-        // searchable copy is the top-level "vector" field below: a *nested*
-        // knn_vector cannot do filtered ANN (any filter forces an exact
-        // brute-force scan), so matching must run on a top-level field.
+        JSONObject embVect = new JSONObject();
+        // https://docs.opensearch.org/docs/latest/vector-search/creating-vector-index/
+        embVect.put("type", "knn_vector");
+        embVect.put("dimension", Embedding.getVectorDimension());
+        embVect.put("space_type", "cosinesimil");
+        embProps.put("vector", embVect);
         embMap.put("properties", embProps);
         map.put("embeddings", embMap);
-
-        // Top-level matchable vector, denormalized from the annotation's match
-        // embedding (see opensearchDocumentSerializer). A top-level (non-nested)
-        // knn_vector with an explicit HNSW method supports Lucene "efficient
-        // filtering", so the filtered identification query stays on the ANN graph
-        // (milliseconds) instead of degrading to an exact scan (tens of seconds,
-        // which trips the OpenSearch client socket timeout -> 0 prospects). The
-        // explicit engine is also required on OpenSearch 3.x, which removed the
-        // nmslib default. Lucene supports cosinesimil at this dimension and
-        // yields the (1 + cos) / 2 score osHitScore() consumes unchanged.
-        // Lucene engine requires OpenSearch 2.3+; Wildbook targets 2.3+/3.x.
-        JSONObject matchVect = new JSONObject();
-        matchVect.put("type", "knn_vector");
-        matchVect.put("dimension", Embedding.getVectorDimension());
-        JSONObject matchVectMethod = new JSONObject();
-        matchVectMethod.put("name", "hnsw");
-        matchVectMethod.put("engine", "lucene");
-        matchVectMethod.put("space_type", "cosinesimil");
-        matchVect.put("method", matchVectMethod);
-        map.put("vector", matchVect);
-        // method/version of the denormalized vector, so the match query can
-        // filter on them at the top level (alongside the candidate filters).
-        map.put("embeddingMethod", keywordType);
-        map.put("embeddingMethodVersion", keywordType);
 
         return map;
     }
@@ -250,6 +230,10 @@ public class Annotation extends Base implements java.io.Serializable {
             jgen.writeStringField("encounterSubmitterId", enc.getSubmitterID());
             jgen.writeStringField("encounterLocationId", enc.getLocationID());
             jgen.writeStringField("encounterTaxonomy", enc.getTaxonomyString());
+            // denormalize the sighting date so temporal re-ID analyses avoid a second round-trip to
+            // the encounter index (mirrors Encounter's own dateMillis serialization)
+            Long encDateMillis = enc.getDateInMillisecondsFallback();
+            if (encDateMillis != null) jgen.writeNumberField("encounterDateMillis", encDateMillis);
             // per discussion on issue 874, including this in indexing, but not (yet) using in matchingSet
             jgen.writeStringField("encounterLivingStatus", enc.getLivingStatus());
             User owner = enc.getSubmitterUser(myShepherd);
@@ -290,56 +274,6 @@ public class Annotation extends Base implements java.io.Serializable {
                 jgen.writeEndObject();
             }
         jgen.writeEndArray();
-
-        // Denormalize ONE match embedding to top-level fields so identification
-        // can run filtered ANN on the graph (nested vectors can't -- see
-        // opensearchMapping). embeddings is a Set, so iteration order is not
-        // stable; pick deterministically -- the most recently created embedding
-        // that carries a vector (newest model wins), tie-broken by id. The
-        // top-level vector and its embeddingMethod/embeddingMethodVersion are
-        // written together, so they are always self-consistent: a match query
-        // filtering on a given method/version simply won't hit annotations whose
-        // chosen top-level embedding is a different method. (Today annotations
-        // carry a single miewid/msv4.1 embedding; per-method top-level vectors
-        // would be needed only if multiple match methods coexist per annotation.)
-        Embedding matchEmb = null;
-        if (this.embeddings != null) {
-            for (Embedding emb : this.embeddings) {
-                if ((emb.vectorToFloatArray() == null) || (emb.vectorLength() < 1)) continue;
-                if (matchEmb == null) {
-                    matchEmb = emb;
-                    continue;
-                }
-                // Total order: created desc, then a null-safe id/method/version
-                // key desc, so selection is deterministic even when created ties
-                // and an id is null (HashSet iteration order never decides).
-                if (emb.getCreated() > matchEmb.getCreated()
-                    || (emb.getCreated() == matchEmb.getCreated()
-                        && embeddingSortKey(emb).compareTo(embeddingSortKey(matchEmb)) > 0)) {
-                    matchEmb = emb;
-                }
-            }
-        }
-        if (matchEmb != null) {
-            jgen.writeStringField("embeddingMethod", matchEmb.getMethod());
-            jgen.writeStringField("embeddingMethodVersion", matchEmb.getMethodVersion());
-            float[] matchVec = matchEmb.vectorToFloatArray();
-            jgen.writeFieldName("vector");
-            jgen.writeStartArray();
-            for (int i = 0; i < matchVec.length; i++) {
-                jgen.writeNumber(matchVec[i]);
-            }
-            jgen.writeEndArray();
-        }
-    }
-
-    // Stable, null-safe key for choosing the deterministic top-level match
-    // embedding when created timestamps tie (see opensearchDocumentSerializer).
-    private static String embeddingSortKey(Embedding emb) {
-        String id = (emb.getId() == null) ? "" : emb.getId();
-        String method = (emb.getMethod() == null) ? "" : emb.getMethod();
-        String version = (emb.getMethodVersion() == null) ? "" : emb.getMethodVersion();
-        return id + "|" + method + "|" + version;
     }
 
     // TODO should this also be limited by matchAgainst and acmId?
@@ -1248,40 +1182,39 @@ public class Annotation extends Base implements java.io.Serializable {
         Embedding emb = getEmbeddingByMethod(method, methodVersion);
 
         if (emb == null) return null;
-        // We work on a copy here so we don't modify matchingSetQuery.
-        // matchingSetQuery is {"query": {"bool": {"filter": [...], "must_not": [...]}}}.
+        // we work on a copy here so we dont modify matchingSetQuery
         JSONObject mq = new JSONObject(matchingSetQuery.toString());
-        JSONObject boolQuery = mq.getJSONObject("query").getJSONObject("bool");
-        // method/methodVersion are denormalized to top-level keyword fields
-        // (embeddingMethod/embeddingMethodVersion), so they are ordinary filter
-        // terms alongside the other candidate filters. (Previously these were
-        // nested embeddings.method/methodVersion terms.) Built via put() rather
-        // than string interpolation.
+        JSONObject nested = new JSONObject(
+            "{\"nested\": {\"path\": \"embeddings\", \"query\": {\"bool\": {}}}}");
+        // Inside the nested bool, keep ONLY the knn clause in `must` so the
+        // per-hit score is exactly the OS knn similarity (no spurious
+        // +1.0-per-term-clause offset). method/methodVersion become
+        // `filter` clauses — they still constrain results but contribute
+        // 0 to score. (Empty-match-prospects C17: MiewID score parity.)
+        JSONArray must = new JSONArray();
+        JSONObject knn = new JSONObject("{\"knn\": {\"embeddings.vector\": {}}}");
+        knn.getJSONObject("knn").getJSONObject("embeddings.vector").put("vector",
+            new JSONArray(emb.vectorToFloatArray()));
+        knn.getJSONObject("knn").getJSONObject("embeddings.vector").put("k", KNN_K_DISTANCE_VALUE);
+        must.put(knn);
+        JSONArray filter = new JSONArray();
         if (method != null)
-            boolQuery.getJSONArray("filter").put(new JSONObject().put("term",
-                new JSONObject().put("embeddingMethod", method)));
+            filter.put(new JSONObject("{\"term\": {\"embeddings.method\":\"" + method + "\"}}"));
         if (methodVersion != null)
-            boolQuery.getJSONArray("filter").put(new JSONObject().put("term",
-                new JSONObject().put("embeddingMethodVersion", methodVersion)));
-        // Query the top-level "vector" field (NOT nested embeddings.vector): a
-        // nested knn_vector can't do filtered ANN and degrades to an exact scan.
-        // We pass the full candidate bool as the knn `filter` so Lucene's
-        // "efficient filtering" keeps the search on the HNSW graph. The OS knn
-        // _score is cosinesimil (1+cos)/2, consumed unchanged by osHitScore().
-        JSONObject knnVector = new JSONObject();
-        knnVector.put("vector", new JSONArray(emb.vectorToFloatArray()));
-        knnVector.put("k", KNN_K_DISTANCE_VALUE);
-        knnVector.put("filter", mq.getJSONObject("query"));
-        JSONObject knn = new JSONObject();
-        knn.put("knn", new JSONObject().put("vector", knnVector));
-        JSONObject result = new JSONObject();
-        result.put("query", knn);
-        // getMatches() only reads _id and _score, so suppress _source -- without
-        // this each of the k hits would return its (large) top-level + nested
-        // vectors. (The previous nested query inherited a _source exclusion from
-        // matchingSetQuery; this rebuild sets it explicitly.)
-        result.put("_source", false);
-        return result;
+            filter.put(new JSONObject("{\"term\": {\"embeddings.methodVersion\":\"" + methodVersion +
+                "\"}}"));
+        nested.getJSONObject("nested").getJSONObject("query").getJSONObject("bool").put("must",
+            must);
+        if (filter.length() > 0) {
+            nested.getJSONObject("nested").getJSONObject("query").getJSONObject("bool").put(
+                "filter", filter);
+        }
+
+        // we put nested under its own top-level must, that way its score counts (whereas filter does not)
+        JSONArray nestedMust = new JSONArray();
+        nestedMust.put(nested);
+        mq.getJSONObject("query").getJSONObject("bool").put("must", nestedMust);
+        return mq;
     }
 
     /**
@@ -1983,6 +1916,8 @@ public class Annotation extends Base implements java.io.Serializable {
                 " deleting " + emb);
             myShepherd.getPM().deletePersistent(emb);
         }
+        // bump version so the reconciler reindexes and the now-removed vector(s) leave the _source
+        this.setVersion();
         return rtn;
     }
 
@@ -2167,8 +2102,17 @@ public class Annotation extends Base implements java.io.Serializable {
     public Set<Embedding> addEmbedding(Embedding emb) {
         if (embeddings == null) embeddings = new HashSet<Embedding>();
         if (emb == null) return embeddings;
-        embeddings.add(emb);
-        if (!this.equals(emb.getAnnotation())) emb.setAnnotation(this);
+        boolean added = embeddings.add(emb);
+        boolean linked = false;
+        if (!this.equals(emb.getAnnotation())) {
+            emb.setAnnotation(this);
+            linked = true;
+        }
+        // bump version only on a real change so the OpenSearch reconciler reindexes this annotation
+        // and writes the embedding vector into the document _source (otherwise the vector is
+        // kNN-searchable but never surfaces in the token-readable _source). Skipping no-op duplicate
+        // adds avoids needless reconciler churn.
+        if (added || linked) this.setVersion();
         return embeddings;
     }
 

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -195,30 +195,44 @@ public class Annotation extends Base implements java.io.Serializable {
         JSONObject embProps = new JSONObject();
         embProps.put("method", keywordType);
         embProps.put("methodVersion", keywordType);
+        // The nested embeddings.vector is retained in _source for API consumers
+        // (e.g. the agent-skill diagnostics that read vectors directly), but it
+        // is NOT the field the matcher searches: a *nested* knn_vector cannot do
+        // filtered ANN -- any filter (viewpoint/iaClass/method/version) forces an
+        // exact brute-force scan. The matchable copy is denormalized to the
+        // top-level "vector" field below, where filtered ANN stays on the graph.
         JSONObject embVect = new JSONObject();
         // https://docs.opensearch.org/docs/latest/vector-search/creating-vector-index/
         embVect.put("type", "knn_vector");
         embVect.put("dimension", Embedding.getVectorDimension());
-        // An explicit HNSW method is REQUIRED: without it, OpenSearch builds no
-        // approximate-nearest-neighbor graph and every kNN match silently
-        // degrades to an exact brute-force scan. On a large annotation corpus
-        // that scan exceeds the match query timeout, getMatches() swallows the
-        // failure, and identification returns 0 prospects. OpenSearch 3.x also
-        // removed the nmslib engine, so an index relying on the old default
-        // loses its graph on upgrade. The Lucene engine supports cosinesimil at
-        // this dimension and preserves the (1 + cos) / 2 score that
-        // osHitScore() relies on for vector/WBIA-MiewID parity. (space_type is
-        // set inside method, which is valid both there and at field level. The
-        // Lucene engine requires OpenSearch 2.3+; earlier 2.x offered only
-        // nmslib/faiss. Wildbook targets 2.3+/3.x, so this is safe.)
-        JSONObject embVectMethod = new JSONObject();
-        embVectMethod.put("name", "hnsw");
-        embVectMethod.put("engine", "lucene");
-        embVectMethod.put("space_type", "cosinesimil");
-        embVect.put("method", embVectMethod);
+        embVect.put("space_type", "cosinesimil");
         embProps.put("vector", embVect);
         embMap.put("properties", embProps);
         map.put("embeddings", embMap);
+
+        // Top-level matchable vector, denormalized from the annotation's match
+        // embedding (see opensearchDocumentSerializer). A top-level (non-nested)
+        // knn_vector with an explicit HNSW method supports Lucene "efficient
+        // filtering", so the filtered identification query stays on the ANN graph
+        // (milliseconds) instead of degrading to an exact scan (tens of seconds,
+        // which trips the OpenSearch client socket timeout -> 0 prospects). The
+        // explicit engine is also required on OpenSearch 3.x, which removed the
+        // nmslib default. Lucene supports cosinesimil at this dimension and
+        // yields the (1 + cos) / 2 score osHitScore() consumes unchanged.
+        // Lucene engine requires OpenSearch 2.3+; Wildbook targets 2.3+/3.x.
+        JSONObject matchVect = new JSONObject();
+        matchVect.put("type", "knn_vector");
+        matchVect.put("dimension", Embedding.getVectorDimension());
+        JSONObject matchVectMethod = new JSONObject();
+        matchVectMethod.put("name", "hnsw");
+        matchVectMethod.put("engine", "lucene");
+        matchVectMethod.put("space_type", "cosinesimil");
+        matchVect.put("method", matchVectMethod);
+        map.put("vector", matchVect);
+        // method/version of the denormalized vector, so the match query can
+        // filter on them at the top level (alongside the candidate filters).
+        map.put("embeddingMethod", keywordType);
+        map.put("embeddingMethodVersion", keywordType);
 
         return map;
     }
@@ -281,6 +295,31 @@ public class Annotation extends Base implements java.io.Serializable {
                 jgen.writeEndObject();
             }
         jgen.writeEndArray();
+
+        // Denormalize the match embedding to top-level fields so identification
+        // can run filtered ANN on the graph (nested vectors can't -- see
+        // opensearchMapping). Use the first embedding that carries a vector;
+        // in practice an annotation has a single (miewid/msv4.1) embedding.
+        Embedding matchEmb = null;
+        if (this.embeddings != null) {
+            for (Embedding emb : this.embeddings) {
+                if ((emb.vectorToFloatArray() != null) && (emb.vectorLength() > 0)) {
+                    matchEmb = emb;
+                    break;
+                }
+            }
+        }
+        if (matchEmb != null) {
+            jgen.writeStringField("embeddingMethod", matchEmb.getMethod());
+            jgen.writeStringField("embeddingMethodVersion", matchEmb.getMethodVersion());
+            float[] matchVec = matchEmb.vectorToFloatArray();
+            jgen.writeFieldName("vector");
+            jgen.writeStartArray();
+            for (int i = 0; i < matchVec.length; i++) {
+                jgen.writeNumber(matchVec[i]);
+            }
+            jgen.writeEndArray();
+        }
     }
 
     // TODO should this also be limited by matchAgainst and acmId?
@@ -1189,39 +1228,34 @@ public class Annotation extends Base implements java.io.Serializable {
         Embedding emb = getEmbeddingByMethod(method, methodVersion);
 
         if (emb == null) return null;
-        // we work on a copy here so we dont modify matchingSetQuery
+        // We work on a copy here so we don't modify matchingSetQuery.
+        // matchingSetQuery is {"query": {"bool": {"filter": [...], "must_not": [...]}}}.
         JSONObject mq = new JSONObject(matchingSetQuery.toString());
-        JSONObject nested = new JSONObject(
-            "{\"nested\": {\"path\": \"embeddings\", \"query\": {\"bool\": {}}}}");
-        // Inside the nested bool, keep ONLY the knn clause in `must` so the
-        // per-hit score is exactly the OS knn similarity (no spurious
-        // +1.0-per-term-clause offset). method/methodVersion become
-        // `filter` clauses — they still constrain results but contribute
-        // 0 to score. (Empty-match-prospects C17: MiewID score parity.)
-        JSONArray must = new JSONArray();
-        JSONObject knn = new JSONObject("{\"knn\": {\"embeddings.vector\": {}}}");
-        knn.getJSONObject("knn").getJSONObject("embeddings.vector").put("vector",
-            new JSONArray(emb.vectorToFloatArray()));
-        knn.getJSONObject("knn").getJSONObject("embeddings.vector").put("k", KNN_K_DISTANCE_VALUE);
-        must.put(knn);
-        JSONArray filter = new JSONArray();
+        JSONObject boolQuery = mq.getJSONObject("query").getJSONObject("bool");
+        // method/methodVersion are denormalized to top-level keyword fields
+        // (embeddingMethod/embeddingMethodVersion), so they are ordinary filter
+        // terms alongside the other candidate filters. (Previously these were
+        // nested embeddings.method/methodVersion terms.)
         if (method != null)
-            filter.put(new JSONObject("{\"term\": {\"embeddings.method\":\"" + method + "\"}}"));
+            boolQuery.getJSONArray("filter").put(
+                new JSONObject("{\"term\": {\"embeddingMethod\":\"" + method + "\"}}"));
         if (methodVersion != null)
-            filter.put(new JSONObject("{\"term\": {\"embeddings.methodVersion\":\"" + methodVersion +
-                "\"}}"));
-        nested.getJSONObject("nested").getJSONObject("query").getJSONObject("bool").put("must",
-            must);
-        if (filter.length() > 0) {
-            nested.getJSONObject("nested").getJSONObject("query").getJSONObject("bool").put(
-                "filter", filter);
-        }
-
-        // we put nested under its own top-level must, that way its score counts (whereas filter does not)
-        JSONArray nestedMust = new JSONArray();
-        nestedMust.put(nested);
-        mq.getJSONObject("query").getJSONObject("bool").put("must", nestedMust);
-        return mq;
+            boolQuery.getJSONArray("filter").put(
+                new JSONObject("{\"term\": {\"embeddingMethodVersion\":\"" + methodVersion + "\"}}"));
+        // Query the top-level "vector" field (NOT nested embeddings.vector): a
+        // nested knn_vector can't do filtered ANN and degrades to an exact scan.
+        // We pass the full candidate bool as the knn `filter` so Lucene's
+        // "efficient filtering" keeps the search on the HNSW graph. The OS knn
+        // _score is cosinesimil (1+cos)/2, consumed unchanged by osHitScore().
+        JSONObject knnVector = new JSONObject();
+        knnVector.put("vector", new JSONArray(emb.vectorToFloatArray()));
+        knnVector.put("k", KNN_K_DISTANCE_VALUE);
+        knnVector.put("filter", mq.getJSONObject("query"));
+        JSONObject knn = new JSONObject();
+        knn.put("knn", new JSONObject().put("vector", knnVector));
+        JSONObject result = new JSONObject();
+        result.put("query", knn);
+        return result;
     }
 
     /**

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -208,7 +208,9 @@ public class Annotation extends Base implements java.io.Serializable {
         // loses its graph on upgrade. The Lucene engine supports cosinesimil at
         // this dimension and preserves the (1 + cos) / 2 score that
         // osHitScore() relies on for vector/WBIA-MiewID parity. (space_type is
-        // set inside method for compatibility across OpenSearch 2.x and 3.x.)
+        // set inside method, which is valid both there and at field level. The
+        // Lucene engine requires OpenSearch 2.3+; earlier 2.x offered only
+        // nmslib/faiss. Wildbook targets 2.3+/3.x, so this is safe.)
         JSONObject embVectMethod = new JSONObject();
         embVectMethod.put("name", "hnsw");
         embVectMethod.put("engine", "lucene");

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -195,18 +195,13 @@ public class Annotation extends Base implements java.io.Serializable {
         JSONObject embProps = new JSONObject();
         embProps.put("method", keywordType);
         embProps.put("methodVersion", keywordType);
-        // The nested embeddings.vector is retained in _source for API consumers
-        // (e.g. the agent-skill diagnostics that read vectors directly), but it
-        // is NOT the field the matcher searches: a *nested* knn_vector cannot do
-        // filtered ANN -- any filter (viewpoint/iaClass/method/version) forces an
-        // exact brute-force scan. The matchable copy is denormalized to the
-        // top-level "vector" field below, where filtered ANN stays on the graph.
-        JSONObject embVect = new JSONObject();
-        // https://docs.opensearch.org/docs/latest/vector-search/creating-vector-index/
-        embVect.put("type", "knn_vector");
-        embVect.put("dimension", Embedding.getVectorDimension());
-        embVect.put("space_type", "cosinesimil");
-        embProps.put("vector", embVect);
+        // NOTE: embeddings.vector is deliberately NOT mapped. The serializer
+        // still writes it, so with dynamic:false it remains in _source for API
+        // consumers that read vectors directly (e.g. agent-skill diagnostics)
+        // -- but it is not indexed, so NO per-nested HNSW graph is built. The
+        // searchable copy is the top-level "vector" field below: a *nested*
+        // knn_vector cannot do filtered ANN (any filter forces an exact
+        // brute-force scan), so matching must run on a top-level field.
         embMap.put("properties", embProps);
         map.put("embeddings", embMap);
 
@@ -296,16 +291,31 @@ public class Annotation extends Base implements java.io.Serializable {
             }
         jgen.writeEndArray();
 
-        // Denormalize the match embedding to top-level fields so identification
+        // Denormalize ONE match embedding to top-level fields so identification
         // can run filtered ANN on the graph (nested vectors can't -- see
-        // opensearchMapping). Use the first embedding that carries a vector;
-        // in practice an annotation has a single (miewid/msv4.1) embedding.
+        // opensearchMapping). embeddings is a Set, so iteration order is not
+        // stable; pick deterministically -- the most recently created embedding
+        // that carries a vector (newest model wins), tie-broken by id. The
+        // top-level vector and its embeddingMethod/embeddingMethodVersion are
+        // written together, so they are always self-consistent: a match query
+        // filtering on a given method/version simply won't hit annotations whose
+        // chosen top-level embedding is a different method. (Today annotations
+        // carry a single miewid/msv4.1 embedding; per-method top-level vectors
+        // would be needed only if multiple match methods coexist per annotation.)
         Embedding matchEmb = null;
         if (this.embeddings != null) {
             for (Embedding emb : this.embeddings) {
-                if ((emb.vectorToFloatArray() != null) && (emb.vectorLength() > 0)) {
+                if ((emb.vectorToFloatArray() == null) || (emb.vectorLength() < 1)) continue;
+                if (matchEmb == null) {
                     matchEmb = emb;
-                    break;
+                    continue;
+                }
+                if (emb.getCreated() > matchEmb.getCreated()) {
+                    matchEmb = emb;
+                } else if ((emb.getCreated() == matchEmb.getCreated())
+                    && (emb.getId() != null) && (matchEmb.getId() != null)
+                    && (emb.getId().compareTo(matchEmb.getId()) > 0)) {
+                    matchEmb = emb;
                 }
             }
         }
@@ -1235,13 +1245,14 @@ public class Annotation extends Base implements java.io.Serializable {
         // method/methodVersion are denormalized to top-level keyword fields
         // (embeddingMethod/embeddingMethodVersion), so they are ordinary filter
         // terms alongside the other candidate filters. (Previously these were
-        // nested embeddings.method/methodVersion terms.)
+        // nested embeddings.method/methodVersion terms.) Built via put() rather
+        // than string interpolation.
         if (method != null)
-            boolQuery.getJSONArray("filter").put(
-                new JSONObject("{\"term\": {\"embeddingMethod\":\"" + method + "\"}}"));
+            boolQuery.getJSONArray("filter").put(new JSONObject().put("term",
+                new JSONObject().put("embeddingMethod", method)));
         if (methodVersion != null)
-            boolQuery.getJSONArray("filter").put(
-                new JSONObject("{\"term\": {\"embeddingMethodVersion\":\"" + methodVersion + "\"}}"));
+            boolQuery.getJSONArray("filter").put(new JSONObject().put("term",
+                new JSONObject().put("embeddingMethodVersion", methodVersion)));
         // Query the top-level "vector" field (NOT nested embeddings.vector): a
         // nested knn_vector can't do filtered ANN and degrades to an exact scan.
         // We pass the full candidate bool as the knn `filter` so Lucene's
@@ -1255,6 +1266,11 @@ public class Annotation extends Base implements java.io.Serializable {
         knn.put("knn", new JSONObject().put("vector", knnVector));
         JSONObject result = new JSONObject();
         result.put("query", knn);
+        // getMatches() only reads _id and _score, so suppress _source -- without
+        // this each of the k hits would return its (large) top-level + nested
+        // vectors. (The previous nested query inherited a _source exclusion from
+        // matchingSetQuery; this rebuild sets it explicitly.)
+        result.put("_source", false);
         return result;
     }
 

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -125,7 +125,16 @@ public class OpenSearch {
     }
 
     public static void initializeClient(HttpHost host) {
-        restClient = RestClient.builder(host).build();
+        // Raise the socket timeout above the 30s default. A slow query (e.g. a
+        // cold/large kNN) otherwise throws SocketTimeoutException, which
+        // getMatches() swallows into an empty result -- surfacing to users as
+        // "0 matches". The top-level-vector match query keeps searches fast;
+        // this is a safety net so a slow query degrades to "slow", not silently
+        // "empty".
+        restClient = RestClient.builder(host)
+            .setRequestConfigCallback(
+                rc -> rc.setConnectTimeout(10000).setSocketTimeout(120000))
+            .build();
         final OpenSearchTransport transport = new RestClientTransport(restClient,
             new JacksonJsonpMapper());
 

--- a/src/test/java/org/ecocean/AnnotationMiewIDScoreTest.java
+++ b/src/test/java/org/ecocean/AnnotationMiewIDScoreTest.java
@@ -1,20 +1,18 @@
 package org.ecocean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests pinning the {@code getMatchQuery} JSON shape: a TOP-LEVEL knn
- * on the denormalized {@code vector} field, with method/methodVersion
- * as top-level {@code embeddingMethod}/{@code embeddingMethodVersion}
- * term clauses passed inside the knn {@code filter} (Lucene efficient
- * filtering). The match was moved off the nested {@code embeddings.vector}
- * field because a nested knn_vector cannot do filtered ANN (any filter
- * forces an exact brute-force scan).
+ * Tests pinning the {@code getMatchQuery} JSON shape that the C17
+ * commit established: knn clause in the nested {@code must} array,
+ * method/methodVersion term clauses in the nested {@code filter}
+ * array. This eliminates the spurious +2.0 score offset that the
+ * original (pre-C17) layout introduced when method/methodVersion
+ * terms were in {@code must}.
  *
  * <p>The earlier "openSearchScoreToCosine" tests have been removed
  * along with the back-transform itself (parity-fix). OpenSearch
@@ -62,17 +60,13 @@ class AnnotationMiewIDScoreTest {
             "missing _score should default to 0.0, not crash");
     }
 
-    // --- getMatchQuery shape regression guard ---------------------------
-    // The matcher queries the TOP-LEVEL "vector" knn_vector field (NOT
-    // nested embeddings.vector, which can't do filtered ANN -- any filter
-    // forces an exact brute-force scan that trips the client timeout).
-    // method/methodVersion are top-level embeddingMethod/embeddingMethodVersion
-    // term filters passed INSIDE the knn `filter` (Lucene efficient
-    // filtering keeps the search on the HNSW graph). The knn _score is the
-    // cosinesimil (1+cos)/2 value, consumed unchanged by osHitScore().
-    // This test pins that shape so a regression back to nested is caught.
+    // --- getMatchQuery shape regression guard (Codex C17 Medium) --------
+    // If a future refactor moves embeddings.method/methodVersion back
+    // into the nested `must` list, callers will start seeing scores
+    // offset by +2.0 again. This test pins the JSON shape so that
+    // drift is caught.
 
-    @Test void getMatchQuery_topLevelKnn_methodVersionInEfficientFilter() {
+    @Test void getMatchQuery_putsKnnInMust_termsInFilter() {
         org.ecocean.Annotation ann = new org.ecocean.Annotation();
         // Embedding constructor auto-attaches to the annotation.
         org.json.JSONArray vec = new org.json.JSONArray();
@@ -86,32 +80,42 @@ class AnnotationMiewIDScoreTest {
         org.json.JSONObject q = ann.getMatchQuery("miewid-msv4.1", "4.1", matchingSet);
         assertNotNull(q, "getMatchQuery returned null");
 
-        // Top-level knn on the denormalized "vector" field (no nested wrapper).
-        org.json.JSONObject knnVector = q.getJSONObject("query")
-            .getJSONObject("knn").getJSONObject("vector");
-        assertTrue(knnVector.has("vector"), "knn should carry the query vector array");
-        assertTrue(knnVector.has("k"), "knn should carry k");
+        // Top-level bool.must should contain a single nested clause.
+        org.json.JSONArray topMust = q.getJSONObject("query")
+            .getJSONObject("bool").getJSONArray("must");
+        assertEquals(1, topMust.length(), "expected 1 top-level must clause");
+        org.json.JSONObject nested = topMust.getJSONObject(0)
+            .getJSONObject("nested");
 
-        // method/version are term filters inside the knn efficient-filter bool.
-        org.json.JSONArray filter = knnVector.getJSONObject("filter")
-            .getJSONObject("bool").getJSONArray("filter");
-        org.json.JSONObject methodTerm = null;
-        org.json.JSONObject versionTerm = null;
-        for (int i = 0; i < filter.length(); i++) {
-            org.json.JSONObject term = filter.getJSONObject(i).optJSONObject("term");
-            if (term == null) continue;
-            if (term.has("embeddingMethod")) methodTerm = term;
-            if (term.has("embeddingMethodVersion")) versionTerm = term;
+        // Inside the nested bool: must has ONLY knn, filter has the
+        // method/methodVersion terms. This is the C17 contract — any
+        // movement of the terms back into must would re-introduce the
+        // +1.0-per-term-clause score offset that turned [0, 1] into
+        // [2, 3] on the live deployment.
+        org.json.JSONObject nestedBool = nested.getJSONObject("query")
+            .getJSONObject("bool");
+
+        org.json.JSONArray nestedMust = nestedBool.getJSONArray("must");
+        assertEquals(1, nestedMust.length(),
+            "nested.must should contain only the knn clause; found: " + nestedMust);
+        assertTrue(nestedMust.getJSONObject(0).has("knn"),
+            "nested.must[0] should be a knn clause: " + nestedMust.getJSONObject(0));
+
+        org.json.JSONArray nestedFilter = nestedBool.getJSONArray("filter");
+        assertEquals(2, nestedFilter.length(),
+            "nested.filter should contain method + methodVersion terms; found: " + nestedFilter);
+        // Both filter entries must be term clauses.
+        for (int i = 0; i < nestedFilter.length(); i++) {
+            assertTrue(nestedFilter.getJSONObject(i).has("term"),
+                "nested.filter[" + i + "] should be a term clause: " +
+                nestedFilter.getJSONObject(i));
         }
-        assertNotNull(methodTerm, "expected embeddingMethod term clause: " + filter);
-        assertNotNull(versionTerm, "expected embeddingMethodVersion term clause: " + filter);
-        assertEquals("miewid-msv4.1", methodTerm.getString("embeddingMethod"));
-        assertEquals("4.1", versionTerm.getString("embeddingMethodVersion"));
     }
 
-    @Test void getMatchQuery_omitsMethodVersionTerms_whenBothNull() {
-        // Legacy api_endpoint-only configs: no method/methodVersion to filter
-        // on. Neither embeddingMethod nor embeddingMethodVersion term is added.
+    @Test void getMatchQuery_omitsNestedFilter_whenMethodAndVersionNull() {
+        // Legacy api_endpoint-only configs: no method/methodVersion to
+        // filter on. The nested.filter array should be absent (or empty)
+        // rather than carrying empty term clauses.
         org.ecocean.Annotation ann = new org.ecocean.Annotation();
         org.json.JSONArray vec = new org.json.JSONArray();
         for (int i = 0; i < 8; i++) vec.put(0.1d * i);
@@ -123,56 +127,15 @@ class AnnotationMiewIDScoreTest {
 
         org.json.JSONObject q = ann.getMatchQuery(null, null, matchingSet);
         assertNotNull(q);
-        org.json.JSONArray filter = q.getJSONObject("query")
-            .getJSONObject("knn").getJSONObject("vector")
-            .getJSONObject("filter").getJSONObject("bool").getJSONArray("filter");
-        for (int i = 0; i < filter.length(); i++) {
-            org.json.JSONObject term = filter.getJSONObject(i).optJSONObject("term");
-            if (term == null) continue;
-            assertFalse(term.has("embeddingMethod"),
-                "embeddingMethod term should be absent when method null");
-            assertFalse(term.has("embeddingMethodVersion"),
-                "embeddingMethodVersion term should be absent when version null");
+        org.json.JSONObject nestedBool = q.getJSONObject("query")
+            .getJSONObject("bool").getJSONArray("must")
+            .getJSONObject(0).getJSONObject("nested")
+            .getJSONObject("query").getJSONObject("bool");
+        // nested.filter should either be absent or empty
+        org.json.JSONArray nestedFilter = nestedBool.optJSONArray("filter");
+        if (nestedFilter != null) {
+            assertEquals(0, nestedFilter.length(),
+                "nested.filter should be absent or empty when method+version both null");
         }
-    }
-
-    @Test void getMatchQuery_preservesMustNot_suppressesSource_noInputMutation() {
-        org.ecocean.Annotation ann = new org.ecocean.Annotation();
-        org.json.JSONArray vec = new org.json.JSONArray();
-        for (int i = 0; i < 8; i++) vec.put(0.1d * i);
-        new org.ecocean.Embedding(ann, "miewid-msv4.1", "4.1", vec);
-
-        // matchingSet carrying BOTH a filter clause and a must_not clause
-        // (as getMatchingSetQuery produces -- e.g. exclude-own-encounter).
-        org.json.JSONArray filter = new org.json.JSONArray();
-        filter.put(new org.json.JSONObject().put("term",
-            new org.json.JSONObject().put("iaClass", "whaleshark")));
-        org.json.JSONArray mustNot = new org.json.JSONArray();
-        mustNot.put(new org.json.JSONObject().put("match",
-            new org.json.JSONObject().put("encounterId", "enc-self")));
-        org.json.JSONObject boolObj = new org.json.JSONObject()
-            .put("filter", filter).put("must_not", mustNot);
-        org.json.JSONObject matchingSet = new org.json.JSONObject()
-            .put("query", new org.json.JSONObject().put("bool", boolObj));
-        String before = matchingSet.toString();
-
-        org.json.JSONObject q = ann.getMatchQuery("miewid-msv4.1", "4.1", matchingSet);
-        assertNotNull(q);
-
-        // _source suppressed (getMatches only reads _id/_score).
-        assertFalse(q.getBoolean("_source"), "_source should be false");
-
-        org.json.JSONObject knnBool = q.getJSONObject("query").getJSONObject("knn")
-            .getJSONObject("vector").getJSONObject("filter").getJSONObject("bool");
-        // must_not preserved into the knn efficient-filter bool.
-        assertTrue(knnBool.has("must_not"), "must_not should be preserved: " + knnBool);
-        assertEquals(1, knnBool.getJSONArray("must_not").length());
-        // original filter clause + appended method + version terms.
-        assertEquals(3, knnBool.getJSONArray("filter").length(),
-            "filter should hold original + method + version: " + knnBool.getJSONArray("filter"));
-
-        // getMatchQuery must work on a copy, not mutate its input.
-        assertEquals(before, matchingSet.toString(),
-            "getMatchQuery must not mutate the matchingSetQuery argument");
     }
 }

--- a/src/test/java/org/ecocean/AnnotationMiewIDScoreTest.java
+++ b/src/test/java/org/ecocean/AnnotationMiewIDScoreTest.java
@@ -1,18 +1,20 @@
 package org.ecocean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests pinning the {@code getMatchQuery} JSON shape that the C17
- * commit established: knn clause in the nested {@code must} array,
- * method/methodVersion term clauses in the nested {@code filter}
- * array. This eliminates the spurious +2.0 score offset that the
- * original (pre-C17) layout introduced when method/methodVersion
- * terms were in {@code must}.
+ * Tests pinning the {@code getMatchQuery} JSON shape: a TOP-LEVEL knn
+ * on the denormalized {@code vector} field, with method/methodVersion
+ * as top-level {@code embeddingMethod}/{@code embeddingMethodVersion}
+ * term clauses passed inside the knn {@code filter} (Lucene efficient
+ * filtering). The match was moved off the nested {@code embeddings.vector}
+ * field because a nested knn_vector cannot do filtered ANN (any filter
+ * forces an exact brute-force scan).
  *
  * <p>The earlier "openSearchScoreToCosine" tests have been removed
  * along with the back-transform itself (parity-fix). OpenSearch
@@ -60,13 +62,17 @@ class AnnotationMiewIDScoreTest {
             "missing _score should default to 0.0, not crash");
     }
 
-    // --- getMatchQuery shape regression guard (Codex C17 Medium) --------
-    // If a future refactor moves embeddings.method/methodVersion back
-    // into the nested `must` list, callers will start seeing scores
-    // offset by +2.0 again. This test pins the JSON shape so that
-    // drift is caught.
+    // --- getMatchQuery shape regression guard ---------------------------
+    // The matcher queries the TOP-LEVEL "vector" knn_vector field (NOT
+    // nested embeddings.vector, which can't do filtered ANN -- any filter
+    // forces an exact brute-force scan that trips the client timeout).
+    // method/methodVersion are top-level embeddingMethod/embeddingMethodVersion
+    // term filters passed INSIDE the knn `filter` (Lucene efficient
+    // filtering keeps the search on the HNSW graph). The knn _score is the
+    // cosinesimil (1+cos)/2 value, consumed unchanged by osHitScore().
+    // This test pins that shape so a regression back to nested is caught.
 
-    @Test void getMatchQuery_putsKnnInMust_termsInFilter() {
+    @Test void getMatchQuery_topLevelKnn_methodVersionInEfficientFilter() {
         org.ecocean.Annotation ann = new org.ecocean.Annotation();
         // Embedding constructor auto-attaches to the annotation.
         org.json.JSONArray vec = new org.json.JSONArray();
@@ -80,42 +86,32 @@ class AnnotationMiewIDScoreTest {
         org.json.JSONObject q = ann.getMatchQuery("miewid-msv4.1", "4.1", matchingSet);
         assertNotNull(q, "getMatchQuery returned null");
 
-        // Top-level bool.must should contain a single nested clause.
-        org.json.JSONArray topMust = q.getJSONObject("query")
-            .getJSONObject("bool").getJSONArray("must");
-        assertEquals(1, topMust.length(), "expected 1 top-level must clause");
-        org.json.JSONObject nested = topMust.getJSONObject(0)
-            .getJSONObject("nested");
+        // Top-level knn on the denormalized "vector" field (no nested wrapper).
+        org.json.JSONObject knnVector = q.getJSONObject("query")
+            .getJSONObject("knn").getJSONObject("vector");
+        assertTrue(knnVector.has("vector"), "knn should carry the query vector array");
+        assertTrue(knnVector.has("k"), "knn should carry k");
 
-        // Inside the nested bool: must has ONLY knn, filter has the
-        // method/methodVersion terms. This is the C17 contract — any
-        // movement of the terms back into must would re-introduce the
-        // +1.0-per-term-clause score offset that turned [0, 1] into
-        // [2, 3] on the live deployment.
-        org.json.JSONObject nestedBool = nested.getJSONObject("query")
-            .getJSONObject("bool");
-
-        org.json.JSONArray nestedMust = nestedBool.getJSONArray("must");
-        assertEquals(1, nestedMust.length(),
-            "nested.must should contain only the knn clause; found: " + nestedMust);
-        assertTrue(nestedMust.getJSONObject(0).has("knn"),
-            "nested.must[0] should be a knn clause: " + nestedMust.getJSONObject(0));
-
-        org.json.JSONArray nestedFilter = nestedBool.getJSONArray("filter");
-        assertEquals(2, nestedFilter.length(),
-            "nested.filter should contain method + methodVersion terms; found: " + nestedFilter);
-        // Both filter entries must be term clauses.
-        for (int i = 0; i < nestedFilter.length(); i++) {
-            assertTrue(nestedFilter.getJSONObject(i).has("term"),
-                "nested.filter[" + i + "] should be a term clause: " +
-                nestedFilter.getJSONObject(i));
+        // method/version are term filters inside the knn efficient-filter bool.
+        org.json.JSONArray filter = knnVector.getJSONObject("filter")
+            .getJSONObject("bool").getJSONArray("filter");
+        org.json.JSONObject methodTerm = null;
+        org.json.JSONObject versionTerm = null;
+        for (int i = 0; i < filter.length(); i++) {
+            org.json.JSONObject term = filter.getJSONObject(i).optJSONObject("term");
+            if (term == null) continue;
+            if (term.has("embeddingMethod")) methodTerm = term;
+            if (term.has("embeddingMethodVersion")) versionTerm = term;
         }
+        assertNotNull(methodTerm, "expected embeddingMethod term clause: " + filter);
+        assertNotNull(versionTerm, "expected embeddingMethodVersion term clause: " + filter);
+        assertEquals("miewid-msv4.1", methodTerm.getString("embeddingMethod"));
+        assertEquals("4.1", versionTerm.getString("embeddingMethodVersion"));
     }
 
-    @Test void getMatchQuery_omitsNestedFilter_whenMethodAndVersionNull() {
-        // Legacy api_endpoint-only configs: no method/methodVersion to
-        // filter on. The nested.filter array should be absent (or empty)
-        // rather than carrying empty term clauses.
+    @Test void getMatchQuery_omitsMethodVersionTerms_whenBothNull() {
+        // Legacy api_endpoint-only configs: no method/methodVersion to filter
+        // on. Neither embeddingMethod nor embeddingMethodVersion term is added.
         org.ecocean.Annotation ann = new org.ecocean.Annotation();
         org.json.JSONArray vec = new org.json.JSONArray();
         for (int i = 0; i < 8; i++) vec.put(0.1d * i);
@@ -127,15 +123,16 @@ class AnnotationMiewIDScoreTest {
 
         org.json.JSONObject q = ann.getMatchQuery(null, null, matchingSet);
         assertNotNull(q);
-        org.json.JSONObject nestedBool = q.getJSONObject("query")
-            .getJSONObject("bool").getJSONArray("must")
-            .getJSONObject(0).getJSONObject("nested")
-            .getJSONObject("query").getJSONObject("bool");
-        // nested.filter should either be absent or empty
-        org.json.JSONArray nestedFilter = nestedBool.optJSONArray("filter");
-        if (nestedFilter != null) {
-            assertEquals(0, nestedFilter.length(),
-                "nested.filter should be absent or empty when method+version both null");
+        org.json.JSONArray filter = q.getJSONObject("query")
+            .getJSONObject("knn").getJSONObject("vector")
+            .getJSONObject("filter").getJSONObject("bool").getJSONArray("filter");
+        for (int i = 0; i < filter.length(); i++) {
+            org.json.JSONObject term = filter.getJSONObject(i).optJSONObject("term");
+            if (term == null) continue;
+            assertFalse(term.has("embeddingMethod"),
+                "embeddingMethod term should be absent when method null");
+            assertFalse(term.has("embeddingMethodVersion"),
+                "embeddingMethodVersion term should be absent when version null");
         }
     }
 }

--- a/src/test/java/org/ecocean/AnnotationMiewIDScoreTest.java
+++ b/src/test/java/org/ecocean/AnnotationMiewIDScoreTest.java
@@ -135,4 +135,44 @@ class AnnotationMiewIDScoreTest {
                 "embeddingMethodVersion term should be absent when version null");
         }
     }
+
+    @Test void getMatchQuery_preservesMustNot_suppressesSource_noInputMutation() {
+        org.ecocean.Annotation ann = new org.ecocean.Annotation();
+        org.json.JSONArray vec = new org.json.JSONArray();
+        for (int i = 0; i < 8; i++) vec.put(0.1d * i);
+        new org.ecocean.Embedding(ann, "miewid-msv4.1", "4.1", vec);
+
+        // matchingSet carrying BOTH a filter clause and a must_not clause
+        // (as getMatchingSetQuery produces -- e.g. exclude-own-encounter).
+        org.json.JSONArray filter = new org.json.JSONArray();
+        filter.put(new org.json.JSONObject().put("term",
+            new org.json.JSONObject().put("iaClass", "whaleshark")));
+        org.json.JSONArray mustNot = new org.json.JSONArray();
+        mustNot.put(new org.json.JSONObject().put("match",
+            new org.json.JSONObject().put("encounterId", "enc-self")));
+        org.json.JSONObject boolObj = new org.json.JSONObject()
+            .put("filter", filter).put("must_not", mustNot);
+        org.json.JSONObject matchingSet = new org.json.JSONObject()
+            .put("query", new org.json.JSONObject().put("bool", boolObj));
+        String before = matchingSet.toString();
+
+        org.json.JSONObject q = ann.getMatchQuery("miewid-msv4.1", "4.1", matchingSet);
+        assertNotNull(q);
+
+        // _source suppressed (getMatches only reads _id/_score).
+        assertFalse(q.getBoolean("_source"), "_source should be false");
+
+        org.json.JSONObject knnBool = q.getJSONObject("query").getJSONObject("knn")
+            .getJSONObject("vector").getJSONObject("filter").getJSONObject("bool");
+        // must_not preserved into the knn efficient-filter bool.
+        assertTrue(knnBool.has("must_not"), "must_not should be preserved: " + knnBool);
+        assertEquals(1, knnBool.getJSONArray("must_not").length());
+        // original filter clause + appended method + version terms.
+        assertEquals(3, knnBool.getJSONArray("filter").length(),
+            "filter should hold original + method + version: " + knnBool.getJSONArray("filter"));
+
+        // getMatchQuery must work on a copy, not mutate its input.
+        assertEquals(before, matchingSet.toString(),
+            "getMatchQuery must not mutate the matchingSetQuery argument");
+    }
 }


### PR DESCRIPTION
## Summary

Restores MiewID/vector identification, which returned **0 prospects against a nonzero candidate count** on OpenSearch 3.x. Two compounding root causes, both fixed here:

1. **No HNSW engine on the vector field.** `embeddings.vector` was a `knn_vector` with no `method` block, so no ANN graph was built (acute after OpenSearch 3.x removed the nmslib default). kNN fell back to exact brute-force.
2. **Nested vectors can't do filtered ANN.** Even with an engine, a *nested* `knn_vector` reverts to exact search the moment any filter is applied (method/version, viewpoint, iaClass) — the match query needs all of those. The exact scan (~31–46 s on the production corpus) exceeded the 30 s client socket timeout; `getMatches()` caught the `SocketTimeoutException` and returned an empty list.

### Fix
- **De-normalize the match vector to a TOP-LEVEL `vector` field** (`knn_vector`, hnsw/lucene/cosinesimil) plus top-level `embeddingMethod`/`embeddingMethodVersion` keywords. Top-level (non-nested) vectors support Lucene "efficient filtering", so the filtered match stays on the HNSW graph.
- **`getMatchQuery`** rewritten to query the top-level field with the candidate bool as the knn `filter`; method/version are top-level term filters; `_source:false` (getMatches only reads `_id`/`_score`). Score path (`osHitScore`, cosinesimil `(1+cos)/2`) unchanged.
- **Nested `embeddings.vector` is no longer mapped** (kept in `_source` via `dynamic:false` for API consumers) so no second HNSW graph is built. `embeddings.method`/`methodVersion` remain mapped (used by the visibility gate).
- **Serializer** writes the top-level vector + method/version from a deterministically chosen embedding (most-recent `created`, null-safe tie-break).
- **Socket timeout** raised 30 s → 120 s as a safety net.

### Verified live (Sharkbook, OpenSearch 3.1)
Same filtered match query that timed out on the nested field returns correct results in **718 ms** on a flat top-level field (WS033's recapture sibling at rank 2). Trail: 0 prospects → no ANN graph → reindex with engine (bare kNN fast) → still 0 (filtered nested kNN = exact → 30 s timeout) → de-nest (718 ms).

### ⚠️ Deploy requires a reindex
A `knn_vector` field/engine cannot be altered in place. The `annotation` index must be recreated with this mapping and reindexed (vectors copy via `_source`; no re-extraction). Any Wild Me install on OpenSearch 3.x with vector matching needs the same.

### Review / testing
- Codex-reviewed (2 rounds): all Major/Minor findings addressed; converged.
- `AnnotationMiewIDScoreTest` updated to pin the top-level query shape. `buildAnnotationMatchableQuery`/its tests unchanged.
- NOTE: `mvn clean install` should run in CI — the build/tests were not executed in the authoring environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)