### PR TITLE
Relax metadata edit permissions on individuals.jsp

### DIFF
--- a/src/main/java/org/ecocean/security/Collaboration.java
+++ b/src/main/java/org/ecocean/security/Collaboration.java
@@ -575,6 +575,18 @@ public class Collaboration implements java.io.Serializable {
         return true;
     }
 
+    // Check if User (via request) has edit access to every Encounter in this Individual
+    public static boolean canUserPartiallyEditMarkedIndividual(MarkedIndividual mi,
+        HttpServletRequest request) {
+        if (request.isUserInRole("admin")) return true;
+        Vector<Encounter> all = mi.getEncounters();
+        if ((all == null) || (all.size() < 1)) return false;
+        for (Encounter enc : all) {
+            if (canEditEncounter(enc, request)) return true; // one is good enough (either owner or in collab or no security etc)
+        }
+        return false;
+    }
+
     public static boolean canUserAccessSocialUnit(SocialUnit su, HttpServletRequest request) {
         List<MarkedIndividual> all = su.getMarkedIndividuals();
 

--- a/src/main/java/org/ecocean/security/Collaboration.java
+++ b/src/main/java/org/ecocean/security/Collaboration.java
@@ -575,7 +575,7 @@ public class Collaboration implements java.io.Serializable {
         return true;
     }
 
-    // Check if User (via request) has edit access to every Encounter in this Individual
+    // Check if User (via request) has edit access to at least one Encounter in this Individual
     public static boolean canUserPartiallyEditMarkedIndividual(MarkedIndividual mi,
         HttpServletRequest request) {
         if (request.isUserInRole("admin")) return true;

--- a/src/main/webapp/individuals.jsp
+++ b/src/main/webapp/individuals.jsp
@@ -500,7 +500,7 @@ $(document).ready(function() {
 
           // replace this with canUserViewIndividual?
           // boolean isOwner = ServletUtilities.isUserAuthorizedForIndividual(sharky, request);
-          boolean isOwner = Collaboration.canUserFullyEditMarkedIndividual(sharky, request);
+          boolean isOwner = Collaboration.canUserPartiallyEditMarkedIndividual(sharky, request);
           //System.out.println("    |=-| INDIVIDUALS.JSP we have sharkID "+id+", isOwner="+isOwner+" and names "+sharky.getNames());
 
           if (CommonConfiguration.allowNicknames(context)) {

--- a/src/test/java/org/ecocean/security/PermissionsTest.java
+++ b/src/test/java/org/ecocean/security/PermissionsTest.java
@@ -29,6 +29,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Vector;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +41,7 @@ import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -178,6 +180,59 @@ class PermissionsTest {
             // but now can edit
             collab.setState(Collaboration.STATE_EDIT_PRIV);
             assertTrue(enc.canUserEdit(user2, myShepherd));
+        }
+    }
+
+    // Collaboration.canUserPartiallyEditMarkedIndividual() returns true if the user can edit
+    // AT LEAST ONE encounter (ANY), vs canUserFullyEditMarkedIndividual() which needs ALL.
+    // This ANY-vs-ALL distinction is the whole point of the method, so we pin it here.
+    @Test void partiallyEditMarkedIndividualTest() {
+        Encounter e1 = new Encounter();
+        Encounter e2 = new Encounter();
+        MarkedIndividual mi = mock(MarkedIndividual.class);
+
+        // admin short-circuits, before the encounter list is even inspected
+        when(mockRequest.isUserInRole("admin")).thenReturn(true);
+        when(mi.getEncounters()).thenReturn(null);
+        assertTrue(Collaboration.canUserPartiallyEditMarkedIndividual(mi, mockRequest));
+
+        // non-admin from here on
+        when(mockRequest.isUserInRole("admin")).thenReturn(false);
+
+        // no encounters -> not editable (null and empty both)
+        when(mi.getEncounters()).thenReturn(null);
+        assertFalse(Collaboration.canUserPartiallyEditMarkedIndividual(mi, mockRequest));
+        when(mi.getEncounters()).thenReturn(new Vector<Encounter>());
+        assertFalse(Collaboration.canUserPartiallyEditMarkedIndividual(mi, mockRequest));
+
+        Vector<Encounter> encs = new Vector<Encounter>();
+        encs.add(e1);
+        encs.add(e2);
+        when(mi.getEncounters()).thenReturn(encs);
+
+        // mock only canEditEncounter() per-encounter; the ANY/ALL loops run for real
+        try (MockedStatic<Collaboration> mockCollab = mockStatic(Collaboration.class,
+                org.mockito.Answers.CALLS_REAL_METHODS)) {
+            // none editable -> neither partial nor full
+            mockCollab.when(() -> Collaboration.canEditEncounter(any(Encounter.class),
+                any(HttpServletRequest.class))).thenReturn(false);
+            assertFalse(Collaboration.canUserPartiallyEditMarkedIndividual(mi, mockRequest));
+            assertFalse(Collaboration.canUserFullyEditMarkedIndividual(mi, mockRequest));
+
+            // exactly one of two editable -> partial=true (ANY), but full=false (needs ALL)
+            // (same() not eq(): Encounter.equals() treats two blank encounters as equal)
+            mockCollab.when(() -> Collaboration.canEditEncounter(same(e1),
+                any(HttpServletRequest.class))).thenReturn(true);
+            mockCollab.when(() -> Collaboration.canEditEncounter(same(e2),
+                any(HttpServletRequest.class))).thenReturn(false);
+            assertTrue(Collaboration.canUserPartiallyEditMarkedIndividual(mi, mockRequest));
+            assertFalse(Collaboration.canUserFullyEditMarkedIndividual(mi, mockRequest));
+
+            // all editable -> both partial and full are true
+            mockCollab.when(() -> Collaboration.canEditEncounter(same(e2),
+                any(HttpServletRequest.class))).thenReturn(true);
+            assertTrue(Collaboration.canUserPartiallyEditMarkedIndividual(mi, mockRequest));
+            assertTrue(Collaboration.canUserFullyEditMarkedIndividual(mi, mockRequest));
         }
     }
 


### PR DESCRIPTION
Relax metadata edit permissions on individuals.jsp - allow anyone with edit access to an Encounter to have metadata edit access to the top section of individuals.jsp

Adds a new method to Collaboration.java security that checks for partial edit access to an individual
Allows metadata edit access in individuals.jsp if partial edit permission is detected

**Before you Submit!**
* Is all the text internationalized?

N/A

* If you made a change to the header, did you update the react, jsp, and html?

N/A

* Are all depedencies at a locked version?

N/A

* Did you adhere to [best practices](https://wildbook.docs.wildme.org/contribute/code-guide.html)?

yes

* Is there a quick [unit test](https://wildbook.docs.wildme.org/contribute/tests.html) you can add?
