### PR TITLE
Prevent indexingActive flag leak from wedging the OpenSearch reconciler

### DIFF
--- a/src/main/java/org/ecocean/Base.java
+++ b/src/main/java/org/ecocean/Base.java
@@ -381,8 +381,13 @@ import org.json.JSONObject;
                 try {
                     if (obj != null) os.index(indexName, obj);
                 } catch (Exception ex) {
-                    System.out.println("Base.opensearchSyncIndex(" + indexName + "): index failed " +
-                        obj + " => " + ex.toString());
+                    // Log the id only -- never "" + obj, because obj.toString() can itself throw
+                    // (e.g. an orphaned Annotation whose MediaAsset row was deleted -> lazy-load
+                    // NucleusObjectNotFoundException). A throw here would escape this per-item catch
+                    // and abort the whole reconcile pass instead of skipping the one bad object.
+                    String failId = (obj == null) ? "?" : obj.getId();
+                    System.out.println("Base.opensearchSyncIndex(" + indexName + "): index failed id=" +
+                        failId + " => " + ex.toString());
                     ex.printStackTrace();
                 }
                 if (ct % 500 == 0)

--- a/src/main/java/org/ecocean/Base.java
+++ b/src/main/java/org/ecocean/Base.java
@@ -358,47 +358,56 @@ import org.json.JSONObject;
             return rtn;
         }
         OpenSearch.setActiveIndexingBackground();
-        OpenSearch os = new OpenSearch();
-        List<List<String> > changes = os.resolveVersions(getAllVersions(myShepherd,
-            baseObj.getAllVersionsSql()), os.getAllVersions(indexName));
-        if (changes.size() != 2) throw new IOException("invalid resolveVersions results");
-        List<String> needIndexing = changes.get(0);
-        List<String> needRemoval = changes.get(1);
-        rtn[0] = needIndexing.size();
-        rtn[1] = needRemoval.size();
-        System.out.println("Base.opensearchSyncIndex(" + indexName + "): stopAfter=" + stopAfter +
-            ", needIndexing=" + rtn[0] + ", needRemoval=" + rtn[1]);
-        int ct = 0;
-        for (String id : needIndexing) {
-            Base obj = baseObj.getById(myShepherd, id);
-            try {
-                if (obj != null) os.index(indexName, obj);
-            } catch (Exception ex) {
-                System.out.println("Base.opensearchSyncIndex(" + indexName + "): index failed " +
-                    obj + " => " + ex.toString());
-                ex.printStackTrace();
+        // The background flag MUST be cleared however we leave this method. Previously an
+        // exception between here and the unset (the resolveVersions IOException below, a
+        // getAllVersions/scroll failure, or an os.delete throwing in the needRemoval loop)
+        // leaked the flag: it stayed set, so every later opensearchSyncIndex() call
+        // short-circuited at the indexingActive() check above and the reconciler was
+        // permanently wedged. try/finally guarantees the unset.
+        try {
+            OpenSearch os = new OpenSearch();
+            List<List<String> > changes = os.resolveVersions(getAllVersions(myShepherd,
+                baseObj.getAllVersionsSql()), os.getAllVersions(indexName));
+            if (changes.size() != 2) throw new IOException("invalid resolveVersions results");
+            List<String> needIndexing = changes.get(0);
+            List<String> needRemoval = changes.get(1);
+            rtn[0] = needIndexing.size();
+            rtn[1] = needRemoval.size();
+            System.out.println("Base.opensearchSyncIndex(" + indexName + "): stopAfter=" + stopAfter +
+                ", needIndexing=" + rtn[0] + ", needRemoval=" + rtn[1]);
+            int ct = 0;
+            for (String id : needIndexing) {
+                Base obj = baseObj.getById(myShepherd, id);
+                try {
+                    if (obj != null) os.index(indexName, obj);
+                } catch (Exception ex) {
+                    System.out.println("Base.opensearchSyncIndex(" + indexName + "): index failed " +
+                        obj + " => " + ex.toString());
+                    ex.printStackTrace();
+                }
+                if (ct % 500 == 0)
+                    System.out.println("Base.opensearchSyncIndex(" + indexName + ") needIndexing: " +
+                        ct + "/" + rtn[0]);
+                ct++;
+                if ((stopAfter > 0) && (ct > stopAfter)) {
+                    System.out.println("Base.opensearchSyncIndex(" + indexName +
+                        ") breaking due to stopAfter");
+                    break;
+                }
             }
-            if (ct % 500 == 0)
-                System.out.println("Base.opensearchSyncIndex(" + indexName + ") needIndexing: " +
-                    ct + "/" + rtn[0]);
-            ct++;
-            if ((stopAfter > 0) && (ct > stopAfter)) {
-                System.out.println("Base.opensearchSyncIndex(" + indexName +
-                    ") breaking due to stopAfter");
-                break;
+            System.out.println("Base.opensearchSyncIndex(" + indexName + ") finished needIndexing");
+            ct = 0;
+            for (String id : needRemoval) {
+                os.delete(indexName, id);
+                if (ct % 500 == 0)
+                    System.out.println("Base.opensearchSyncIndex(" + indexName + ") needRemoval: " +
+                        ct + "/" + rtn[1]);
+                ct++;
             }
+            System.out.println("Base.opensearchSyncIndex(" + indexName + ") finished needRemoval");
+        } finally {
+            OpenSearch.unsetActiveIndexingBackground();
         }
-        System.out.println("Base.opensearchSyncIndex(" + indexName + ") finished needIndexing");
-        ct = 0;
-        for (String id : needRemoval) {
-            os.delete(indexName, id);
-            if (ct % 500 == 0)
-                System.out.println("Base.opensearchSyncIndex(" + indexName + ") needRemoval: " +
-                    ct + "/" + rtn[1]);
-            ct++;
-        }
-        System.out.println("Base.opensearchSyncIndex(" + indexName + ") finished needRemoval");
-        OpenSearch.unsetActiveIndexingBackground();
         return rtn;
     }
 

--- a/src/main/webapp/appadmin/opensearchSync.jsp
+++ b/src/main/webapp/appadmin/opensearchSync.jsp
@@ -122,7 +122,12 @@ if (endNum > 0) {
                 iObj.opensearchIndex();
                 numProcessed++;
             } catch (Exception ex) {
-                System.out.println("opensearchSync.jsp: exception failure on " + iObj);
+                // Log the id only -- never "" + iObj, because iObj.toString() can itself throw
+                // (e.g. an orphaned Annotation whose MediaAsset row was deleted -> lazy-load
+                // NucleusObjectNotFoundException). A throw here would escape this per-item catch
+                // and abort the whole reindex instead of skipping the one bad object.
+                String failId = (iObj == null) ? "?" : iObj.getId();
+                System.out.println("opensearchSync.jsp: exception failure on id=" + failId);
                 ex.printStackTrace();
             }
             if (ct % 100 == 0) System.out.println("opensearchSync.jsp: count " + ct);

--- a/src/main/webapp/appadmin/opensearchSync.jsp
+++ b/src/main/webapp/appadmin/opensearchSync.jsp
@@ -77,6 +77,10 @@ if (OpenSearch.indexingActive()) {
 }
 
 OpenSearch.setActiveIndexingForeground();
+// try/finally so the foreground flag can never leak on an exception. A leaked flag
+// leaves OpenSearch.indexingActive() permanently true, which makes the background
+// reconciler (Base.opensearchSyncIndex) skip every pass and wedges all indexing.
+try {
 
 if (!os.existsIndex(indexName)) {
         obj.opensearchCreateIndex();
@@ -132,10 +136,13 @@ if (endNum > 0) {
     out.println("<p>removed: <b>" + res[1] + "</b></p>");
 }
 
-myShepherd.rollbackAndClose();
-
-OpenSearch.unsetActiveIndexingForeground();
-os.deleteAllPits();
+} finally {
+    // Isolate each cleanup so a failure in one cannot skip the others (especially the
+    // foreground-flag unset -- the whole point of this block) or mask the original exception.
+    try { myShepherd.rollbackAndClose(); } catch (Exception cex) { cex.printStackTrace(); }
+    try { OpenSearch.unsetActiveIndexingForeground(); } catch (Exception cex) { cex.printStackTrace(); }
+    try { os.deleteAllPits(); } catch (Exception cex) { cex.printStackTrace(); }
+}
 
 double totalMin = System.currentTimeMillis() - timer;
 totalMin = totalMin / 60000D;


### PR DESCRIPTION
## Problem

Wildbook guards OpenSearch (re)indexing with two process-wide flags — foreground (`OpenSearch.setActiveIndexingForeground`/`unset…`) and background (`setActiveIndexingBackground`/`unset…`). The background reconciler `Base.opensearchSyncIndex` bails at the top when `OpenSearch.indexingActive()` (foreground || background) is true.

Both flags were set and unset **without `try/finally`**. If anything threw between the set and the unset, the flag **leaked and stayed `true` forever**, so every subsequent reconciler pass short-circuited — logging `skipped due to indexingActive()` indefinitely — and the index never converged.

This was observed live on a Sharkbook deployment: a foreground reindex (`opensearchSync.jsp`) that errored before reaching its unset left `indexingActive` stuck true. Meanwhile an unrelated queue kept deep-reindexing via the async `IndexingManager` path (which doesn't consult the flag), so the index churned continuously (flat doc count, rising `deleted`/tombstones) while the one process that would have reconciled it was permanently switched off.

## Fix

- **`Base.opensearchSyncIndex`**: wrap the reconcile body in `try { … } finally { unsetActiveIndexingBackground(); }` so the background flag is always cleared — including when `resolveVersions`/`getAllVersions` throw or `os.delete` fails mid-loop. The early `skipped` return happens *before* the flag is set, so it correctly does not touch the flag.
- **`opensearchSync.jsp`**: wrap the foreground reindex in `try { … } finally { … }` so `setActiveIndexingForeground()` is always cleared even if the reindex loop throws or the request is aborted. Each cleanup (`rollbackAndClose`, foreground unset, `deleteAllPits`) is isolated in its own `try/catch` so one failing can't skip the others (especially the unset) or mask the original exception.

No behavior change on the success path; purely makes flag cleanup exception-safe.

## Review

Codex-reviewed: confirmed both flags are always cleared on every exception path, scopes/returns valid, no use-after-close, double-unset is idempotent/harmless. The isolated-cleanup refinement in the JSP `finally` came out of that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)