### PR TITLE
Raise OpenSearch client socket timeout to 120s

### DIFF
--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -125,7 +125,16 @@ public class OpenSearch {
     }
 
     public static void initializeClient(HttpHost host) {
-        restClient = RestClient.builder(host).build();
+        // Raise the socket timeout above the 30s default. A slow query (e.g. a
+        // cold/large kNN) otherwise throws SocketTimeoutException, which
+        // getMatches() swallows into an empty result -- surfacing to users as
+        // "0 matches". The top-level-vector match query keeps searches fast;
+        // this is a safety net so a slow query degrades to "slow", not silently
+        // "empty".
+        restClient = RestClient.builder(host)
+            .setRequestConfigCallback(
+                rc -> rc.setConnectTimeout(10000).setSocketTimeout(120000))
+            .build();
         final OpenSearchTransport transport = new RestClientTransport(restClient,
             new JacksonJsonpMapper());
 


### PR DESCRIPTION
## What

Raise the OpenSearch REST client socket timeout from the 30s default to 120s, and set an explicit 10s connect timeout. One-file, ~10-line change in `OpenSearch.initializeClient()`.

## Why

The REST client uses the default 30s socket timeout. A slow query — a cold or large kNN search whose HNSW graph must page into native memory — throws `SocketTimeoutException`, which `Annotation.getMatches()` catches and turns into an **empty** result. To the user this surfaces as "**0 matches against N candidates**": the candidate count (a fast `_count` query) is non-zero, but the match query silently returned nothing.

Raising the socket timeout lets a slow query complete instead of being silently swallowed — it degrades to "slow", not "empty".

## Scope / what this is NOT

This is a **defensive safety net**, not a root-cause fix. A healthy ANN graph answers filtered kNN in milliseconds; the timeout only matters for cold-start or degraded-graph situations (e.g. an index whose graph was invalidated by an OpenSearch 3.x upgrade and needs a reindex). Operationally the durable fix is a clean reindex; this change just ensures that while a graph is cold/rebuilding, users see slow results rather than false "0 matches".

Deliberately minimal — no mapping/schema changes, no query-shape changes.

Reviewed by Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
