### PR TITLE
Don't index non-candidate (trivial) annotations in OpenSearch

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -276,10 +276,27 @@ public class Annotation extends Base implements java.io.Serializable {
         jgen.writeEndArray();
     }
 
-    // TODO should this also be limited by matchAgainst and acmId?
     @Override public String getAllVersionsSql() {
+        // Desired-state for the OpenSearch reconciler: only annotations that should have
+        // an index doc -- match candidates (matchAgainst) or anything carrying an
+        // embedding. MUST stay semantically identical to shouldIndexInOpenSearch() below.
+        // Non-candidate/"trivial" (undetected, no-embedding) annotations are excluded so
+        // the reconciler neither re-indexes them nor flags them as missing (which would
+        // churn forever), and removes any already-indexed ones via its needRemoval pass.
         return
-                "SELECT \"ID\", \"VERSION\" AS version FROM \"ANNOTATION\" ORDER BY \"MATCHAGAINST\" DESC, version";
+                "SELECT \"ID\", \"VERSION\" AS version FROM \"ANNOTATION\" " +
+                "WHERE \"MATCHAGAINST\" = true OR EXISTS " +
+                "(SELECT 1 FROM \"EMBEDDING\" e WHERE e.\"ANNOTATION_ID\" = \"ANNOTATION\".\"ID\") " +
+                "ORDER BY \"MATCHAGAINST\" DESC, version";
+    }
+
+    // Keep non-candidate / "trivial" (undetected, no-embedding) annotations OUT of the
+    // OpenSearch annotation index: they bloat it and get churned by encounter deep-index
+    // cascades without ever being match candidates. Do NOT use isTrivial() (bbox
+    // geometry) -- matchable whole-image/unity/spot-crop annotations are geometrically
+    // trivial but MUST be indexed. MUST stay identical to the getAllVersionsSql() filter.
+    @Override public boolean shouldIndexInOpenSearch() {
+        return getMatchAgainst() || (numberEmbeddings() > 0);
     }
 
     @Override public Base getById(Shepherd myShepherd, String id) {

--- a/src/main/java/org/ecocean/Base.java
+++ b/src/main/java/org/ecocean/Base.java
@@ -140,6 +140,15 @@ import org.json.JSONObject;
         return map;
     }
 
+    // Whether this object should have a document in its OpenSearch index at all.
+    // Default true; overridden by classes (e.g. Annotation) that keep non-candidate
+    // records out of the index. Enforced centrally in OpenSearch.index(), so both
+    // opensearchIndex() and the reconciler's direct os.index() honor it; keep the
+    // class's getAllVersionsSql() filtered to the same set.
+    public boolean shouldIndexInOpenSearch() {
+        return true;
+    }
+
     public void opensearchIndex()
     throws IOException {
         long startT = System.currentTimeMillis();

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -4814,6 +4814,11 @@ public class Encounter extends Base implements java.io.Serializable {
                     }
                     if (enc.hasAnnotations()) {
                         for (Annotation ann : enc.getAnnotations()) {
+                            // Skip non-candidate/"trivial" annotations so encounter deep-index
+                            // cascades don't repeatedly touch index docs that shouldn't exist
+                            // (OpenSearch.index() would just delete them). See
+                            // Annotation.shouldIndexInOpenSearch().
+                            if (!ann.shouldIndexInOpenSearch()) continue;
                             System.out.println("opensearchIndexDeep() background indexing annot " +
                                 ann.getId() + " via enc " + encId);
                             try {

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -279,6 +279,15 @@ public class OpenSearch {
         String id = obj.getId();
         if (!Util.stringExists(id))
             throw new RuntimeException("must have id property to index: " + obj);
+        // Central gate: objects that opt out (e.g. non-candidate/"trivial" annotations)
+        // must not have an index doc. Delete any stale doc (covers matchAgainst->false or
+        // last-embedding-removed transitions) and skip indexing. This makes BOTH
+        // Base.opensearchIndex() and the reconciler's direct os.index(obj) honor the
+        // predicate. Synchronous delete: callers are already on background threads.
+        if (!obj.shouldIndexInOpenSearch()) {
+            delete(indexName, id);   // delete() no-ops if the index/doc is absent
+            return;
+        }
         ensureIndex(indexName, obj.opensearchMapping());
         IndexRequest<Base> indexRequest = new IndexRequest.Builder<Base>()
                 .index(indexName)

--- a/src/main/resources/agent-skills/api-reference.md
+++ b/src/main/resources/agent-skills/api-reference.md
@@ -39,6 +39,13 @@ Pagination via `?from=&size=` query params; total hits in the `X-Wildbook-Total-
 Non-admin `individual` search may only query/sort identity fields. Scripted queries and cross-index
 term lookups are rejected.
 
+**What `annotation` search covers.** The `annotation` index holds only annotations that are ready for
+photo-matching — ones that have been through animal detection or otherwise carry a matching
+fingerprint. A plain whole-photo entry for a picture that has not yet been through detection is **not**
+in this index, so it will not appear in `annotation` search results, counts, or aggregations. To see
+every photo on an encounter — including not-yet-detected ones — search `encounter` instead: each
+encounter result lists all of its photos with image URLs (`mediaAssets[].url`).
+
 **Counting with aggregations.** A single bounded `terms` aggregation is supported — e.g. to count
 records per location without paging them all:
 ```json
@@ -86,6 +93,14 @@ are just `{ id, status }`. **Branch on `status`: only `identified` and `unidenti
 entry that has an image: the `bbox` is in the `imageWidth`×`imageHeight` coordinate space; **fetch
 `imageUrl`, read its real pixel dimensions, and scale `bbox` by `realW/imageWidth`, `realH/imageHeight`
 before cropping** (usually a no-op).
+
+**Which IDs resolve to an image.** `media/resolve` can only return an image for an annotation that is
+in the `annotation` index — that is, a match-ready annotation (see *What `annotation` search covers*
+above). If you pass the ID of a plain whole-photo entry (a picture that has not been through
+detection), it comes back `unavailable` — the same status as an ID you are not allowed to see. That
+does **not** mean the photo is out of reach: read the whole-photo URL directly from the encounter
+result's `mediaAssets[].url`. Use `media/resolve` for detected annotation crops, and `search/encounter`
+for an encounter's complete photo list.
 
 ## OpenSearch schema (token-exposed fields)
 Key indices and fields:

--- a/src/test/java/org/ecocean/AnnotationShouldIndexTest.java
+++ b/src/test/java/org/ecocean/AnnotationShouldIndexTest.java
@@ -1,0 +1,72 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the "should this annotation have an OpenSearch doc?" contract that keeps
+ * non-candidate / "trivial" (undetected, no-embedding) annotations out of the
+ * annotation index. The predicate ({@link Annotation#shouldIndexInOpenSearch()})
+ * and the reconciler desired-state SQL ({@link Annotation#getAllVersionsSql()})
+ * MUST stay semantically identical; these tests guard both.
+ *
+ * <p>Deliberately does NOT use {@code isTrivial()} (bbox geometry): matchable
+ * whole-image / unity / spot-crop annotations are geometrically trivial but must
+ * still be indexed, so the predicate keys on matchAgainst / embedding presence.</p>
+ */
+class AnnotationShouldIndexTest {
+
+    @Test void nonCandidate_notIndexed() {
+        Annotation ann = new Annotation();
+        // default: matchAgainst=false, no embeddings -> non-candidate/trivial
+        assertFalse(ann.getMatchAgainst(), "precondition: matchAgainst defaults false");
+        assertFalse(ann.shouldIndexInOpenSearch(),
+            "annotation with matchAgainst=false and no embeddings must NOT be indexed");
+    }
+
+    @Test void matchAgainst_isIndexed() {
+        Annotation ann = new Annotation();
+        ann.setMatchAgainst(true);
+        assertTrue(ann.shouldIndexInOpenSearch(),
+            "matchAgainst==true annotation must be indexed");
+    }
+
+    @Test void hasEmbedding_isIndexed_evenWhenNotMatchAgainst() {
+        Annotation ann = new Annotation();
+        org.json.JSONArray vec = new org.json.JSONArray();
+        for (int i = 0; i < 8; i++) vec.put(0.1d * i);
+        new org.ecocean.Embedding(ann, "miewid", "msv4.1", vec); // constructor auto-attaches
+        assertTrue(ann.numberEmbeddings() > 0, "precondition: embedding attached");
+        assertFalse(ann.getMatchAgainst(), "precondition: matchAgainst still false");
+        assertTrue(ann.shouldIndexInOpenSearch(),
+            "annotation carrying an embedding must be indexed even if matchAgainst=false");
+    }
+
+    // The reconciler SQL must select the SAME set the predicate accepts, or the
+    // reconciler would either churn (re-listing excluded docs as missing) or fail to
+    // remove them. Pin the filter shape so drift is caught.
+    @Test void getAllVersionsSql_filtersToCandidates() {
+        String sql = new Annotation().getAllVersionsSql();
+        assertTrue(sql.contains("\"MATCHAGAINST\" = true"),
+            "reconciler SQL must filter on matchAgainst: " + sql);
+        assertTrue(sql.contains("EXISTS"),
+            "reconciler SQL must use EXISTS for the embedding check: " + sql);
+        assertTrue(sql.contains("\"EMBEDDING\"") && sql.contains("\"ANNOTATION_ID\""),
+            "reconciler SQL must check the EMBEDDING table by ANNOTATION_ID: " + sql);
+    }
+
+    // Exact-shape guard: pins the predicate AND the ORDER BY so any drift (or a change
+    // that diverges from shouldIndexInOpenSearch()) trips a failure.
+    @Test void getAllVersionsSql_exactShape() {
+        String expected =
+                "SELECT \"ID\", \"VERSION\" AS version FROM \"ANNOTATION\" " +
+                "WHERE \"MATCHAGAINST\" = true OR EXISTS " +
+                "(SELECT 1 FROM \"EMBEDDING\" e WHERE e.\"ANNOTATION_ID\" = \"ANNOTATION\".\"ID\") " +
+                "ORDER BY \"MATCHAGAINST\" DESC, version";
+        assertEquals(expected, new Annotation().getAllVersionsSql(),
+            "getAllVersionsSql drifted from the pinned candidate-filter shape");
+    }
+}


### PR DESCRIPTION
## Problem

The OpenSearch `annotation` index carries **every** annotation (~1M on a large deployment), but vector matching only ever queries **match candidates** (~260k). The historical tail of trivial / undetected, no-embedding annotations:
- bloats the index (disk, filter bitsets, merges, caches),
- inflates the reconciler's `getAllVersions` scroll past its socket timeout (so the reconciler can't run), and
- **gets repeatedly deep-reindexed via encounter cascades** — churn that keeps regenerating segments/tombstones and defeats `force-merge`.

Observed live on a large Sharkbook deployment: filtered kNN over ~226k candidates times out (→ empty match results), the annotation index sat at ~642k live + ~345k deleted docs (35% tombstones), and an active detection run kept deep-reindexing trivial annotations.

## Change

Keep non-candidate annotations out of the index — keyed on **match-candidacy, not bbox geometry**. (Deliberately **not** `isTrivial()`: matchable whole-image / unity / spot-crop annotations are geometrically trivial but must be indexed — see the earlier matchable-unity fix.)

- **`Base.shouldIndexInOpenSearch()`** — new, default `true` (no change for Encounter/Individual/Occurrence/MediaAsset).
- **`Annotation.shouldIndexInOpenSearch()`** — `getMatchAgainst() || numberEmbeddings() > 0`. (`||` short-circuits, so match candidates never trigger the embedding count.)
- **`OpenSearch.index()`** — single central gate: if an object opts out, **delete any stale doc and skip**. Makes *both* `Base.opensearchIndex()` (postStore/`IndexingManager`) and the reconciler's direct `os.index()` honor the predicate, and cleans docs on `matchAgainst`→false / last-embedding-removed transitions.
- **`Annotation.getAllVersionsSql()`** — filtered to the identical set (`"MATCHAGAINST"=true OR EXISTS(embedding)`), so the reconciler skips non-candidates in `needIndexing` and removes already-indexed ones via `needRemoval`. (Resolves the pre-existing TODO on this method.)
- **`Encounter` deep-index cascade** — skips excluded annotations so cascades don't repeatedly touch index docs that shouldn't exist.
- **Test** — pins the predicate and the exact reconciler SQL (predicate ⟷ SQL parity is load-bearing).

No change to `Base.opensearchSyncIndex` or `opensearchSync.jsp` → **no conflict with #1652**.

## Review
Design **and** code Codex-reviewed — concurred, no Critical/Major. Minors addressed (predicate short-circuit for the lazy-count concern; exact-SQL test assertion).

## Rollout notes (deployers)
1. **Bootstrap of existing docs:** this stops *new* trivial indexing and the reconciler will *remove* existing trivial docs via `needRemoval` — but on an already-bloated index the reconciler scroll may time out first. Do a **fresh candidate-only reindex** (`opensearchSync` `resetIndex`) or shrink via force-merge so the reconciler can run.
2. **DB index:** the reconciler SQL now does `EXISTS(EMBEDDING by ANNOTATION_ID)` each pass — confirm `EMBEDDING.ANNOTATION_ID` is indexed (it's a FK, normally is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)