### PR TITLE
Allow logged-in users to edit public encounters

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -3349,6 +3349,9 @@ public class Encounter extends Base implements java.io.Serializable {
         if (user == null) return false;
         if (isUserOwner(user)) return true;
         if (user.isAdmin(myShepherd)) return true;
+        // any logged-in user can edit a public (ownerless) encounter, matching the
+        // legacy ServletUtilities.isUserAuthorizedForEncounter() behavior
+        if (User.isUsernameAnonymous(this.getSubmitterID())) return true;
         if (Collaboration.canEditEncounter(this, user, myShepherd.getContext())) return true;
         // TODO there seems to be some legacy stuff about roles based on location. is this real?
         return false;

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -3357,6 +3357,15 @@ public class Encounter extends Base implements java.io.Serializable {
         return false;
     }
 
+    // edit access on a public encounter (see canUserEdit) does not by itself
+    // grant visibility of other users' contact emails
+    public boolean canUserViewContactInfo(User user, Shepherd myShepherd) {
+        if (user == null) return false;
+        if (isUserOwner(user)) return true;
+        if (user.isAdmin(myShepherd)) return true;
+        return Collaboration.canEditEncounter(this, user, myShepherd.getContext());
+    }
+
     public boolean isUserOwner(User user) { // the definition of this might change?
         if (user == null) return false;
         if ((submitters != null) && submitters.contains(user)) return true;
@@ -4955,11 +4964,15 @@ public class Encounter extends Base implements java.io.Serializable {
             if (canUserEdit(user, myShepherd)) {
                 rtn.put("access", "write");
                 blocked = false;
-                // we can allow email being shown when access=write
-                hideUserEmail = false;
-                if (submitter != null)
-                    rtn.put("submitterInfo",
-                        submitter.infoJSONObject(myShepherd, true, hideUserEmail));
+                // we can allow email being shown when the user has a real
+                // relationship to the encounter (owner/admin/edit-collab);
+                // write access via the public-encounter grant is not enough
+                if (canUserViewContactInfo(user, myShepherd)) {
+                    hideUserEmail = false;
+                    if (submitter != null)
+                        rtn.put("submitterInfo",
+                            submitter.infoJSONObject(myShepherd, true, hideUserEmail));
+                }
             } else if (canUserView(user, myShepherd)) {
                 blocked = false;
             }

--- a/src/test/java/org/ecocean/security/PermissionsTest.java
+++ b/src/test/java/org/ecocean/security/PermissionsTest.java
@@ -199,9 +199,57 @@ class PermissionsTest {
             assertTrue(enc.canUserEdit(user, myShepherd));
             // anonymous (not logged in) still cannot edit
             assertFalse(enc.canUserEdit(null, myShepherd));
+            // all the User.isUsernameAnonymous flavors of "ownerless" count as public
+            enc.setSubmitterID(null);
+            assertTrue(enc.canUserEdit(user, myShepherd));
+            enc.setSubmitterID("");
+            assertTrue(enc.canUserEdit(user, myShepherd));
+            enc.setSubmitterID("   ");
+            assertTrue(enc.canUserEdit(user, myShepherd));
+            enc.setSubmitterID("N/A");
+            assertTrue(enc.canUserEdit(user, myShepherd));
             // encounters owned by someone else remain uneditable
             enc.setSubmitterID("someone-else");
             assertFalse(enc.canUserEdit(user, myShepherd));
+            // ...even on sites with collaboration security disabled
+            mockCollab.when(() -> Collaboration.securityEnabled(any(String.class))).thenReturn(
+                false);
+            assertFalse(enc.canUserEdit(user, myShepherd));
+        }
+    }
+
+    // edit access on a public encounter must not expose other users' emails (issue 1626)
+    @Test void encounterPublicEditEmailHiddenTest()
+    throws IOException {
+        User user = new User("test-user", null, null);
+        User contact = new User("contact-person", null, null);
+
+        contact.setEmailAddress("secret@example.com");
+        Encounter enc = org.mockito.Mockito.spy(new Encounter());
+        enc.setSubmitterID("public");
+        enc.addSubmitter(contact);
+        Shepherd myShepherd = mock(Shepherd.class);
+        when(myShepherd.getContext()).thenReturn("context0");
+        when(myShepherd.getAllRolesForUser(anyString())).thenReturn(new ArrayList<>());
+        org.mockito.Mockito.doReturn(new JSONObject()).when(enc).opensearchDocumentAsJSONObject(
+            any(Shepherd.class));
+        // avoids a real Shepherd (and thus a real database) inside the test
+        org.mockito.Mockito.doReturn(new JSONObject()).when(enc).spotMappingJsonForApiGet();
+
+        try (MockedStatic<Collaboration> mockCollab = mockStatic(Collaboration.class,
+                org.mockito.Answers.CALLS_REAL_METHODS)) {
+            mockCollab.when(() -> Collaboration.collaborationBetweenUsers(any(String.class),
+                any(String.class), any(String.class))).thenReturn(null);
+            mockCollab.when(() -> Collaboration.securityEnabled(any(String.class))).thenReturn(
+                true);
+
+            JSONObject rtn = enc.jsonForApiGet(myShepherd, user);
+            // a random logged-in user gets edit access to the public encounter...
+            Assertions.assertEquals("write", rtn.getString("access"));
+            // ...but the submitter-list emails stay hidden
+            JSONArray subs = rtn.getJSONArray("submitters");
+            Assertions.assertEquals(1, subs.length());
+            assertFalse(subs.getJSONObject(0).has("email"));
         }
     }
 

--- a/src/test/java/org/ecocean/security/PermissionsTest.java
+++ b/src/test/java/org/ecocean/security/PermissionsTest.java
@@ -181,6 +181,30 @@ class PermissionsTest {
         }
     }
 
+    // any logged-in user can edit a public encounter (issue 1626)
+    @Test void encounterPublicEditTest() {
+        User user = new User("test-user", null, null);
+        Encounter enc = new Encounter();
+        Shepherd myShepherd = mock(Shepherd.class);
+
+        when(myShepherd.getContext()).thenReturn("context0");
+        try (MockedStatic<Collaboration> mockCollab = mockStatic(Collaboration.class,
+                org.mockito.Answers.CALLS_REAL_METHODS)) {
+            mockCollab.when(() -> Collaboration.collaborationBetweenUsers(any(String.class),
+                any(String.class), any(String.class))).thenReturn(null);
+            mockCollab.when(() -> Collaboration.securityEnabled(any(String.class))).thenReturn(
+                true);
+
+            enc.setSubmitterID("public");
+            assertTrue(enc.canUserEdit(user, myShepherd));
+            // anonymous (not logged in) still cannot edit
+            assertFalse(enc.canUserEdit(null, myShepherd));
+            // encounters owned by someone else remain uneditable
+            enc.setSubmitterID("someone-else");
+            assertFalse(enc.canUserEdit(user, myShepherd));
+        }
+    }
+
     // Collaboration.canCollaborate() is central to many other calls
     @Test void canCollaborateTest() {
         User userResearcher = new User("user-researcher", null, null);


### PR DESCRIPTION
## Problem

On the React encounter page, encounters submitted by the anonymous `public` user show no edit controls (pencil icons) unless the viewer is an admin, and PATCH requests from non-admin logged-in users are rejected. Researchers have always been able to edit public encounters through the classic JSP pages.

Fixes #1626

## Root cause

The 10.9 rewrite of `Encounter.canUserEdit(User, Shepherd)` grants edit only to the owner, admins, or edit-privilege collaborators. For a public encounter the collaboration check looks up a collaboration record with the literal username `public`, which never exists, so `GET /api/v3/encounters/{id}` returns `access: "read"` (hiding all edit UI) and `api/BaseObject` rejects PATCHes.

The legacy path, `ServletUtilities.isUserAuthorizedForEncounter()`, explicitly allows any logged-in user to edit a public encounter — and the read path already treats anonymous-owned encounters as publicly readable (`User.isUsernameAnonymous` carve-out in `Collaboration.canCollaborate`). Edit was the only place missing the carve-out.

## Fix

1. **`canUserEdit()`**: add an anonymous-owner early return using the same `User.isUsernameAnonymous(submitterID)` predicate the read path uses. Any logged-in user can now edit a public (ownerless) encounter, matching legacy behavior. This predicate was chosen deliberately over `isPubliclyReadable()`, which would also have granted edit-everything on installs with `collaborationSecurityEnabled=false`.

2. **Email visibility stays unchanged**: previously `access=write` implied showing user emails in the API response. The new grant would have exposed submitter/photographer/informOthers emails on public encounters to every logged-in user, so `jsonForApiGet()` now unhides emails only for users with a real relationship to the encounter (owner/admin/edit-collaborator, via new `canUserViewContactInfo()`), exactly the set that had write access before this change.

## Testing

New regression tests in `PermissionsTest` (each written first and verified failing before its fix):

- `encounterPublicEditTest` — logged-in user can edit a public encounter (all `isUsernameAnonymous` submitterID flavors); anonymous caller cannot; other users' encounters stay uneditable, including with `collaborationSecurityEnabled=false`.
- `encounterPublicEditEmailHiddenTest` — `jsonForApiGet` returns `access=write` for a logged-in user on a public encounter while submitter-list emails remain hidden.

All `PermissionsTest` (7), `EncounterAclFieldsTest`, `ComputeViewUsersTest`, `MatchResultTest`, `EncounterApiTest` (28 total) pass. Search/ACL visibility is unaffected: `computeViewUsers` and the OpenSearch ACL fields use the view path, not `canUserEdit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
