### PR TITLE
AcmIdBot: replace 24h query with WBIA reconciliation sweep of the matchable set

### DIFF
--- a/docs/superpowers/plans/2026-07-01-acmidbot-reconciliation-sweep.md
+++ b/docs/superpowers/plans/2026-07-01-acmidbot-reconciliation-sweep.md
@@ -417,6 +417,7 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
   - `static SweepPage AcmIdBot.collectSweepPage(Iterator<MediaAsset> assetsInIdOrder, int pageSize)`
   - `static int AcmIdBot.nextCursorAfterSuccess(SweepPage page, boolean maxFixesHit, int resumeAssetId)`
   - `static boolean AcmIdBot.shouldSkipPoisonedPage(int consecutiveFailures)`
+  - `static boolean AcmIdBot.sendConfirmedAcmId(org.json.JSONObject sendRtn, String expectedAcmId)` — true only when the WBIA add-images response echoes the expected acmId; Task 6 gates commit+count on it
 
 - [ ] **Step 1: Write the failing test**
 
@@ -562,6 +563,43 @@ class AcmIdBotSweepTest {
         assertTrue(AcmIdBot.shouldSkipPoisonedPage(3));
         assertTrue(AcmIdBot.shouldSkipPoisonedPage(4));
     }
+
+    // ---------- sendConfirmedAcmId ----------
+
+    private static org.json.JSONObject sendRtnWithUuids(String... uuids) {
+        org.json.JSONArray resp = new org.json.JSONArray();
+
+        for (String u : uuids) {
+            org.json.JSONObject fancy = new org.json.JSONObject();
+            fancy.put("__UUID__", u);
+            resp.put(fancy);
+        }
+        org.json.JSONObject rtn = new org.json.JSONObject();
+        rtn.put("response", resp);
+        org.json.JSONArray batches = new org.json.JSONArray();
+        batches.put(rtn);
+        org.json.JSONObject all = new org.json.JSONObject();
+        all.put("batchResults", batches);
+        return all;
+    }
+
+    @Test void confirmsWhenResponseContainsExpectedAcmId() {
+        assertTrue(AcmIdBot.sendConfirmedAcmId(sendRtnWithUuids("abc", "def"), "def"));
+    }
+
+    @Test void doesNotConfirmWhenUuidAbsentOrBatchEmpty() {
+        assertFalse(AcmIdBot.sendConfirmedAcmId(sendRtnWithUuids("abc"), "def"));
+        org.json.JSONObject all = new org.json.JSONObject();
+        org.json.JSONArray batches = new org.json.JSONArray();
+        batches.put("EMPTY BATCH");
+        all.put("batchResults", batches);
+        assertFalse(AcmIdBot.sendConfirmedAcmId(all, "def"));
+    }
+
+    @Test void doesNotConfirmOnNulls() {
+        assertFalse(AcmIdBot.sendConfirmedAcmId(null, "abc"));
+        assertFalse(AcmIdBot.sendConfirmedAcmId(sendRtnWithUuids("abc"), null));
+    }
 }
 ```
 
@@ -606,19 +644,20 @@ In `src/main/java/org/ecocean/AcmIdBot.java`, after the closing brace of `fixFea
         while (assetsInIdOrder.hasNext()) {
             MediaAsset asset = assetsInIdOrder.next();
             if (asset == null) continue;
-            if (seen.contains(asset.getId())) continue;
+            // NOTE: MediaAsset.getId() returns String; getIdInt() is the int accessor
+            if (seen.contains(asset.getIdInt())) continue;
             if (seen.size() >= pageSize) {
                 page.rawExhausted = false;
                 return page;
             }
-            seen.add(asset.getId());
-            page.lastAssetId = asset.getId();
+            seen.add(asset.getIdInt());
+            page.lastAssetId = asset.getIdInt();
             // known-invalid assets are unhealable: counted as processed, never probed
             if (asset.isValidImageForIA() != null && !asset.isValidImageForIA()) continue;
             if (asset.getAcmId() == null) {
-                page.nullAcmAssetIds.add(asset.getId());
+                page.nullAcmAssetIds.add(asset.getIdInt());
             } else {
-                page.acmIdToAssetId.put(asset.getAcmId(), asset.getId());
+                page.acmIdToAssetId.put(asset.getAcmId(), asset.getIdInt());
             }
         }
         return page;
@@ -637,12 +676,34 @@ In `src/main/java/org/ecocean/AcmIdBot.java`, after the closing brace of `fixFea
     static boolean shouldSkipPoisonedPage(int consecutiveFailures) {
         return consecutiveFailures >= PAGE_FAIL_LIMIT;
     }
+
+    // did a sendMediaAssetsNew() round-trip actually register this acmId with
+    // WBIA? add_images_json returns the registered image UUIDs; require ours
+    // among them before counting (and committing) a heal — otherwise a locally
+    // pre-assigned acmId could be persisted although WBIA never registered it
+    static boolean sendConfirmedAcmId(org.json.JSONObject sendRtn, String expectedAcmId) {
+        if ((sendRtn == null) || (expectedAcmId == null)) return false;
+        org.json.JSONArray batches = sendRtn.optJSONArray("batchResults");
+        if (batches == null) return false;
+        for (int b = 0; b < batches.length(); b++) {
+            org.json.JSONObject rtn = batches.optJSONObject(b);
+            if (rtn == null) continue; // "EMPTY BATCH" marker string
+            org.json.JSONArray resp = rtn.optJSONArray("response");
+            if (resp == null) continue;
+            for (int i = 0; i < resp.length(); i++) {
+                org.json.JSONObject fancy = resp.optJSONObject(i);
+                if ((fancy != null) &&
+                    expectedAcmId.equals(fancy.optString("__UUID__", null))) return true;
+            }
+        }
+        return false;
+    }
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `mvn test -Dtest=AcmIdBotSweepTest 2>&1 | tail -25`
-Expected: `Tests run: 11, Failures: 0, Errors: 0` — BUILD SUCCESS.
+Expected: `Tests run: 14, Failures: 0, Errors: 0` — BUILD SUCCESS.
 
 - [ ] **Step 5: CRLF check and commit**
 
@@ -662,7 +723,7 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 - Modify: `src/main/java/org/ecocean/AcmIdBot.java` (replace the Query-2/filter3 block in `fixAcmIds` lines 154-171; add `sweepMatchableAssets`; update the class comment lines 17-24; add imports)
 
 **Interfaces:**
-- Consumes: `SweepPage`/`collectSweepPage`/`nextCursorAfterSuccess`/`shouldSkipPoisonedPage`/`sweepCursor`/`sweepFailCount`/`SWEEP_PAGE_SIZE` (Task 5); `WildbookIAM.iaMissingImageIds(List, String)` (Task 2); `IBEISIA.sendMediaAssetsNew(mas, context, false)` (Task 3); existing `MediaAssetFactory.load(int, Shepherd)` (MediaAssetFactory.java:21), `Shepherd.updateDBTransaction()`.
+- Consumes: `SweepPage`/`collectSweepPage`/`nextCursorAfterSuccess`/`shouldSkipPoisonedPage`/`sendConfirmedAcmId`/`sweepCursor`/`sweepFailCount`/`SWEEP_PAGE_SIZE` (Task 5); `WildbookIAM.iaMissingImageIds(List, String)` (Task 2); `IBEISIA.sendMediaAssetsNew(mas, context, false)` (Task 3); existing `MediaAssetFactory.load(int, Shepherd)` (MediaAssetFactory.java:21), `Shepherd.updateDBTransaction()`.
 - Produces: `static void AcmIdBot.sweepMatchableAssets(String context, int maxFixes)` — called from `fixAcmIds` after the Query-1 heal.
 
 - [ ] **Step 1: Replace the Query-2 block in `fixAcmIds`**
@@ -804,21 +865,29 @@ Current code (AcmIdBot.java, after the `fixFeats(feats, ...)` Query-1 call — t
                         if (!asset.isValidImageForIA()) continue;
                         if (!asset.hasFamily(healShepherd)) asset.updateStandardChildren();
                         // legacy rows: adopt the constructor convention before sending
-                        if (asset.getAcmId() == null) asset.setAcmId(asset.getUUID());
+                        String priorAcmId = asset.getAcmId();
+                        if (priorAcmId == null) asset.setAcmId(asset.getUUID());
                         ArrayList<MediaAsset> fixMe = new ArrayList<MediaAsset>();
                         fixMe.add(asset);
                         // checkFirst=false: the probe already established absence
-                        IBEISIA.sendMediaAssetsNew(fixMe, context, false);
+                        org.json.JSONObject sendRtn = IBEISIA.sendMediaAssetsNew(fixMe,
+                            context, false);
                         sentCount++;
-                        // commit so the (possibly rectified) acmId survives rollbackAndClose
-                        healShepherd.updateDBTransaction();
-                        if (asset.getAcmId() != null) {
+                        if (sendConfirmedAcmId(sendRtn, asset.getAcmId())) {
+                            // commit so the confirmed acmId survives rollbackAndClose
+                            healShepherd.updateDBTransaction();
                             healedCount++;
                             if (healedCount >= maxFixes) {
                                 maxFixesHit = true;
                                 resumeAssetId = assetId.intValue();
                                 break;
                             }
+                        } else {
+                            System.out.println(
+                                "WARNING: AcmIdBot sweep could not confirm WBIA registration for asset "
+                                + assetId + "; not counting as healed");
+                            // don't persist an acmId WBIA never acknowledged
+                            asset.setAcmId(priorAcmId);
                         }
                     } catch (Exception ec) {
                         System.out.println("Exception in AcmIdBot sweep heal for asset " +
@@ -878,7 +947,7 @@ with:
 
 Run: `mvn -q compile 2>&1 | tail -20` — expect no `ERROR` lines.
 Run: `mvn test -Dtest='AcmIdBotSweepTest,WildbookIAMRowidProbeParseTest' 2>&1 | tail -20`
-Expected: `Tests run: 18, Failures: 0, Errors: 0`.
+Expected: `Tests run: 21, Failures: 0, Errors: 0`.
 
 - [ ] **Step 5: CRLF check and commit**
 
@@ -974,7 +1043,7 @@ Current code (AcmIdBot.java lines 85-127: `startServices` through `cleanup`). Re
 mvn -q compile 2>&1 | tail -20                    # expect no ERROR lines
 mvn test -Dtest='AcmIdBotSweepTest,WildbookIAMRowidProbeParseTest,WildbookIAMImageIdsStrictTest,WildbookIAMFancyUuidArrayStrictTest' 2>&1 | tail -20
 ```
-Expected: all listed classes pass (18 new tests + existing strict-parse tests as regression guard).
+Expected: all listed classes pass (21 new tests + existing strict-parse tests as regression guard).
 
 - [ ] **Step 3: CRLF check and commit**
 

--- a/docs/superpowers/plans/2026-07-01-acmidbot-reconciliation-sweep.md
+++ b/docs/superpowers/plans/2026-07-01-acmidbot-reconciliation-sweep.md
@@ -854,8 +854,13 @@ Current code (AcmIdBot.java, after the `fixFeats(feats, ...)` Query-1 call — t
             try {
                 for (Integer assetId : candidateIds) {
                     healShepherd.setAction("AcmIdBot.sweepHeal_asset_" + assetId);
+                    // hoisted so the catch block can revert a pre-assigned acmId that
+                    // WBIA never acknowledged (send threw before confirmation)
+                    MediaAsset asset = null;
+                    String priorAcmId = null;
+                    boolean priorCaptured = false;
                     try {
-                        MediaAsset asset = org.ecocean.media.MediaAssetFactory.load(
+                        asset = org.ecocean.media.MediaAssetFactory.load(
                             assetId.intValue(), healShepherd);
                         if (asset == null) continue;
                         if (asset.isValidImageForIA() == null) {
@@ -865,7 +870,8 @@ Current code (AcmIdBot.java, after the `fixFeats(feats, ...)` Query-1 call — t
                         if (!asset.isValidImageForIA()) continue;
                         if (!asset.hasFamily(healShepherd)) asset.updateStandardChildren();
                         // legacy rows: adopt the constructor convention before sending
-                        String priorAcmId = asset.getAcmId();
+                        priorAcmId = asset.getAcmId();
+                        priorCaptured = true;
                         if (priorAcmId == null) asset.setAcmId(asset.getUUID());
                         ArrayList<MediaAsset> fixMe = new ArrayList<MediaAsset>();
                         fixMe.add(asset);
@@ -890,14 +896,16 @@ Current code (AcmIdBot.java, after the `fixFeats(feats, ...)` Query-1 call — t
                             asset.setAcmId(priorAcmId);
                         }
                     } catch (Exception ec) {
+                        // revert BEFORE any commit below (or a later asset's commit)
+                        // can persist an acmId WBIA never acknowledged; probed-missing
+                        // assets revert to their original non-null DB acmId
+                        if (priorCaptured && asset != null) asset.setAcmId(priorAcmId);
                         System.out.println("Exception in AcmIdBot sweep heal for asset " +
                             assetId);
                         ec.printStackTrace();
                         // mirror fixFeats: a 500 from WBIA marks the image invalid for IA
                         if (ec.toString().contains("HTTP error code : 500")) {
                             try {
-                                MediaAsset asset = org.ecocean.media.MediaAssetFactory.load(
-                                    assetId.intValue(), healShepherd);
                                 if (asset != null) {
                                     asset.setIsValidImageForIA(false);
                                     healShepherd.updateDBTransaction();

--- a/docs/superpowers/plans/2026-07-01-acmidbot-reconciliation-sweep.md
+++ b/docs/superpowers/plans/2026-07-01-acmidbot-reconciliation-sweep.md
@@ -1,0 +1,994 @@
+# AcmIdBot Reconciliation Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace AcmIdBot's 24-hour Query 2 with a cursor-paged sweep of all matchable MediaAssets that probes WBIA for unknown acmIds and heals them.
+
+**Architecture:** Three-phase sweep inside the existing 15-minute AcmIdBot scheduler: (1) read phase collects one page of distinct asset ids/acmIds from a JDOQL query over `matchAgainst==true` annotations, (2) probe phase asks WBIA `GET /api/image/rowid/uuid/` in 50-UUID chunks which acmIds it doesn't know, (3) heal phase re-registers missing assets via the existing `sendMediaAssets` (which sends Wildbook-assigned `image_uuid_list`) with explicit transaction commits. An in-memory cursor pages ~10k assets per run and wraps around.
+
+**Tech Stack:** Java 11, DataNucleus JDO (JDOQL string queries), org.json, JUnit 5 (Jupiter), Maven surefire.
+
+**Spec:** `docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md` (rev 2 — read it before starting any task).
+
+## Global Constraints
+
+- Working directory: `/mnt/c/Wildbook-clean2/.claude/worktrees/acmidbot-sweep` (git worktree, branch `feature/acmidbot-reconciliation-sweep`). NEVER run `git checkout`, `git branch`, `git reset`, or `git stash`.
+- Constants (exact values from spec): `SWEEP_PAGE_SIZE = 10000`, `PROBE_CHUNK_SIZE = 50`, `PAGE_FAIL_LIMIT = 3`, `maxFixes = 500` (existing local in `fixAcmIds`).
+- Query 1 (ImportTask fast-path) in `AcmIdBot.fixAcmIds()` stays untouched.
+- JUnit 5 assertion message goes LAST: `assertTrue(cond, "msg")`.
+- Before every commit: `grep -c $'\r' <file>` must print `0` for each staged file (CRLF check); if not, `sed -i 's/\r$//' <file>`.
+- Compile check command (backend only, ~2–4 min on WSL): `mvn -q compile 2>&1 | tail -20` — expect no `ERROR` lines.
+- Single-class test command: `mvn test -Dtest=<ClassName> 2>&1 | tail -25` (pom's surefire argLine already carries the needed `--add-opens`).
+- Match surrounding code style: `System.out.println` + `IA.log` logging, C-style Java, no lambdas in AcmIdBot (keep its existing idiom), generics OK.
+
+---
+
+### Task 1: WBIA probe pure helpers (`chunkList`, `parseRowidProbeResponse`)
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/ia/plugin/WildbookIAM.java` (add two package-visible static helpers + one constant, near `parseImageIdsArrayStrict` ~line 637)
+- Test: `src/test/java/org/ecocean/ia/plugin/WildbookIAMRowidProbeParseTest.java` (create)
+
+**Interfaces:**
+- Consumes: nothing new (org.json only).
+- Produces: `static <T> List<List<T>> WildbookIAM.chunkList(List<T> items, int size)`; `static List<String> WildbookIAM.parseRowidProbeResponse(List<String> chunkAcmIds, JSONArray response) throws IOException`; `static final int WildbookIAM.PROBE_CHUNK_SIZE = 50`. Task 2 calls all three.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/java/org/ecocean/ia/plugin/WildbookIAMRowidProbeParseTest.java`:
+
+```java
+package org.ecocean.ia.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Coverage of the pure helpers behind
+ * {@link WildbookIAM#iaMissingImageIds(java.util.List, String)}:
+ * {@link WildbookIAM#chunkList(List, int)} and
+ * {@link WildbookIAM#parseRowidProbeResponse(List, JSONArray)}.
+ * The WBIA endpoint /api/image/rowid/uuid/ returns a rowid per requested
+ * image UUID, with JSON null where the UUID is unknown; null entries mark
+ * the acmId as missing from WBIA. (AcmIdBot reconciliation sweep spec §3.)
+ */
+class WildbookIAMRowidProbeParseTest {
+
+    // ---------- chunkList ----------
+
+    @Test void chunkListSplitsAtExactBoundary() {
+        List<String> in = new ArrayList<String>();
+        for (int i = 0; i < 100; i++) in.add("u" + i);
+        List<List<String>> out = WildbookIAM.chunkList(in, 50);
+        assertEquals(2, out.size());
+        assertEquals(50, out.get(0).size());
+        assertEquals(50, out.get(1).size());
+        assertEquals("u0", out.get(0).get(0));
+        assertEquals("u99", out.get(1).get(49));
+    }
+
+    @Test void chunkListHandlesRemainderAndSmallInput() {
+        List<List<String>> out = WildbookIAM.chunkList(Arrays.asList("a", "b", "c"), 2);
+        assertEquals(2, out.size());
+        assertEquals(2, out.get(0).size());
+        assertEquals(1, out.get(1).size());
+        out = WildbookIAM.chunkList(Arrays.asList("solo"), 50);
+        assertEquals(1, out.size());
+        assertEquals("solo", out.get(0).get(0));
+    }
+
+    @Test void chunkListEmptyOrNullOrBadSizeReturnsEmpty() {
+        assertEquals(0, WildbookIAM.chunkList(new ArrayList<String>(), 50).size());
+        assertEquals(0, WildbookIAM.chunkList(null, 50).size());
+        assertEquals(0, WildbookIAM.chunkList(Arrays.asList("a"), 0).size());
+    }
+
+    // ---------- parseRowidProbeResponse ----------
+
+    @Test void nullRowidEntriesAreMissing() throws IOException {
+        List<String> chunk = Arrays.asList("aaa", "bbb", "ccc");
+        JSONArray resp = new JSONArray();
+        resp.put(101);
+        resp.put(org.json.JSONObject.NULL);
+        resp.put(303);
+        List<String> missing = WildbookIAM.parseRowidProbeResponse(chunk, resp);
+        assertEquals(1, missing.size());
+        assertEquals("bbb", missing.get(0));
+    }
+
+    @Test void allKnownReturnsEmpty() throws IOException {
+        List<String> chunk = Arrays.asList("aaa", "bbb");
+        JSONArray resp = new JSONArray();
+        resp.put(1);
+        resp.put(2);
+        assertEquals(0, WildbookIAM.parseRowidProbeResponse(chunk, resp).size());
+    }
+
+    @Test void lengthMismatchThrows() {
+        List<String> chunk = Arrays.asList("aaa", "bbb");
+        JSONArray resp = new JSONArray();
+        resp.put(1);
+        IOException ex = assertThrows(IOException.class,
+            () -> WildbookIAM.parseRowidProbeResponse(chunk, resp));
+        assertTrue(ex.getMessage().contains("length"),
+            "message should mention length: " + ex.getMessage());
+    }
+
+    @Test void nullResponseThrows() {
+        List<String> chunk = Arrays.asList("aaa");
+        assertThrows(IOException.class,
+            () -> WildbookIAM.parseRowidProbeResponse(chunk, null));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -Dtest=WildbookIAMRowidProbeParseTest 2>&1 | tail -25`
+Expected: COMPILATION ERROR — `cannot find symbol: method chunkList` / `parseRowidProbeResponse`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/main/java/org/ecocean/ia/plugin/WildbookIAM.java`, directly after the `parseImageIdsArrayStrict` method (~line 638), add:
+
+```java
+    /**
+     * Chunk size for the /api/image/rowid/uuid/ existence probe. 50 fancy
+     * UUIDs is ~3.5 KB of query string — safely under common proxy URL
+     * limits. (AcmIdBot reconciliation sweep spec §3/§6.)
+     */
+    static final int PROBE_CHUNK_SIZE = 50;
+
+    /**
+     * Split a list into consecutive sublists of at most {@code size}
+     * elements, preserving order. Returns an empty list for null/empty
+     * input or a non-positive size.
+     */
+    static <T> java.util.List<java.util.List<T>> chunkList(java.util.List<T> items, int size) {
+        java.util.List<java.util.List<T>> out = new ArrayList<java.util.List<T>>();
+
+        if ((items == null) || items.isEmpty() || (size < 1)) return out;
+        for (int i = 0; i < items.size(); i += size) {
+            out.add(new ArrayList<T>(items.subList(i, Math.min(items.size(), i + size))));
+        }
+        return out;
+    }
+
+    /**
+     * Interpret one /api/image/rowid/uuid/ response chunk. WBIA returns a
+     * rowid per requested UUID, with JSON null where the UUID is unknown;
+     * those unknown acmIds are returned. Throws IOException on a null
+     * response or a request/response length mismatch so a malformed reply
+     * is treated as a failed probe, never as "all present". (AcmIdBot
+     * reconciliation sweep spec §3.)
+     */
+    static List<String> parseRowidProbeResponse(List<String> chunkAcmIds, JSONArray response)
+    throws IOException {
+        if (response == null)
+            throw new IOException("rowid probe returned null response for chunk of " +
+                    chunkAcmIds.size());
+        if (response.length() != chunkAcmIds.size())
+            throw new IOException("rowid probe response length " + response.length() +
+                    " != request length " + chunkAcmIds.size());
+        List<String> missing = new ArrayList<String>();
+        for (int i = 0; i < response.length(); i++) {
+            if (response.isNull(i)) missing.add(chunkAcmIds.get(i));
+        }
+        return missing;
+    }
+```
+
+Note: `WildbookIAM.java` already imports `java.io.IOException`, `java.util.ArrayList`, `java.util.List`, and `org.json.JSONArray` — verify with `grep -n "^import" src/main/java/org/ecocean/ia/plugin/WildbookIAM.java` and add any of those that are absent.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn test -Dtest=WildbookIAMRowidProbeParseTest 2>&1 | tail -25`
+Expected: `Tests run: 7, Failures: 0, Errors: 0` — BUILD SUCCESS.
+
+- [ ] **Step 5: CRLF check and commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/ia/plugin/WildbookIAM.java src/test/java/org/ecocean/ia/plugin/WildbookIAMRowidProbeParseTest.java
+# each line must end ":0"; if not: sed -i 's/\r$//' <file>
+git add src/main/java/org/ecocean/ia/plugin/WildbookIAM.java src/test/java/org/ecocean/ia/plugin/WildbookIAMRowidProbeParseTest.java
+git commit -m "feat: pure helpers for WBIA image-uuid existence probe
+
+chunkList + parseRowidProbeResponse interpret /api/image/rowid/uuid/
+responses (null rowid = unknown acmId); malformed replies throw rather
+than reading as all-present. Sweep spec §3.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `iaMissingImageIds` probe method
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/ia/plugin/WildbookIAM.java` (add one method right after `parseRowidProbeResponse` from Task 1)
+
+**Interfaces:**
+- Consumes: `chunkList`, `parseRowidProbeResponse`, `PROBE_CHUNK_SIZE` (Task 1); existing `apiGetJSONArray(String, String)` and `toFancyUUID(String)`.
+- Produces: `public static List<String> WildbookIAM.iaMissingImageIds(List<String> acmIds, String context) throws IOException` — Task 6 calls this. Skips null entries; returns the subset of acmIds WBIA does not know; throws IOException if any chunk fails (caller must treat the whole probe as failed).
+
+No new unit test: the branching logic lives in the Task 1 helpers (already tested); this method is HTTP orchestration following the existing `iaImageIds()` idiom, verified by compile + review.
+
+- [ ] **Step 1: Write the implementation**
+
+Directly after `parseRowidProbeResponse` in `WildbookIAM.java`, add:
+
+```java
+    /**
+     * Ask WBIA which of the given image acmIds it does NOT have, via
+     * GET /api/image/rowid/uuid/ in {@link #PROBE_CHUNK_SIZE} chunks
+     * (a null rowid in the response marks that UUID unknown — see
+     * wildbook-ia get_image_gids_from_uuid). Null acmIds are skipped
+     * (callers treat those assets as heal candidates without probing).
+     * Throws IOException if any chunk fails so callers never mistake a
+     * failed probe for "all present". (AcmIdBot sweep spec §3.)
+     */
+    public static List<String> iaMissingImageIds(List<String> acmIds, String context)
+    throws IOException {
+        List<String> missing = new ArrayList<String>();
+
+        if (acmIds == null) return missing;
+        List<String> probeable = new ArrayList<String>();
+        for (String acmId : acmIds) {
+            if (acmId != null) probeable.add(acmId);
+        }
+        for (List<String> chunk : chunkList(probeable, PROBE_CHUNK_SIZE)) {
+            StringBuilder sb = new StringBuilder();
+            for (String acmId : chunk) {
+                if (sb.length() > 0) sb.append(",");
+                sb.append(toFancyUUID(acmId).toString());
+            }
+            JSONArray resp = null;
+            try {
+                resp = apiGetJSONArray("/api/image/rowid/uuid/?uuid_list=[" + sb.toString() +
+                    "]", context);
+            } catch (Exception ex) {
+                throw new IOException("WBIA /api/image/rowid/uuid/ probe failed: " +
+                        ex.getMessage(), ex);
+            }
+            // apiGetJSONArray returns null when status.success is false or
+            // the payload is unparseable; parseRowidProbeResponse throws on it
+            missing.addAll(parseRowidProbeResponse(chunk, resp));
+        }
+        return missing;
+    }
+```
+
+- [ ] **Step 2: Compile and re-run Task 1 tests (regression)**
+
+Run: `mvn test -Dtest=WildbookIAMRowidProbeParseTest 2>&1 | tail -15`
+Expected: compiles, `Tests run: 7, Failures: 0, Errors: 0`.
+
+- [ ] **Step 3: CRLF check and commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/ia/plugin/WildbookIAM.java   # expect 0
+git add src/main/java/org/ecocean/ia/plugin/WildbookIAM.java
+git commit -m "feat: iaMissingImageIds — batch WBIA existence probe by acmId
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `IBEISIA.sendMediaAssetsNew` checkFirst overload
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/identity/IBEISIA.java:3677-3683` (the existing 2-arg `sendMediaAssetsNew`)
+
+**Interfaces:**
+- Consumes: existing `getPluginInstance(context)` (IBEISIA.java:3671) and `WildbookIAM.sendMediaAssets(ArrayList<MediaAsset>, boolean)`.
+- Produces: `public static JSONObject IBEISIA.sendMediaAssetsNew(ArrayList<MediaAsset> mas, String context, boolean checkFirst)` — Task 6's heal loop calls it with `checkFirst=false`. The 2-arg form keeps its exact current behavior (`checkFirst=true`).
+
+- [ ] **Step 1: Replace the 2-arg method with a delegating pair**
+
+Current code at IBEISIA.java:3677:
+
+```java
+    public static JSONObject sendMediaAssetsNew(ArrayList<MediaAsset> mas, String context)
+    throws RuntimeException, MalformedURLException, IOException, NoSuchAlgorithmException,
+        InvalidKeyException {
+        WildbookIAM plugin = getPluginInstance(context);
+
+        return plugin.sendMediaAssets(mas, true);
+    }
+```
+
+Replace with:
+
+```java
+    public static JSONObject sendMediaAssetsNew(ArrayList<MediaAsset> mas, String context)
+    throws RuntimeException, MalformedURLException, IOException, NoSuchAlgorithmException,
+        InvalidKeyException {
+        return sendMediaAssetsNew(mas, context, true);
+    }
+
+    // checkFirst=false skips the full iaImageIds() existence pre-check; use when
+    // the caller has already established the assets are missing from WBIA
+    // (e.g. AcmIdBot sweep probe). (AcmIdBot sweep spec §4.)
+    public static JSONObject sendMediaAssetsNew(ArrayList<MediaAsset> mas, String context,
+        boolean checkFirst)
+    throws RuntimeException, MalformedURLException, IOException, NoSuchAlgorithmException,
+        InvalidKeyException {
+        WildbookIAM plugin = getPluginInstance(context);
+
+        return plugin.sendMediaAssets(mas, checkFirst);
+    }
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `mvn -q compile 2>&1 | tail -20`
+Expected: no `ERROR` lines (BUILD SUCCESS or silent).
+
+- [ ] **Step 3: CRLF check and commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/identity/IBEISIA.java   # expect 0
+git add src/main/java/org/ecocean/identity/IBEISIA.java
+git commit -m "feat: sendMediaAssetsNew overload with explicit checkFirst
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Commit healed acmIds in `fixFeats` (Critical rollback bug)
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/AcmIdBot.java:53-60` (inside `fixFeats`)
+
+**Interfaces:**
+- Consumes: existing `Shepherd.updateDBTransaction()` (= commit + begin, Shepherd.java:3388).
+- Produces: no new API. Behavior fix only: acmIds written by `AcmUtil.rectifyMediaAssetIds` during a Query-1 heal now survive the `rollbackAndClose()` at the end of `fixAcmIds`.
+
+Background (spec "Verified facts"): `fixAcmIds()` ends with `myShepherd.rollbackAndClose()`; `fixFeats` only calls `updateDBTransaction()` in its validate branch. An asset healed without passing through that branch gets its new acmId rolled back. No practical unit test without a DB — this is a reviewed one-line transactional fix.
+
+- [ ] **Step 1: Add the commit after a successful send**
+
+In `fixFeats`, current code (AcmIdBot.java:53-60):
+
+```java
+                        IBEISIA.sendMediaAssetsNew(fixMe, context);
+                        numAcmIdFixesSent++;
+                        if (asset.getAcmId() != null) {
+                            numAcmIdFixesSuccessful++;
+```
+
+Replace with:
+
+```java
+                        IBEISIA.sendMediaAssetsNew(fixMe, context);
+                        numAcmIdFixesSent++;
+                        // commit now: rectifyMediaAssetIds set acmId on this asset, and
+                        // fixAcmIds() ends with rollbackAndClose() which would discard it
+                        myShepherd.updateDBTransaction();
+                        if (asset.getAcmId() != null) {
+                            numAcmIdFixesSuccessful++;
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `mvn -q compile 2>&1 | tail -20`
+Expected: no `ERROR` lines.
+
+- [ ] **Step 3: CRLF check and commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/AcmIdBot.java   # expect 0
+git add src/main/java/org/ecocean/AcmIdBot.java
+git commit -m "fix: commit healed acmIds in AcmIdBot.fixFeats
+
+fixAcmIds() ends with rollbackAndClose(); without an explicit commit
+after sendMediaAssetsNew, the acmId written by rectifyMediaAssetIds
+could be silently rolled back. Sweep spec Critical finding #1.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Sweep page collection + cursor pure helpers
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/AcmIdBot.java` (add constants, static state, `SweepPage` inner class, three package-visible static helpers — place them between `fixFeats` and `startServices`)
+- Test: `src/test/java/org/ecocean/AcmIdBotSweepTest.java` (create)
+
+**Interfaces:**
+- Consumes: `MediaAsset` (constructed in tests as `new MediaAsset(id, null, null)` — existing test precedent constructs MediaAssets directly; note this constructor defaults `acmId = getUUID()`, so tests use `setAcmId(null)` to simulate legacy rows, `setIsValidImageForIA(false)` for known-invalid).
+- Produces (Task 6 consumes all of these):
+  - `static final int AcmIdBot.SWEEP_PAGE_SIZE = 10000`
+  - `static final int AcmIdBot.PAGE_FAIL_LIMIT = 3`
+  - `static int AcmIdBot.sweepCursor` / `static int AcmIdBot.sweepFailCount` (package-visible mutable state)
+  - `static class AcmIdBot.SweepPage { List<Integer> nullAcmAssetIds; LinkedHashMap<String,Integer> acmIdToAssetId; boolean rawExhausted; int lastAssetId; }`
+  - `static SweepPage AcmIdBot.collectSweepPage(Iterator<MediaAsset> assetsInIdOrder, int pageSize)`
+  - `static int AcmIdBot.nextCursorAfterSuccess(SweepPage page, boolean maxFixesHit, int resumeAssetId)`
+  - `static boolean AcmIdBot.shouldSkipPoisonedPage(int consecutiveFailures)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/java/org/ecocean/AcmIdBotSweepTest.java`:
+
+```java
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.ecocean.media.MediaAsset;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure-logic coverage of the AcmIdBot reconciliation sweep helpers
+ * (spec docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md):
+ * page collection (dedup, bucketing, exhaustion), cursor advancement
+ * (wrap-around, maxFixes clamp), and the poisoned-page skip threshold.
+ */
+class AcmIdBotSweepTest {
+
+    private static MediaAsset asset(int id) {
+        // constructor defaults acmId to the asset's own UUID
+        return new MediaAsset(id, null, null);
+    }
+
+    private static MediaAsset nullAcmAsset(int id) {
+        MediaAsset ma = asset(id);
+
+        ma.setAcmId(null); // legacy row: never assigned
+        return ma;
+    }
+
+    private static MediaAsset invalidAsset(int id) {
+        MediaAsset ma = asset(id);
+
+        ma.setIsValidImageForIA(false);
+        return ma;
+    }
+
+    // ---------- collectSweepPage ----------
+
+    @Test void bucketsNullAcmSeparatelyFromProbeable() {
+        List<MediaAsset> in = Arrays.asList(asset(1), nullAcmAsset(2), asset(3));
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 10);
+
+        assertEquals(2, page.acmIdToAssetId.size());
+        assertEquals(1, page.nullAcmAssetIds.size());
+        assertEquals(Integer.valueOf(2), page.nullAcmAssetIds.get(0));
+        assertTrue(page.rawExhausted, "short input should exhaust");
+        assertEquals(3, page.lastAssetId);
+    }
+
+    @Test void dedupesRepeatedAssets() {
+        MediaAsset one = asset(1);
+        List<MediaAsset> in = Arrays.asList(one, one, asset(2), one);
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 10);
+
+        assertEquals(2, page.acmIdToAssetId.size());
+        assertTrue(page.rawExhausted);
+    }
+
+    @Test void skipsKnownInvalidButStillCountsThemTowardPage() {
+        List<MediaAsset> in = Arrays.asList(invalidAsset(1), asset(2));
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 10);
+
+        assertEquals(1, page.acmIdToAssetId.size());
+        assertEquals(0, page.nullAcmAssetIds.size());
+        assertEquals(2, page.lastAssetId);
+    }
+
+    @Test void skipsNullAssetsFromDanglingFeatures() {
+        List<MediaAsset> in = Arrays.asList(null, asset(2));
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 10);
+
+        assertEquals(1, page.acmIdToAssetId.size());
+        assertTrue(page.rawExhausted);
+    }
+
+    @Test void pageLimitStopsCollectionAndMarksNotExhausted() {
+        List<MediaAsset> in = new ArrayList<MediaAsset>();
+        for (int i = 1; i <= 5; i++) in.add(asset(i));
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 3);
+
+        assertEquals(3, page.acmIdToAssetId.size());
+        assertFalse(page.rawExhausted, "limit hit before input end: not exhausted");
+        assertEquals(3, page.lastAssetId);
+    }
+
+    @Test void exactlyFullPageWithNoMoreInputIsExhausted() {
+        List<MediaAsset> in = Arrays.asList(asset(1), asset(2), asset(3));
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 3);
+
+        assertEquals(3, page.acmIdToAssetId.size());
+        assertTrue(page.rawExhausted, "input ended exactly at limit: exhausted");
+    }
+
+    @Test void emptyInputIsExhaustedWithSentinelLastId() {
+        AcmIdBot.SweepPage page =
+            AcmIdBot.collectSweepPage(new ArrayList<MediaAsset>().iterator(), 10);
+
+        assertTrue(page.rawExhausted);
+        assertEquals(-1, page.lastAssetId);
+        assertEquals(0, page.acmIdToAssetId.size());
+        assertEquals(0, page.nullAcmAssetIds.size());
+    }
+
+    // ---------- nextCursorAfterSuccess ----------
+
+    @Test void normalPageAdvancesToLastAssetId() {
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(
+            Arrays.asList(asset(7), asset(9)).iterator(), 1); // limit -> not exhausted
+        assertFalse(page.rawExhausted);
+        assertEquals(7, AcmIdBot.nextCursorAfterSuccess(page, false, page.lastAssetId));
+    }
+
+    @Test void exhaustionWrapsCursorToZero() {
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(
+            Arrays.asList(asset(7)).iterator(), 10);
+        assertTrue(page.rawExhausted);
+        assertEquals(0, AcmIdBot.nextCursorAfterSuccess(page, false, page.lastAssetId));
+    }
+
+    @Test void maxFixesClampBeatsExhaustionWrap() {
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(
+            Arrays.asList(asset(7), asset(9)).iterator(), 10);
+        assertTrue(page.rawExhausted);
+        // cap hit while healing asset 7: resume from 7, do NOT wrap
+        assertEquals(7, AcmIdBot.nextCursorAfterSuccess(page, true, 7));
+    }
+
+    // ---------- shouldSkipPoisonedPage ----------
+
+    @Test void skipsOnlyAtFailLimit() {
+        assertFalse(AcmIdBot.shouldSkipPoisonedPage(1));
+        assertFalse(AcmIdBot.shouldSkipPoisonedPage(2));
+        assertTrue(AcmIdBot.shouldSkipPoisonedPage(3));
+        assertTrue(AcmIdBot.shouldSkipPoisonedPage(4));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn test -Dtest=AcmIdBotSweepTest 2>&1 | tail -25`
+Expected: COMPILATION ERROR — `cannot find symbol: class SweepPage` etc.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/main/java/org/ecocean/AcmIdBot.java`, after the closing brace of `fixFeats` (line 83) and before `startServices`, add:
+
+```java
+    // ------- reconciliation sweep (spec: 2026-07-01-acmidbot-reconciliation-sweep-design.md) -------
+
+    static final int SWEEP_PAGE_SIZE = 10000; // distinct assets examined per 15-minute run
+    static final int PAGE_FAIL_LIMIT = 3; // failed runs on one page before skipping it
+    // in-memory sweep state; a restart just restarts the sweep (probes are cheap)
+    static int sweepCursor = 0; // highest asset id processed
+    static int sweepFailCount = 0; // consecutive failures at the current cursor
+
+    // one page of sweep candidates, reduced to primitives so no JDO object
+    // outlives the read transaction
+    static class SweepPage {
+        final List<Integer> nullAcmAssetIds = new ArrayList<Integer>();
+        final java.util.LinkedHashMap<String, Integer> acmIdToAssetId =
+            new java.util.LinkedHashMap<String, Integer>();
+        boolean rawExhausted = false;
+        int lastAssetId = -1; // -1 = empty page
+    }
+
+    // walk assets (ascending id order, may contain duplicates from multiple
+    // Features per asset) collecting up to pageSize distinct assets.
+    // rawExhausted is true only when the input ran out — never inferred from
+    // a post-dedup count (spec §1/§2).
+    static SweepPage collectSweepPage(java.util.Iterator<MediaAsset> assetsInIdOrder,
+        int pageSize) {
+        SweepPage page = new SweepPage();
+        java.util.Set<Integer> seen = new java.util.HashSet<Integer>();
+
+        page.rawExhausted = true;
+        while (assetsInIdOrder.hasNext()) {
+            MediaAsset asset = assetsInIdOrder.next();
+            if (asset == null) continue;
+            if (seen.contains(asset.getId())) continue;
+            if (seen.size() >= pageSize) {
+                page.rawExhausted = false;
+                return page;
+            }
+            seen.add(asset.getId());
+            page.lastAssetId = asset.getId();
+            // known-invalid assets are unhealable: counted as processed, never probed
+            if (asset.isValidImageForIA() != null && !asset.isValidImageForIA()) continue;
+            if (asset.getAcmId() == null) {
+                page.nullAcmAssetIds.add(asset.getId());
+            } else {
+                page.acmIdToAssetId.put(asset.getAcmId(), asset.getId());
+            }
+        }
+        return page;
+    }
+
+    // cursor policy (spec §2): maxFixes clamp wins (resume mid-page next run),
+    // else wrap to 0 on true exhaustion, else advance past the page
+    static int nextCursorAfterSuccess(SweepPage page, boolean maxFixesHit, int resumeAssetId) {
+        if (maxFixesHit) return resumeAssetId;
+        if (page.rawExhausted) return 0;
+        return page.lastAssetId;
+    }
+
+    // poisoned-page guard (spec §5): after PAGE_FAIL_LIMIT consecutive failures
+    // on the same page, skip it so one bad page cannot stall the sweep forever
+    static boolean shouldSkipPoisonedPage(int consecutiveFailures) {
+        return consecutiveFailures >= PAGE_FAIL_LIMIT;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn test -Dtest=AcmIdBotSweepTest 2>&1 | tail -25`
+Expected: `Tests run: 11, Failures: 0, Errors: 0` — BUILD SUCCESS.
+
+- [ ] **Step 5: CRLF check and commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/AcmIdBot.java src/test/java/org/ecocean/AcmIdBotSweepTest.java   # expect 0 each
+git add src/main/java/org/ecocean/AcmIdBot.java src/test/java/org/ecocean/AcmIdBotSweepTest.java
+git commit -m "feat: sweep page collection + cursor helpers for AcmIdBot
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Wire `sweepMatchableAssets` into `fixAcmIds`, remove Query 2
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/AcmIdBot.java` (replace the Query-2/filter3 block in `fixAcmIds` lines 154-171; add `sweepMatchableAssets`; update the class comment lines 17-24; add imports)
+
+**Interfaces:**
+- Consumes: `SweepPage`/`collectSweepPage`/`nextCursorAfterSuccess`/`shouldSkipPoisonedPage`/`sweepCursor`/`sweepFailCount`/`SWEEP_PAGE_SIZE` (Task 5); `WildbookIAM.iaMissingImageIds(List, String)` (Task 2); `IBEISIA.sendMediaAssetsNew(mas, context, false)` (Task 3); existing `MediaAssetFactory.load(int, Shepherd)` (MediaAssetFactory.java:21), `Shepherd.updateDBTransaction()`.
+- Produces: `static void AcmIdBot.sweepMatchableAssets(String context, int maxFixes)` — called from `fixAcmIds` after the Query-1 heal.
+
+- [ ] **Step 1: Replace the Query-2 block in `fixAcmIds`**
+
+Current code (AcmIdBot.java, after the `fixFeats(feats, ...)` Query-1 call — the block from `// check recent Encounter submissions in last 24 hours...` through `fixFeats(feats2, ...)`, lines 154-171) and the `query3` machinery around it. Replace the whole method body with:
+
+```java
+    public static void fixAcmIds(String context) {
+        Shepherd myShepherd = new Shepherd(context);
+
+        myShepherd.setAction("AcmIdBot.java");
+        myShepherd.beginDBTransaction();
+
+        // number of fixes to consider before finishing and letting a new round of work restart the effort
+        int maxFixes = 500;
+        Query query2 = null;
+        try {
+            System.out.println(
+                "Looking for complete import tasks with media assets with missing acmIds");
+
+            String filter2 =
+                "select from org.ecocean.media.Feature where itask.status == 'complete' && itask.encounters.contains(enc) && enc.annotations.contains(annot) && annot.features.contains(this) && asset.acmId == null VARIABLES org.ecocean.Encounter enc;org.ecocean.servlet.importer.ImportTask itask;org.ecocean.Annotation annot";
+            query2 = myShepherd.getPM().newQuery(filter2);
+            query2.setOrdering("revision desc");
+            Collection c2 = (Collection)(query2.execute());
+            List<Feature> feats = new ArrayList<Feature>(c2);
+            query2.closeAll();
+            query2 = null;  // Mark as closed
+
+            fixFeats(feats, myShepherd, "ACM ID ImportTask fixing summary", maxFixes);
+        } catch (Exception f) {
+            System.out.println("Exception in AcmIdBot!");
+            f.printStackTrace();
+        } finally {
+            if (query2 != null) query2.closeAll();
+            myShepherd.rollbackAndClose();
+        }
+
+        // full reconciliation sweep of the matchable set (replaces the old
+        // 24-hour Encounter query); manages its own transactions
+        sweepMatchableAssets(context, maxFixes);
+    }
+```
+
+- [ ] **Step 2: Add `sweepMatchableAssets` after `fixAcmIds`**
+
+```java
+    /**
+     * One 15-minute bite of the reconciliation sweep (spec
+     * docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md).
+     * Phase-separated: (1) read one page of distinct matchable assets inside a
+     * short transaction, reduced to primitives; (2) probe WBIA for unknown
+     * acmIds over HTTP with no transaction open; (3) heal missing assets in a
+     * fresh transaction with explicit commits so rectified acmIds survive
+     * rollbackAndClose.
+     */
+    static void sweepMatchableAssets(String context, int maxFixes) {
+        // ---- read phase ----
+        SweepPage page = null;
+        Shepherd readShepherd = new Shepherd(context);
+
+        readShepherd.setAction("AcmIdBot.sweepRead");
+        readShepherd.beginDBTransaction();
+        Query query = null;
+        try {
+            System.out.println("AcmIdBot sweep: reading matchable assets from cursor " +
+                sweepCursor);
+            String filter =
+                "select from org.ecocean.media.Feature where annot.matchAgainst == true && annot.features.contains(this) && asset.id > "
+                + sweepCursor + " VARIABLES org.ecocean.Annotation annot";
+            query = readShepherd.getPM().newQuery(filter);
+            query.setOrdering("asset.id ascending");
+            Collection c = (Collection)(query.execute());
+            final java.util.Iterator featIter = c.iterator();
+            java.util.Iterator<MediaAsset> assetIter = new java.util.Iterator<MediaAsset>() {
+                public boolean hasNext() {
+                    return featIter.hasNext();
+                }
+                public MediaAsset next() {
+                    return ((Feature)featIter.next()).getMediaAsset();
+                }
+            };
+            page = collectSweepPage(assetIter, SWEEP_PAGE_SIZE);
+        } catch (Exception ex) {
+            System.out.println("Exception in AcmIdBot.sweepMatchableAssets read phase!");
+            ex.printStackTrace();
+        } finally {
+            if (query != null) query.closeAll();
+            readShepherd.rollbackAndClose();
+        }
+        if (page == null) return; // read failed; cursor unchanged, retry next run
+
+        // ---- probe phase (no transaction open) ----
+        List<String> missingAcmIds = null;
+        try {
+            missingAcmIds = org.ecocean.ia.plugin.WildbookIAM.iaMissingImageIds(
+                new ArrayList<String>(page.acmIdToAssetId.keySet()), context);
+        } catch (java.io.IOException ex) {
+            sweepFailCount++;
+            System.out.println("WARNING: AcmIdBot sweep probe failed (attempt " +
+                sweepFailCount + " of " + PAGE_FAIL_LIMIT + " at cursor " + sweepCursor +
+                "): " + ex.toString());
+            if (shouldSkipPoisonedPage(sweepFailCount)) {
+                System.out.println(
+                    "WARNING: AcmIdBot sweep SKIPPING page after repeated failures; cursor " +
+                    sweepCursor + " -> " + page.lastAssetId);
+                if (page.lastAssetId >= 0) sweepCursor = page.lastAssetId;
+                sweepFailCount = 0;
+            }
+            return; // cursor otherwise unchanged: same page retried next run
+        }
+
+        // ---- heal phase (own transaction, explicit commits) ----
+        List<Integer> candidateIds = new ArrayList<Integer>(page.nullAcmAssetIds);
+        for (String acmId : missingAcmIds) {
+            Integer assetId = page.acmIdToAssetId.get(acmId);
+            if (assetId != null) candidateIds.add(assetId);
+        }
+        java.util.Collections.sort(candidateIds); // ascending id = cursor order
+        int healedCount = 0;
+        int sentCount = 0;
+        boolean maxFixesHit = false;
+        int resumeAssetId = page.lastAssetId;
+        if (candidateIds.size() > 0) {
+            Shepherd healShepherd = new Shepherd(context);
+            healShepherd.setAction("AcmIdBot.sweepHeal");
+            healShepherd.beginDBTransaction();
+            try {
+                for (Integer assetId : candidateIds) {
+                    healShepherd.setAction("AcmIdBot.sweepHeal_asset_" + assetId);
+                    try {
+                        MediaAsset asset = org.ecocean.media.MediaAssetFactory.load(
+                            assetId.intValue(), healShepherd);
+                        if (asset == null) continue;
+                        if (asset.isValidImageForIA() == null) {
+                            asset.validateSourceImage();
+                            healShepherd.updateDBTransaction();
+                        }
+                        if (!asset.isValidImageForIA()) continue;
+                        if (!asset.hasFamily(healShepherd)) asset.updateStandardChildren();
+                        // legacy rows: adopt the constructor convention before sending
+                        if (asset.getAcmId() == null) asset.setAcmId(asset.getUUID());
+                        ArrayList<MediaAsset> fixMe = new ArrayList<MediaAsset>();
+                        fixMe.add(asset);
+                        // checkFirst=false: the probe already established absence
+                        IBEISIA.sendMediaAssetsNew(fixMe, context, false);
+                        sentCount++;
+                        // commit so the (possibly rectified) acmId survives rollbackAndClose
+                        healShepherd.updateDBTransaction();
+                        if (asset.getAcmId() != null) {
+                            healedCount++;
+                            if (healedCount >= maxFixes) {
+                                maxFixesHit = true;
+                                resumeAssetId = assetId.intValue();
+                                break;
+                            }
+                        }
+                    } catch (Exception ec) {
+                        System.out.println("Exception in AcmIdBot sweep heal for asset " +
+                            assetId);
+                        ec.printStackTrace();
+                        // mirror fixFeats: a 500 from WBIA marks the image invalid for IA
+                        if (ec.toString().contains("HTTP error code : 500")) {
+                            try {
+                                MediaAsset asset = org.ecocean.media.MediaAssetFactory.load(
+                                    assetId.intValue(), healShepherd);
+                                if (asset != null) {
+                                    asset.setIsValidImageForIA(false);
+                                    healShepherd.updateDBTransaction();
+                                }
+                            } catch (Exception inner) {
+                                inner.printStackTrace();
+                            }
+                        }
+                    }
+                }
+            } finally {
+                healShepherd.rollbackAndClose();
+            }
+        }
+        sweepCursor = nextCursorAfterSuccess(page, maxFixesHit, resumeAssetId);
+        sweepFailCount = 0;
+        System.out.println("AcmIdBot Reconciliation Sweep Summary");
+        System.out.println("...page: " + (page.acmIdToAssetId.size() +
+            page.nullAcmAssetIds.size()) + " candidates (" + page.acmIdToAssetId.size() +
+            " probed, " + page.nullAcmAssetIds.size() + " null acmId)");
+        System.out.println("......missing from WBIA: " + missingAcmIds.size());
+        System.out.println("......heals sent: " + sentCount + ", heals successful: " +
+            healedCount + (maxFixesHit ? " (maxFixes cap hit)" : ""));
+        System.out.println("......cursor now " + sweepCursor +
+            (page.rawExhausted && !maxFixesHit ? " (sweep complete, wrapped)" : ""));
+    }
+```
+
+- [ ] **Step 3: Update the class comment (AcmIdBot.java lines 17-24)**
+
+Replace the last sentence of the class comment:
+
+```java
+ * fails. It first checks bulk ImportTasks for appropriate images that may be missing an acmId, and then it checks Encounters submitted within the
+ * past 24 hours.
+```
+
+with:
+
+```java
+ * fails. It first checks bulk ImportTasks for appropriate images that may be missing an acmId (fast path for fresh imports), and then runs one
+ * page of a continuous reconciliation sweep: every MediaAsset backing a matchAgainst annotation is eventually probed against WBIA
+ * (/api/image/rowid/uuid/) and re-registered if WBIA does not know its acmId.
+```
+
+- [ ] **Step 4: Compile and run both new test classes**
+
+Run: `mvn -q compile 2>&1 | tail -20` — expect no `ERROR` lines.
+Run: `mvn test -Dtest='AcmIdBotSweepTest,WildbookIAMRowidProbeParseTest' 2>&1 | tail -20`
+Expected: `Tests run: 18, Failures: 0, Errors: 0`.
+
+- [ ] **Step 5: CRLF check and commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/AcmIdBot.java   # expect 0
+git add src/main/java/org/ecocean/AcmIdBot.java
+git commit -m "feat: replace AcmIdBot 24h query with matchable-set reconciliation sweep
+
+Cursor-paged sweep (10k assets/run) over matchAgainst annotations:
+probe WBIA for unknown acmIds, heal via sendMediaAssetsNew with
+checkFirst=false, phase-separated transactions with explicit commits.
+Poisoned-page 3-strike skip; maxFixes clamps the cursor mid-page.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Scheduler hardening + final verification
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/AcmIdBot.java` (the contiguous `startServices` / `startCollector` / `cleanup` block — line numbers will have shifted after Tasks 5–6; anchor by method names)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: no API change (`startServices(String)` / `cleanup()` signatures unchanged — StartupWildbook.java:190/899 keep working). Behavior: double `startServices` no longer spawns a second executor; `cleanup()` actually shuts the executor down.
+
+- [ ] **Step 1: Replace the scheduler block**
+
+Current code (AcmIdBot.java lines 85-127: `startServices` through `cleanup`). Replace with:
+
+```java
+    // background workers
+    private static ScheduledExecutorService schedExec = null;
+
+    public static synchronized boolean startServices(String context) {
+        if ((schedExec != null) && !schedExec.isShutdown()) {
+            System.out.println("WARNING: AcmIdBot.startServices(" + context +
+                ") called but collector already running; ignoring");
+            return false;
+        }
+        startCollector(context);
+        return true;
+    }
+
+    // basically our "listener" daemon; but is more pull (poll?) than push so to speak.
+    private static void startCollector(final String context) { // throws IOException {
+        long interval = 15; // number minutes between runs
+        long initialDelay = 1; // number minutes before first execution occurs
+
+        System.out.println("+ AcmIdBot.startCollector(" + context + ") starting.");
+        schedExec = Executors.newScheduledThreadPool(1);
+        final ScheduledExecutorService execRef = schedExec;
+        final ScheduledFuture schedFuture = execRef.scheduleWithFixedDelay(new Runnable() {
+            // DO WORK HERE
+            public void run() {
+                if (new java.io.File("/tmp/WB_AcmIdBot_SHUTDOWN").exists()) {
+                    System.out.println("INFO: AcmIdBot.startCollection(" + context +
+                    ") shutting down due to file signal");
+                    execRef.shutdown();
+                    return;
+                }
+                fixAcmIds(context);
+            }
+        }, initialDelay, // initial delay
+            interval, // period delay *after* execution finishes
+            TimeUnit.MINUTES); // unit of delays above
+
+        System.out.println("Let's get AcmIdBot's time running.");
+        try {
+            execRef.awaitTermination(5000, TimeUnit.MILLISECONDS);
+        } catch (java.lang.InterruptedException ex) {
+            System.out.println("WARNING: AcmIdBot.startCollector(" + context + ") interrupted: " +
+                ex.toString());
+        }
+        System.out.println("+ AcmIdBot.startCollector(" + context + ") backgrounded");
+    }
+
+    // called from StartupWildbook contextDestroyed
+    public static synchronized void cleanup() {
+        if (schedExec != null) {
+            schedExec.shutdown();
+            schedExec = null;
+        }
+        System.out.println(
+            "================ = = = = = = ===================== AcmIdBot.cleanup() finished.");
+    }
+```
+
+- [ ] **Step 2: Full verification pass**
+
+```bash
+mvn -q compile 2>&1 | tail -20                    # expect no ERROR lines
+mvn test -Dtest='AcmIdBotSweepTest,WildbookIAMRowidProbeParseTest,WildbookIAMImageIdsStrictTest,WildbookIAMFancyUuidArrayStrictTest' 2>&1 | tail -20
+```
+Expected: all listed classes pass (18 new tests + existing strict-parse tests as regression guard).
+
+- [ ] **Step 3: CRLF check and commit**
+
+```bash
+grep -c $'\r' src/main/java/org/ecocean/AcmIdBot.java   # expect 0
+git add src/main/java/org/ecocean/AcmIdBot.java
+git commit -m "fix: guard AcmIdBot against double start; shut executor down in cleanup
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Post-plan checklist (for the coordinating session, not a task)
+
+- Codex adversarial review of the full diff (`feedback_codex_review` standing preference), iterate to convergence.
+- Push branch + open PR off `main` referencing the spec.

--- a/docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md
@@ -1,0 +1,151 @@
+# AcmIdBot Reconciliation Sweep — Design
+
+**Date:** 2026-07-01
+**Status:** Approved (pending spec review)
+**Branch:** `feature/acmidbot-reconciliation-sweep`
+
+## Problem
+
+`AcmIdBot.fixAcmIds()` heals MediaAssets that never got registered with WBIA. Its
+second query only looks at Encounters submitted in the last 24 hours with
+`asset.acmId == null`. This misses two things:
+
+1. **Scope.** The set we actually care about is every MediaAsset that could be used
+   in matching — i.e. assets backing an Annotation with `matchAgainst == true` — not
+   just yesterday's submissions.
+2. **Desync detection.** Wildbook now owns acmId assignment (the MediaAsset
+   constructor defaults `acmId = getUUID()`; the v2 detection path sets it) and tells
+   WBIA which UUID to use. An asset can therefore hold a plausible acmId that WBIA
+   never actually registered — invisible to any `acmId == null` query. Only asking
+   WBIA "do you know this UUID?" can find these.
+
+## Verified facts (code archaeology)
+
+- **Matchable-candidate definition** (`Annotation.java:1600–1602`): the OpenSearch
+  indexer and `Annotation.getMatchingSetQuery` both require
+  `matchAgainst == true && acmId != null`.
+- **WBIA existence probe exists:** `GET /api/image/rowid/uuid/?uuid_list=[...]`
+  (`wildbook-ia/wbia/control/manual_image_funcs.py:1691`,
+  `get_image_gids_from_uuid`) — batch of image UUIDs in, parallel list of rowids
+  out, `null` where the UUID is unknown. (The tidier `/api/image/uuid/missing/`
+  exists but its `@register_api` is commented out — not usable over REST.)
+- **Wildbook already has the calling pattern:** `IBEISIA.iaImageSetIdFromUUID()`
+  (`IBEISIA.java:2859`) hits the sibling `/api/imageset/rowid/uuid/` with
+  `RestClient.get` + `iaURL` + `toFancyUUID`, treating `optInt(0, -1) == -1` as
+  not-found.
+- **Wildbook-assigns-UUID registration is supported end to end:**
+  `POST /api/image/json/` (`add_images_json`, `apis_json.py:59`) accepts an optional
+  `image_uuid_list` which flows into `add_images(image_uuid_list=...)`
+  (`manual_image_funcs.py:464–481`), overriding the hash-computed UUID with the
+  caller's.
+- **Gap:** `WildbookIAM.sendMediaAssets()` today does NOT send `image_uuid_list`; it
+  lets WBIA hash-derive the UUID and rectifies acmId afterward
+  (`AcmUtil.rectifyMediaAssetIds`). Under Wildbook-owned UUIDs, a heal that omits
+  `image_uuid_list` could register the image under a hash UUID different from the
+  probed acmId — the sweep would then flag that asset missing forever.
+
+## Design
+
+### 1. Query changes in `AcmIdBot.fixAcmIds()`
+
+- **Query 1 (unchanged):** completed-ImportTask healing stays as the recency
+  fast-path for fresh bulk imports.
+- **Query 2 (replaced):** the 24-hour Encounter query is removed. In its place, a
+  paged sweep over the matchable set:
+
+  ```
+  Feature where annot.matchAgainst == true && asset.id > <cursor>
+  VARIABLES org.ecocean.Annotation annot
+  ordering: asset.id ascending
+  ```
+
+  Each run takes a page of **10,000 distinct MediaAssets** (deduped in Java — one
+  asset can carry several Features). No `acmId == null` filter: the sweep considers
+  the entire matchable set, because desync is not detectable from the DB alone.
+  Assets with `isValidImageForIA == false` are excluded up front (unhealable; don't
+  burn probe/heal slots every sweep).
+
+### 2. Sweep cursor
+
+- In-memory `static long` on `AcmIdBot`: the highest asset id processed.
+- A page returning fewer than pageSize assets ⇒ sweep complete ⇒ cursor resets to 0
+  (wrap-around; continuous background reconciliation).
+- Tomcat restart resets the cursor. Accepted: probes are cheap idempotent GETs, so a
+  restarted sweep merely re-verifies healthy assets.
+- Full-sweep duration at Sharkbook scale (~1M matchable): ~100 runs ≈ ~1 day.
+  Small installs sweep in one or two runs.
+
+### 3. Existence probe
+
+New method in `WildbookIAM` (alongside `iaImageIds()`):
+
+```java
+public static List<String> iaMissingImageIds(List<String> acmIds, String context)
+```
+
+- Chunks acmIds into groups of **100** (bounds URL length).
+- Per chunk: `GET /api/image/rowid/uuid/?uuid_list=[<fancy UUIDs>]` via the existing
+  `iaURL`/`RestClient.get`/`toFancyUUID` idiom.
+- A `null` / `-1` rowid in the response marks that acmId as unknown to WBIA.
+- Returns the list of missing acmIds.
+
+Heal candidates for a page = probe-missing assets **plus** assets with
+`acmId == null` (legacy rows; assign `acmId = getUUID()` before healing, matching
+the constructor convention).
+
+### 4. Heal path (Wildbook-assigns-UUID)
+
+Extend `WildbookIAM.sendMediaAssets` with an overload:
+
+```java
+public JSONObject sendMediaAssets(ArrayList<MediaAsset> mas, boolean checkFirst,
+                                  boolean sendImageUuids)
+```
+
+- When `sendImageUuids` is true, the POST body includes
+  `image_uuid_list = [asset.getAcmId() ...]` parallel to `image_uri_list` — the
+  verified `add_images_json` signature where the caller dictates the UUID.
+- The sweep calls it with `checkFirst=false` (we just probed; skip the redundant
+  full-list `iaImageIds()` fetch) and `sendImageUuids=true`.
+- Existing behavior of the two-arg call is untouched (other callers unaffected).
+- `AcmUtil.rectifyMediaAssetIds` still runs on the response; with caller-supplied
+  UUIDs it should be a no-op confirmation.
+- Heals per run remain capped by the existing `maxFixes = 500`.
+
+### 5. Error handling
+
+- WBIA unreachable / a probe chunk throws ⇒ log and end the run **without advancing
+  the cursor** (same page retried next run). Prevents silently skipping a page.
+- Individual heal failures: log, continue with the rest; the next full sweep retries
+  naturally.
+- Existing summary-logging conventions kept (candidate counts, probes performed,
+  missing found, heals sent/succeeded).
+
+### 6. Constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `SWEEP_PAGE_SIZE` | 10,000 | assets examined per 15-minute run |
+| `PROBE_CHUNK_SIZE` | 100 | UUIDs per `/api/image/rowid/uuid/` GET |
+| `maxFixes` | 500 (existing) | max successful heals per run |
+
+Plain constants for now; promote to config properties only if a deployment needs
+tuning.
+
+## Out of scope (follow-ups)
+
+- Making **all** `sendMediaAssets` callers pass `image_uuid_list` (the global
+  ownership-model fix). This design only adds the opt-in overload used by the sweep.
+- Exposing WBIA's `/api/image/uuid/missing/` endpoint (would simplify the probe to
+  one purpose-built call).
+- Durable (DB/file) cursor persistence — revisit only if restart-induced re-sweeps
+  prove costly in practice.
+
+## Testing
+
+- Unit tests for the probe-response parsing (missing-UUID extraction, null/`-1`
+  handling, chunking boundaries).
+- Unit test that the `sendImageUuids` overload builds `image_uuid_list` parallel to
+  `image_uri_list` and that the two-arg path is byte-identical to before.
+- Sweep-logic tests (cursor advance, wrap-around, dedup, cap interaction) — extract
+  the page-processing step into a testable method rather than testing the scheduler.

--- a/docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md
@@ -77,7 +77,9 @@ second query only looks at Encounters submitted in the last 24 hours with
 
 ### 2. Sweep cursor
 
-- In-memory `static long` on `AcmIdBot`: the highest asset id **processed**.
+- In-memory `static int` on `AcmIdBot`: the highest asset id **processed**
+  (`MediaAsset.id` is an `int`; note `getId()` returns String — `getIdInt()` is
+  the int accessor).
 - Raw result exhausted ⇒ sweep complete ⇒ cursor resets to 0 (wrap-around;
   continuous background reconciliation).
 - **maxFixes interplay:** if the heal cap (existing `maxFixes = 500`) is hit

--- a/docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md
@@ -141,7 +141,11 @@ the constructor convention).
   cursor position. After **3** failed runs on the same page, advance the cursor
   past the page with a prominent log line, so one bad page cannot stall the sweep
   forever. (Locally-invalid UUIDs are filtered before sending, so this is a
-  backstop, not the primary defense.)
+  backstop, not the primary defense.) Read-phase failures (e.g. a corrupt row at
+  the current cursor) count toward the same 3-strike counter as probe failures;
+  since no page ids are available in that case, the skip is a blind
+  `sweepCursor += SWEEP_PAGE_SIZE` advance rather than a targeted one, and
+  wrap-around later resweeps the skipped range.
 - Individual heal failures: log, continue; the next full sweep retries naturally.
 - Existing summary-logging conventions kept (candidate counts, probes performed,
   missing found, heals sent/succeeded).

--- a/docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md
@@ -1,6 +1,6 @@
 # AcmIdBot Reconciliation Sweep — Design
 
-**Date:** 2026-07-01
+**Date:** 2026-07-01 (rev 2, post-Codex review)
 **Status:** Approved (pending spec review)
 **Branch:** `feature/acmidbot-reconciliation-sweep`
 
@@ -13,13 +13,13 @@ second query only looks at Encounters submitted in the last 24 hours with
 1. **Scope.** The set we actually care about is every MediaAsset that could be used
    in matching — i.e. assets backing an Annotation with `matchAgainst == true` — not
    just yesterday's submissions.
-2. **Desync detection.** Wildbook now owns acmId assignment (the MediaAsset
-   constructor defaults `acmId = getUUID()`; the v2 detection path sets it) and tells
-   WBIA which UUID to use. An asset can therefore hold a plausible acmId that WBIA
-   never actually registered — invisible to any `acmId == null` query. Only asking
-   WBIA "do you know this UUID?" can find these.
+2. **Desync detection.** Wildbook owns acmId assignment and tells WBIA which image
+   UUID to use (`sendMediaAssets` sends `image_uuid_list` = acmId, falling back to
+   the asset UUID; `add_images_json` honors it). An asset can therefore hold a
+   plausible acmId that WBIA never actually registered — invisible to any
+   `acmId == null` query. Only asking WBIA "do you know this UUID?" finds these.
 
-## Verified facts (code archaeology)
+## Verified facts (code archaeology, against main)
 
 - **Matchable-candidate definition** (`Annotation.java:1600–1602`): the OpenSearch
   indexer and `Annotation.getMatchingSetQuery` both require
@@ -31,18 +31,20 @@ second query only looks at Encounters submitted in the last 24 hours with
   exists but its `@register_api` is commented out — not usable over REST.)
 - **Wildbook already has the calling pattern:** `IBEISIA.iaImageSetIdFromUUID()`
   (`IBEISIA.java:2859`) hits the sibling `/api/imageset/rowid/uuid/` with
-  `RestClient.get` + `iaURL` + `toFancyUUID`, treating `optInt(0, -1) == -1` as
-  not-found.
-- **Wildbook-assigns-UUID registration is supported end to end:**
-  `POST /api/image/json/` (`add_images_json`, `apis_json.py:59`) accepts an optional
-  `image_uuid_list` which flows into `add_images(image_uuid_list=...)`
-  (`manual_image_funcs.py:464–481`), overriding the hash-computed UUID with the
-  caller's.
-- **Gap:** `WildbookIAM.sendMediaAssets()` today does NOT send `image_uuid_list`; it
-  lets WBIA hash-derive the UUID and rectifies acmId afterward
-  (`AcmUtil.rectifyMediaAssetIds`). Under Wildbook-owned UUIDs, a heal that omits
-  `image_uuid_list` could register the image under a hash UUID different from the
-  probed acmId — the sweep would then flag that asset missing forever.
+  `RestClient.get` + `iaURL` + `toFancyUUID`.
+- **Registration already sends Wildbook-assigned UUIDs:**
+  `WildbookIAM.sendMediaAssets()` (main, lines 132–133) sends
+  `image_uuid_list = (acmId != null ? acmId : UUID)` per asset;
+  `add_images_json` → `add_images(image_uuid_list=...)`
+  (`manual_image_funcs.py:464–481`) overrides the hash-computed UUID with the
+  caller's. No new send path is needed — the heal is a plain
+  `sendMediaAssets(candidates, /* checkFirst */ false)`.
+- **Transaction semantics:** `Shepherd.updateDBTransaction()` = commit + begin
+  (`Shepherd.java:3388`). `AcmUtil.rectifyMediaAssetIds()` mutates JDO-attached
+  assets and relies on the caller to commit. `fixAcmIds()` currently ends with
+  `rollbackAndClose()` and only commits inside the validate branch of `fixFeats` —
+  so acmId writes from a heal can be silently rolled back today. The sweep must
+  commit explicitly.
 
 ## Design
 
@@ -54,24 +56,35 @@ second query only looks at Encounters submitted in the last 24 hours with
   paged sweep over the matchable set:
 
   ```
-  Feature where annot.matchAgainst == true && asset.id > <cursor>
+  select from org.ecocean.media.Feature
+  where annot.matchAgainst == true
+    && annot.features.contains(this)
+    && asset.id > <cursor>
   VARIABLES org.ecocean.Annotation annot
   ordering: asset.id ascending
   ```
 
-  Each run takes a page of **10,000 distinct MediaAssets** (deduped in Java — one
-  asset can carry several Features). No `acmId == null` filter: the sweep considers
-  the entire matchable set, because desync is not detectable from the DB alone.
-  Assets with `isValidImageForIA == false` are excluded up front (unhealable; don't
-  burn probe/heal slots every sweep).
+  (Note the explicit `annot.features.contains(this)` binding — without it the
+  variable is unbound; matches the existing Query 1/2 idiom.)
+
+  Each run processes a page of up to **10,000 distinct MediaAssets**. Because
+  Feature rows ≠ asset rows, paging is by distinct asset: iterate the ordered
+  result, collecting distinct assets until 10,000 are gathered or the raw result is
+  exhausted. **Wrap-around triggers only on raw-result exhaustion**, never on a
+  post-dedup count (which would falsely end the sweep). Assets with
+  `isValidImageForIA == false` are excluded (unhealable; don't burn probe/heal
+  slots every sweep).
 
 ### 2. Sweep cursor
 
-- In-memory `static long` on `AcmIdBot`: the highest asset id processed.
-- A page returning fewer than pageSize assets ⇒ sweep complete ⇒ cursor resets to 0
-  (wrap-around; continuous background reconciliation).
-- Tomcat restart resets the cursor. Accepted: probes are cheap idempotent GETs, so a
-  restarted sweep merely re-verifies healthy assets.
+- In-memory `static long` on `AcmIdBot`: the highest asset id **processed**.
+- Raw result exhausted ⇒ sweep complete ⇒ cursor resets to 0 (wrap-around;
+  continuous background reconciliation).
+- **maxFixes interplay:** if the heal cap (existing `maxFixes = 500`) is hit
+  mid-page, the cursor advances only to the last asset actually processed, so the
+  rest of the page is not deferred until the next full sweep.
+- Tomcat restart resets the cursor. Accepted: probes are cheap idempotent GETs, so
+  a restarted sweep merely re-verifies healthy assets.
 - Full-sweep duration at Sharkbook scale (~1M matchable): ~100 runs ≈ ~1 day.
   Small installs sweep in one or two runs.
 
@@ -83,41 +96,51 @@ New method in `WildbookIAM` (alongside `iaImageIds()`):
 public static List<String> iaMissingImageIds(List<String> acmIds, String context)
 ```
 
-- Chunks acmIds into groups of **100** (bounds URL length).
-- Per chunk: `GET /api/image/rowid/uuid/?uuid_list=[<fancy UUIDs>]` via the existing
-  `iaURL`/`RestClient.get`/`toFancyUUID` idiom.
-- A `null` / `-1` rowid in the response marks that acmId as unknown to WBIA.
+- Skips/never sends null acmIds (`toFancyUUID(null)` must not happen; null-acmId
+  assets are heal candidates without probing).
+- Chunks acmIds into groups of **50** (~3.5 KB URL — safely under common proxy
+  limits; Codex flagged 100 as borderline).
+- Per chunk: `GET /api/image/rowid/uuid/?uuid_list=[<fancy UUIDs>]` via the
+  existing `iaURL`/`RestClient.get`/`toFancyUUID` idiom.
+- Response validation: require `status.success` and response length == request
+  length; treat a `null` rowid entry as missing. On malformed response, treat the
+  chunk as failed (see §5), never as "all present."
 - Returns the list of missing acmIds.
 
 Heal candidates for a page = probe-missing assets **plus** assets with
 `acmId == null` (legacy rows; assign `acmId = getUUID()` before healing, matching
 the constructor convention).
 
-### 4. Heal path (Wildbook-assigns-UUID)
+### 4. Heal path
 
-Extend `WildbookIAM.sendMediaAssets` with an overload:
+- Call the **existing** `WildbookIAM.sendMediaAssets(candidates, false)` —
+  `checkFirst=false` because we just probed (skips the redundant full-list
+  `iaImageIds()` fetch, which is ~1M UUIDs on Sharkbook). It already sends
+  `image_uuid_list` (the acmId we probed for), so a healed asset registers under
+  exactly the UUID the next sweep will probe. No overload needed.
+- `AcmUtil.rectifyMediaAssetIds` runs on the response as today; with
+  caller-supplied UUIDs it is a no-op confirmation (and logs loudly if WBIA
+  returns a different UUID).
+- Heals per run capped by the existing `maxFixes = 500`.
 
-```java
-public JSONObject sendMediaAssets(ArrayList<MediaAsset> mas, boolean checkFirst,
-                                  boolean sendImageUuids)
-```
+### 5. Transactions & error handling
 
-- When `sendImageUuids` is true, the POST body includes
-  `image_uuid_list = [asset.getAcmId() ...]` parallel to `image_uri_list` — the
-  verified `add_images_json` signature where the caller dictates the UUID.
-- The sweep calls it with `checkFirst=false` (we just probed; skip the redundant
-  full-list `iaImageIds()` fetch) and `sendImageUuids=true`.
-- Existing behavior of the two-arg call is untouched (other callers unaffected).
-- `AcmUtil.rectifyMediaAssetIds` still runs on the response; with caller-supplied
-  UUIDs it should be a no-op confirmation.
-- Heals per run remain capped by the existing `maxFixes = 500`.
-
-### 5. Error handling
-
-- WBIA unreachable / a probe chunk throws ⇒ log and end the run **without advancing
-  the cursor** (same page retried next run). Prevents silently skipping a page.
-- Individual heal failures: log, continue with the rest; the next full sweep retries
-  naturally.
+- **Phase separation (fixes the rollback bug):**
+  1. *Read phase* — open transaction, run the sweep query, collect
+     `(assetId, acmId, validity)` tuples for the page, close the transaction.
+  2. *Probe phase* — HTTP only, **no transaction open**.
+  3. *Heal phase* — new transaction; re-fetch the candidate assets; run the heal;
+     `updateDBTransaction()` (commit) after each heal batch so rectified acmIds
+     and validity flags persist. The final `rollbackAndClose()` then only discards
+     the trailing empty transaction.
+- **WBIA unreachable / probe chunk fails:** log and end the run without advancing
+  the cursor (same page retried next run).
+- **Poisoned-page guard:** a static consecutive-failure counter for the current
+  cursor position. After **3** failed runs on the same page, advance the cursor
+  past the page with a prominent log line, so one bad page cannot stall the sweep
+  forever. (Locally-invalid UUIDs are filtered before sending, so this is a
+  backstop, not the primary defense.)
+- Individual heal failures: log, continue; the next full sweep retries naturally.
 - Existing summary-logging conventions kept (candidate counts, probes performed,
   missing found, heals sent/succeeded).
 
@@ -125,27 +148,51 @@ public JSONObject sendMediaAssets(ArrayList<MediaAsset> mas, boolean checkFirst,
 
 | Constant | Value | Meaning |
 |---|---|---|
-| `SWEEP_PAGE_SIZE` | 10,000 | assets examined per 15-minute run |
-| `PROBE_CHUNK_SIZE` | 100 | UUIDs per `/api/image/rowid/uuid/` GET |
+| `SWEEP_PAGE_SIZE` | 10,000 | distinct assets examined per 15-minute run |
+| `PROBE_CHUNK_SIZE` | 50 | UUIDs per `/api/image/rowid/uuid/` GET |
+| `PAGE_FAIL_LIMIT` | 3 | failed runs on one page before skipping it |
 | `maxFixes` | 500 (existing) | max successful heals per run |
 
 Plain constants for now; promote to config properties only if a deployment needs
 tuning.
 
+### 7. Opportunistic hardening (small, in-scope)
+
+- Guard `startServices()`/`startCollector()` against double start (static
+  already-started flag per context), and have `cleanup()` actually shut down the
+  scheduled executor. (Codex Minor; trivial and touches code we're editing.)
+
 ## Out of scope (follow-ups)
 
-- Making **all** `sendMediaAssets` callers pass `image_uuid_list` (the global
-  ownership-model fix). This design only adds the opt-in overload used by the sweep.
 - Exposing WBIA's `/api/image/uuid/missing/` endpoint (would simplify the probe to
   one purpose-built call).
 - Durable (DB/file) cursor persistence — revisit only if restart-induced re-sweeps
   prove costly in practice.
+- Auditing other `fixFeats`-style callers for the same commit-after-rectify gap
+  outside the sweep path.
 
 ## Testing
 
-- Unit tests for the probe-response parsing (missing-UUID extraction, null/`-1`
-  handling, chunking boundaries).
-- Unit test that the `sendImageUuids` overload builds `image_uuid_list` parallel to
-  `image_uri_list` and that the two-arg path is byte-identical to before.
-- Sweep-logic tests (cursor advance, wrap-around, dedup, cap interaction) — extract
-  the page-processing step into a testable method rather than testing the scheduler.
+- Unit tests for probe-response parsing: missing-UUID extraction, null rowid,
+  length-mismatch and `status` failure treated as chunk failure, chunking
+  boundaries, null-acmId exclusion.
+- Sweep-logic tests (extract page processing into a testable method rather than
+  testing the scheduler): cursor advance, wrap-around only on raw exhaustion,
+  distinct-asset dedup, maxFixes cursor clamp, poisoned-page skip after 3
+  failures.
+- Transaction test (or focused review): healed acmId survives
+  `rollbackAndClose()` — i.e. commit happens in the heal phase.
+
+## Codex review disposition (rev 1 → rev 2)
+
+| # | Severity | Finding | Disposition |
+|---|---|---|---|
+| 1 | Critical | Heals rolled back by `rollbackAndClose()` | §5 phase separation + explicit commits |
+| 2 | Major | JDOQL variable unbound | §1 adds `annot.features.contains(this)` |
+| 3 | Major | "sendMediaAssets lacks image_uuid_list" was stale (read on wrong branch) | §4: use existing method, no overload |
+| 4 | Major | Dedup vs page-size false wrap-around | §1/§2: wrap only on raw exhaustion |
+| 5 | Major | Poisoned page stalls cursor forever | §5: 3-strike page skip |
+| 6 | Major | maxFixes defers rest of page a full sweep | §2: cursor clamps to last processed |
+| 7 | Minor | Probe response validation | §3: status + length checks, no null UUIDs |
+| 8 | Minor | URL length at 100 UUIDs | §3/§6: chunk = 50 |
+| 9 | Minor | Executor double-start / no shutdown | §7 opportunistic hardening |

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -18,8 +18,9 @@ import org.ecocean.shepherd.core.Shepherd;
  * Wildbook requires shared UUIDs (a.k.a. acmID) between MediaAsset objects in the Wildbook database and images in WBIA. AcmIDs are a prerequisite for
  * detection and therefore can be a blocker in the IA pipeline if for any reason WBIA times out or is otherwise unavailable to provide an acmId to
  * Wildbook when new data is submitted. This bot provides some automated backend healing to get images registered if for any reason acmId registration
- * fails. It first checks bulk ImportTasks for appropriate images that may be missing an acmId, and then it checks Encounters submitted within the
- * past 24 hours.
+ * fails. It first checks bulk ImportTasks for appropriate images that may be missing an acmId (fast path for fresh imports), and then runs one
+ * page of a continuous reconciliation sweep: every MediaAsset backing a matchAgainst annotation is eventually probed against WBIA
+ * (/api/image/rowid/uuid/) and re-registered if WBIA does not know its acmId.
  *
  */
 public class AcmIdBot {
@@ -221,14 +222,13 @@ public class AcmIdBot {
         myShepherd.setAction("AcmIdBot.java");
         myShepherd.beginDBTransaction();
 
+        // number of fixes to consider before finishing and letting a new round of work restart the effort
+        int maxFixes = 500;
         Query query2 = null;
-        Query query3 = null;
         try {
             System.out.println(
                 "Looking for complete import tasks with media assets with missing acmIds");
 
-            // number of fixes to consider before finishing and letting a new round of work restart the effort
-            int maxFixes = 500;
             String filter2 =
                 "select from org.ecocean.media.Feature where itask.status == 'complete' && itask.encounters.contains(enc) && enc.annotations.contains(annot) && annot.features.contains(this) && asset.acmId == null VARIABLES org.ecocean.Encounter enc;org.ecocean.servlet.importer.ImportTask itask;org.ecocean.Annotation annot";
             query2 = myShepherd.getPM().newQuery(filter2);
@@ -239,32 +239,178 @@ public class AcmIdBot {
             query2 = null;  // Mark as closed
 
             fixFeats(feats, myShepherd, "ACM ID ImportTask fixing summary", maxFixes);
-
-            // check recent Encounter submissions in last 24 hours for missing acmIds
-            long currentTimeInMillis = System.currentTimeMillis();
-            long twenyFourHoursAgo = currentTimeInMillis - (1000 * 60 * 60 * 24);
-            System.out.println(
-                "Looking for recent Encounters (24 hours) with media assets with missing acmIds");
-            // dwcDateAddedLong >=
-            String filter3 =
-                "select from org.ecocean.media.Feature where enc45.dwcDateAddedLong >= " +
-                twenyFourHoursAgo +
-                " && enc45.annotations.contains(annot) && annot.features.contains(this) && asset.acmId == null VARIABLES org.ecocean.Encounter enc45;org.ecocean.Annotation annot";
-            query3 = myShepherd.getPM().newQuery(filter3);
-            query3.setOrdering("revision desc");
-            Collection c3 = (Collection)(query3.execute());
-            List<Feature> feats2 = new ArrayList<Feature>(c3);
-            query3.closeAll();
-            query3 = null;  // Mark as closed
-
-            fixFeats(feats2, myShepherd, "Recent Encounter ACM ID Fixing Summary", maxFixes);
         } catch (Exception f) {
             System.out.println("Exception in AcmIdBot!");
             f.printStackTrace();
         } finally {
             if (query2 != null) query2.closeAll();
-            if (query3 != null) query3.closeAll();
             myShepherd.rollbackAndClose();
         }
+
+        // full reconciliation sweep of the matchable set (replaces the old
+        // 24-hour Encounter query); manages its own transactions
+        sweepMatchableAssets(context, maxFixes);
+    }
+
+    /**
+     * One 15-minute bite of the reconciliation sweep (spec
+     * docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md).
+     * Phase-separated: (1) read one page of distinct matchable assets inside a
+     * short transaction, reduced to primitives; (2) probe WBIA for unknown
+     * acmIds over HTTP with no transaction open; (3) heal missing assets in a
+     * fresh transaction with explicit commits so rectified acmIds survive
+     * rollbackAndClose.
+     */
+    static void sweepMatchableAssets(String context, int maxFixes) {
+        // ---- read phase ----
+        SweepPage page = null;
+        Shepherd readShepherd = new Shepherd(context);
+
+        readShepherd.setAction("AcmIdBot.sweepRead");
+        readShepherd.beginDBTransaction();
+        Query query = null;
+        try {
+            System.out.println("AcmIdBot sweep: reading matchable assets from cursor " +
+                sweepCursor);
+            String filter =
+                "select from org.ecocean.media.Feature where annot.matchAgainst == true && annot.features.contains(this) && asset.id > "
+                + sweepCursor + " VARIABLES org.ecocean.Annotation annot";
+            query = readShepherd.getPM().newQuery(filter);
+            query.setOrdering("asset.id ascending");
+            Collection c = (Collection)(query.execute());
+            final java.util.Iterator featIter = c.iterator();
+            java.util.Iterator<MediaAsset> assetIter = new java.util.Iterator<MediaAsset>() {
+                public boolean hasNext() {
+                    return featIter.hasNext();
+                }
+                public MediaAsset next() {
+                    return ((Feature)featIter.next()).getMediaAsset();
+                }
+            };
+            page = collectSweepPage(assetIter, SWEEP_PAGE_SIZE);
+        } catch (Exception ex) {
+            System.out.println("Exception in AcmIdBot.sweepMatchableAssets read phase!");
+            ex.printStackTrace();
+        } finally {
+            if (query != null) query.closeAll();
+            readShepherd.rollbackAndClose();
+        }
+        if (page == null) return; // read failed; cursor unchanged, retry next run
+
+        // ---- probe phase (no transaction open) ----
+        List<String> missingAcmIds = null;
+        try {
+            missingAcmIds = org.ecocean.ia.plugin.WildbookIAM.iaMissingImageIds(
+                new ArrayList<String>(page.acmIdToAssetId.keySet()), context);
+        } catch (java.io.IOException ex) {
+            sweepFailCount++;
+            System.out.println("WARNING: AcmIdBot sweep probe failed (attempt " +
+                sweepFailCount + " of " + PAGE_FAIL_LIMIT + " at cursor " + sweepCursor +
+                "): " + ex.toString());
+            if (shouldSkipPoisonedPage(sweepFailCount)) {
+                System.out.println(
+                    "WARNING: AcmIdBot sweep SKIPPING page after repeated failures; cursor " +
+                    sweepCursor + " -> " + page.lastAssetId);
+                if (page.lastAssetId >= 0) sweepCursor = page.lastAssetId;
+                sweepFailCount = 0;
+            }
+            return; // cursor otherwise unchanged: same page retried next run
+        }
+
+        // ---- heal phase (own transaction, explicit commits) ----
+        List<Integer> candidateIds = new ArrayList<Integer>(page.nullAcmAssetIds);
+        for (String acmId : missingAcmIds) {
+            Integer assetId = page.acmIdToAssetId.get(acmId);
+            if (assetId != null) candidateIds.add(assetId);
+        }
+        java.util.Collections.sort(candidateIds); // ascending id = cursor order
+        int healedCount = 0;
+        int sentCount = 0;
+        boolean maxFixesHit = false;
+        int resumeAssetId = page.lastAssetId;
+        if (candidateIds.size() > 0) {
+            Shepherd healShepherd = new Shepherd(context);
+            healShepherd.setAction("AcmIdBot.sweepHeal");
+            healShepherd.beginDBTransaction();
+            try {
+                for (Integer assetId : candidateIds) {
+                    healShepherd.setAction("AcmIdBot.sweepHeal_asset_" + assetId);
+                    // hoisted so the catch block can revert a pre-assigned acmId that
+                    // WBIA never acknowledged (send threw before confirmation)
+                    MediaAsset asset = null;
+                    String priorAcmId = null;
+                    boolean priorCaptured = false;
+                    try {
+                        asset = org.ecocean.media.MediaAssetFactory.load(
+                            assetId.intValue(), healShepherd);
+                        if (asset == null) continue;
+                        if (asset.isValidImageForIA() == null) {
+                            asset.validateSourceImage();
+                            healShepherd.updateDBTransaction();
+                        }
+                        if (!asset.isValidImageForIA()) continue;
+                        if (!asset.hasFamily(healShepherd)) asset.updateStandardChildren();
+                        // legacy rows: adopt the constructor convention before sending
+                        priorAcmId = asset.getAcmId();
+                        priorCaptured = true;
+                        if (priorAcmId == null) asset.setAcmId(asset.getUUID());
+                        ArrayList<MediaAsset> fixMe = new ArrayList<MediaAsset>();
+                        fixMe.add(asset);
+                        // checkFirst=false: the probe already established absence
+                        org.json.JSONObject sendRtn = IBEISIA.sendMediaAssetsNew(fixMe,
+                            context, false);
+                        sentCount++;
+                        if (sendConfirmedAcmId(sendRtn, asset.getAcmId())) {
+                            // commit so the confirmed acmId survives rollbackAndClose
+                            healShepherd.updateDBTransaction();
+                            healedCount++;
+                            if (healedCount >= maxFixes) {
+                                maxFixesHit = true;
+                                resumeAssetId = assetId.intValue();
+                                break;
+                            }
+                        } else {
+                            System.out.println(
+                                "WARNING: AcmIdBot sweep could not confirm WBIA registration for asset "
+                                + assetId + "; not counting as healed");
+                            // don't persist an acmId WBIA never acknowledged
+                            asset.setAcmId(priorAcmId);
+                        }
+                    } catch (Exception ec) {
+                        // revert BEFORE any commit below (or a later asset's commit)
+                        // can persist an acmId WBIA never acknowledged; probed-missing
+                        // assets revert to their original non-null DB acmId
+                        if (priorCaptured && asset != null) asset.setAcmId(priorAcmId);
+                        System.out.println("Exception in AcmIdBot sweep heal for asset " +
+                            assetId);
+                        ec.printStackTrace();
+                        // mirror fixFeats: a 500 from WBIA marks the image invalid for IA
+                        if (ec.toString().contains("HTTP error code : 500")) {
+                            try {
+                                if (asset != null) {
+                                    asset.setIsValidImageForIA(false);
+                                    healShepherd.updateDBTransaction();
+                                }
+                            } catch (Exception inner) {
+                                inner.printStackTrace();
+                            }
+                        }
+                    }
+                }
+            } finally {
+                healShepherd.rollbackAndClose();
+            }
+        }
+        sweepCursor = nextCursorAfterSuccess(page, maxFixesHit, resumeAssetId);
+        sweepFailCount = 0;
+        System.out.println("AcmIdBot Reconciliation Sweep Summary");
+        System.out.println("...page: " + (page.acmIdToAssetId.size() +
+            page.nullAcmAssetIds.size()) + " candidates (" + page.acmIdToAssetId.size() +
+            " probed, " + page.nullAcmAssetIds.size() + " null acmId)");
+        System.out.println("......missing from WBIA: " + missingAcmIds.size());
+        System.out.println("......heals sent: " + sentCount + ", heals successful: " +
+            healedCount + (maxFixesHit ? " (maxFixes cap hit)" : ""));
+        System.out.println("......cursor now " + sweepCursor +
+            (page.rawExhausted && !maxFixesHit ? " (sweep complete, wrapped)" : ""));
     }
 }

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -24,8 +24,6 @@ import org.ecocean.shepherd.core.Shepherd;
  *
  */
 public class AcmIdBot {
-    static String context = "context0";
-
     private static void fixFeats(List<Feature> feats, Shepherd myShepherd, String summaryMessage,
                                  int maxFixes) {
         if (feats != null && feats.size() > 0) {
@@ -51,7 +49,7 @@ public class AcmIdBot {
                         if (!asset.hasFamily(myShepherd)) asset.updateStandardChildren();
                         ArrayList<MediaAsset> fixMe = new ArrayList<MediaAsset>();
                         fixMe.add(asset);
-                        IBEISIA.sendMediaAssetsNew(fixMe, context);
+                        IBEISIA.sendMediaAssetsNew(fixMe, myShepherd.getContext());
                         numAcmIdFixesSent++;
                         // commit now: rectifyMediaAssetIds set acmId on this asset, and
                         // fixAcmIds() ends with rollbackAndClose() which would discard it
@@ -127,10 +125,18 @@ public class AcmIdBot {
             page.lastAssetId = asset.getIdInt();
             // known-invalid assets are unhealable: counted as processed, never probed
             if (asset.isValidImageForIA() != null && !asset.isValidImageForIA()) continue;
-            if (asset.getAcmId() == null) {
+            // null or malformed acmId: route straight to the heal path rather than
+            // the probe, since a non-UUID value would make WBIA reject the whole
+            // probe chunk and could strand the rest of the page (see Fix B)
+            if (asset.getAcmId() == null || !Util.isUUID(asset.getAcmId())) {
                 page.nullAcmAssetIds.add(asset.getIdInt());
             } else {
-                page.acmIdToAssetId.put(asset.getAcmId(), asset.getIdInt());
+                Integer displaced = page.acmIdToAssetId.put(asset.getAcmId(), asset.getIdInt());
+                if (displaced != null) {
+                    System.out.println("WARNING: AcmIdBot sweep found duplicate acmId " +
+                        asset.getAcmId() + " on assets " + displaced + " and " +
+                        asset.getIdInt() + "; only the latter will be probed/healed this sweep");
+                }
             }
         }
         return page;
@@ -228,40 +234,54 @@ public class AcmIdBot {
             "================ = = = = = = ===================== AcmIdBot.cleanup() finished.");
     }
 
+    // fixAcmIds is public and mutates static sweep state; guard against a
+    // concurrent manual invocation racing the scheduled run
+    private static final java.util.concurrent.atomic.AtomicBoolean botRunning =
+        new java.util.concurrent.atomic.AtomicBoolean(false);
+
     public static void fixAcmIds(String context) {
-        Shepherd myShepherd = new Shepherd(context);
-
-        myShepherd.setAction("AcmIdBot.java");
-        myShepherd.beginDBTransaction();
-
-        // number of fixes to consider before finishing and letting a new round of work restart the effort
-        int maxFixes = 500;
-        Query query2 = null;
-        try {
+        if (!botRunning.compareAndSet(false, true)) {
             System.out.println(
-                "Looking for complete import tasks with media assets with missing acmIds");
-
-            String filter2 =
-                "select from org.ecocean.media.Feature where itask.status == 'complete' && itask.encounters.contains(enc) && enc.annotations.contains(annot) && annot.features.contains(this) && asset.acmId == null VARIABLES org.ecocean.Encounter enc;org.ecocean.servlet.importer.ImportTask itask;org.ecocean.Annotation annot";
-            query2 = myShepherd.getPM().newQuery(filter2);
-            query2.setOrdering("revision desc");
-            Collection c2 = (Collection)(query2.execute());
-            List<Feature> feats = new ArrayList<Feature>(c2);
-            query2.closeAll();
-            query2 = null;  // Mark as closed
-
-            fixFeats(feats, myShepherd, "ACM ID ImportTask fixing summary", maxFixes);
-        } catch (Exception f) {
-            System.out.println("Exception in AcmIdBot!");
-            f.printStackTrace();
-        } finally {
-            if (query2 != null) query2.closeAll();
-            myShepherd.rollbackAndClose();
+                "WARNING: AcmIdBot.fixAcmIds() already running; skipping this invocation");
+            return;
         }
+        try {
+            Shepherd myShepherd = new Shepherd(context);
 
-        // full reconciliation sweep of the matchable set (replaces the old
-        // 24-hour Encounter query); manages its own transactions
-        sweepMatchableAssets(context, maxFixes);
+            myShepherd.setAction("AcmIdBot.java");
+            myShepherd.beginDBTransaction();
+
+            // number of fixes to consider before finishing and letting a new round of work restart the effort
+            int maxFixes = 500;
+            Query query2 = null;
+            try {
+                System.out.println(
+                    "Looking for complete import tasks with media assets with missing acmIds");
+
+                String filter2 =
+                    "select from org.ecocean.media.Feature where itask.status == 'complete' && itask.encounters.contains(enc) && enc.annotations.contains(annot) && annot.features.contains(this) && asset.acmId == null VARIABLES org.ecocean.Encounter enc;org.ecocean.servlet.importer.ImportTask itask;org.ecocean.Annotation annot";
+                query2 = myShepherd.getPM().newQuery(filter2);
+                query2.setOrdering("revision desc");
+                Collection c2 = (Collection)(query2.execute());
+                List<Feature> feats = new ArrayList<Feature>(c2);
+                query2.closeAll();
+                query2 = null;  // Mark as closed
+
+                fixFeats(feats, myShepherd, "ACM ID ImportTask fixing summary", maxFixes);
+            } catch (Exception f) {
+                System.out.println("Exception in AcmIdBot!");
+                f.printStackTrace();
+            } finally {
+                if (query2 != null) query2.closeAll();
+                myShepherd.rollbackAndClose();
+            }
+
+            // full reconciliation sweep of the matchable set (replaces the old
+            // 24-hour Encounter query); manages its own transactions
+            sweepMatchableAssets(context, maxFixes);
+        } finally {
+            botRunning.set(false);
+        }
     }
 
     /**
@@ -385,16 +405,22 @@ public class AcmIdBot {
                         }
                         if (!asset.isValidImageForIAForced()) continue;
                         if (!asset.hasFamily(healShepherd)) asset.updateStandardChildren();
-                        // legacy rows: adopt the constructor convention before sending
+                        // legacy null or malformed acmIds adopt the asset UUID before sending
                         priorAcmId = asset.getAcmId();
                         priorCaptured = true;
-                        if (priorAcmId == null) asset.setAcmId(asset.getUUID());
+                        if ((priorAcmId == null) || !Util.isUUID(priorAcmId))
+                            asset.setAcmId(asset.getUUID());
                         ArrayList<MediaAsset> fixMe = new ArrayList<MediaAsset>();
                         fixMe.add(asset);
                         // checkFirst=false: the probe already established absence
                         org.json.JSONObject sendRtn = IBEISIA.sendMediaAssetsNew(fixMe,
                             context, false);
                         sentCount++;
+                        // NOTE: compared against the POST-rectify acmId on purpose. If WBIA
+                        // already knew this image under a different UUID, rectifyMediaAssetIds
+                        // (inside the send) adopted WBIA's authoritative UUID — that
+                        // convergence IS the heal, and committing it is correct. A strict
+                        // compare against the pre-send UUID would revert and re-probe forever.
                         if (sendConfirmedAcmId(sendRtn, asset.getAcmId())) {
                             // commit so the confirmed acmId survives rollbackAndClose
                             healShepherd.updateDBTransaction();

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -289,6 +289,10 @@ public class AcmIdBot {
                 + sweepCursor + " VARIABLES org.ecocean.Annotation annot";
             query = readShepherd.getPM().newQuery(filter);
             query.setOrdering("asset.id ascending");
+            // stream the result instead of buffering ~1M Feature rows client-side
+            // (pgjdbc default fetchSize=0 buffers the whole ResultSet); setRange
+            // would break rawExhausted semantics, a cursor fetch does not
+            query.getFetchPlan().setFetchSize(1000);
             Collection c = (Collection)(query.execute());
             final java.util.Iterator featIter = c.iterator();
             java.util.Iterator<MediaAsset> assetIter = new java.util.Iterator<MediaAsset>() {
@@ -307,7 +311,26 @@ public class AcmIdBot {
             if (query != null) query.closeAll();
             readShepherd.rollbackAndClose();
         }
-        if (page == null) return; // read failed; cursor unchanged, retry next run
+        if (page == null) {
+            // read phase failed: this counts toward the same poisoned-page guard as
+            // probe failures, since a corrupt row at this cursor could otherwise
+            // stall the sweep forever. There is no page.lastAssetId to resume from
+            // here, so a skip is a blind advance rather than a targeted one.
+            sweepFailCount++;
+            System.out.println("WARNING: AcmIdBot sweep read phase failed (attempt " +
+                sweepFailCount + " of " + PAGE_FAIL_LIMIT + " at cursor " + sweepCursor +
+                ")");
+            if (shouldSkipPoisonedPage(sweepFailCount)) {
+                System.out.println(
+                    "WARNING: AcmIdBot sweep SKIPPING page after repeated read failures; " +
+                    "blind-advancing cursor " + sweepCursor + " -> " +
+                    (sweepCursor + SWEEP_PAGE_SIZE) +
+                    " (no page ids available; wrap-around will resweep the skipped range)");
+                sweepCursor += SWEEP_PAGE_SIZE;
+                sweepFailCount = 0;
+            }
+            return; // cursor otherwise unchanged: same page retried next run
+        }
 
         // ---- probe phase (no transaction open) ----
         List<String> missingAcmIds = null;
@@ -360,7 +383,7 @@ public class AcmIdBot {
                             asset.validateSourceImage();
                             healShepherd.updateDBTransaction();
                         }
-                        if (!asset.isValidImageForIA()) continue;
+                        if (!asset.isValidImageForIAForced()) continue;
                         if (!asset.hasFamily(healShepherd)) asset.updateStandardChildren();
                         // legacy rows: adopt the constructor convention before sending
                         priorAcmId = asset.getAcmId();

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -398,12 +398,20 @@ public class AcmIdBot {
                     try {
                         asset = org.ecocean.media.MediaAssetFactory.load(
                             assetId.intValue(), healShepherd);
-                        if (asset == null) continue;
+                        if (asset == null) {
+                            System.out.println("WARNING: AcmIdBot sweep skipping unhealable asset "
+                                + assetId + " (no longer exists)");
+                            continue;
+                        }
                         if (asset.isValidImageForIA() == null) {
                             asset.validateSourceImage();
                             healShepherd.updateDBTransaction();
                         }
-                        if (!asset.isValidImageForIAForced()) continue;
+                        if (!asset.isValidImageForIAForced()) {
+                            System.out.println("WARNING: AcmIdBot sweep skipping unhealable asset "
+                                + assetId + " (invalid or unvalidatable image for IA)");
+                            continue;
+                        }
                         if (!asset.hasFamily(healShepherd)) asset.updateStandardChildren();
                         // legacy null or malformed acmIds adopt the asset UUID before sending
                         priorAcmId = asset.getAcmId();

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -173,7 +173,14 @@ public class AcmIdBot {
     }
 
     // background workers
-    public static boolean startServices(String context) {
+    private static ScheduledExecutorService schedExec = null;
+
+    public static synchronized boolean startServices(String context) {
+        if ((schedExec != null) && !schedExec.isShutdown()) {
+            System.out.println("WARNING: AcmIdBot.startServices(" + context +
+                ") called but collector already running; ignoring");
+            return false;
+        }
         startCollector(context);
         return true;
     }
@@ -184,14 +191,15 @@ public class AcmIdBot {
         long initialDelay = 1; // number minutes before first execution occurs
 
         System.out.println("+ AcmIdBot.startCollector(" + context + ") starting.");
-        final ScheduledExecutorService schedExec = Executors.newScheduledThreadPool(1);
-        final ScheduledFuture schedFuture = schedExec.scheduleWithFixedDelay(new Runnable() {
+        schedExec = Executors.newScheduledThreadPool(1);
+        final ScheduledExecutorService execRef = schedExec;
+        final ScheduledFuture schedFuture = execRef.scheduleWithFixedDelay(new Runnable() {
             // DO WORK HERE
             public void run() {
                 if (new java.io.File("/tmp/WB_AcmIdBot_SHUTDOWN").exists()) {
                     System.out.println("INFO: AcmIdBot.startCollection(" + context +
                     ") shutting down due to file signal");
-                    schedExec.shutdown();
+                    execRef.shutdown();
                     return;
                 }
                 fixAcmIds(context);
@@ -202,7 +210,7 @@ public class AcmIdBot {
 
         System.out.println("Let's get AcmIdBot's time running.");
         try {
-            schedExec.awaitTermination(5000, TimeUnit.MILLISECONDS);
+            execRef.awaitTermination(5000, TimeUnit.MILLISECONDS);
         } catch (java.lang.InterruptedException ex) {
             System.out.println("WARNING: AcmIdBot.startCollector(" + context + ") interrupted: " +
                 ex.toString());
@@ -210,8 +218,12 @@ public class AcmIdBot {
         System.out.println("+ AcmIdBot.startCollector(" + context + ") backgrounded");
     }
 
-    // mostly for ContextDestroyed in StartupWildbook..... i think?
-    public static void cleanup() {
+    // called from StartupWildbook contextDestroyed
+    public static synchronized void cleanup() {
+        if (schedExec != null) {
+            schedExec.shutdown();
+            schedExec = null;
+        }
         System.out.println(
             "================ = = = = = = ===================== AcmIdBot.cleanup() finished.");
     }

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -52,6 +52,9 @@ public class AcmIdBot {
                         fixMe.add(asset);
                         IBEISIA.sendMediaAssetsNew(fixMe, context);
                         numAcmIdFixesSent++;
+                        // commit now: rectifyMediaAssetIds set acmId on this asset, and
+                        // fixAcmIds() ends with rollbackAndClose() which would discard it
+                        myShepherd.updateDBTransaction();
                         if (asset.getAcmId() != null) {
                             numAcmIdFixesSuccessful++;
                             // allow the bot to determine how many fixes it wants the logic to consider before exiting

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -85,6 +85,92 @@ public class AcmIdBot {
         }
     }
 
+    // ------- reconciliation sweep (spec: 2026-07-01-acmidbot-reconciliation-sweep-design.md) -------
+
+    static final int SWEEP_PAGE_SIZE = 10000; // distinct assets examined per 15-minute run
+    static final int PAGE_FAIL_LIMIT = 3; // failed runs on one page before skipping it
+    // in-memory sweep state; a restart just restarts the sweep (probes are cheap)
+    static int sweepCursor = 0; // highest asset id processed
+    static int sweepFailCount = 0; // consecutive failures at the current cursor
+
+    // one page of sweep candidates, reduced to primitives so no JDO object
+    // outlives the read transaction
+    static class SweepPage {
+        final List<Integer> nullAcmAssetIds = new ArrayList<Integer>();
+        final java.util.LinkedHashMap<String, Integer> acmIdToAssetId =
+            new java.util.LinkedHashMap<String, Integer>();
+        boolean rawExhausted = false;
+        int lastAssetId = -1; // -1 = empty page
+    }
+
+    // walk assets (ascending id order, may contain duplicates from multiple
+    // Features per asset) collecting up to pageSize distinct assets.
+    // rawExhausted is true only when the input ran out — never inferred from
+    // a post-dedup count (spec §1/§2).
+    static SweepPage collectSweepPage(java.util.Iterator<MediaAsset> assetsInIdOrder,
+        int pageSize) {
+        SweepPage page = new SweepPage();
+        java.util.Set<Integer> seen = new java.util.HashSet<Integer>();
+
+        page.rawExhausted = true;
+        while (assetsInIdOrder.hasNext()) {
+            MediaAsset asset = assetsInIdOrder.next();
+            if (asset == null) continue;
+            // NOTE: MediaAsset.getId() returns String; getIdInt() is the int accessor
+            if (seen.contains(asset.getIdInt())) continue;
+            if (seen.size() >= pageSize) {
+                page.rawExhausted = false;
+                return page;
+            }
+            seen.add(asset.getIdInt());
+            page.lastAssetId = asset.getIdInt();
+            // known-invalid assets are unhealable: counted as processed, never probed
+            if (asset.isValidImageForIA() != null && !asset.isValidImageForIA()) continue;
+            if (asset.getAcmId() == null) {
+                page.nullAcmAssetIds.add(asset.getIdInt());
+            } else {
+                page.acmIdToAssetId.put(asset.getAcmId(), asset.getIdInt());
+            }
+        }
+        return page;
+    }
+
+    // cursor policy (spec §2): maxFixes clamp wins (resume mid-page next run),
+    // else wrap to 0 on true exhaustion, else advance past the page
+    static int nextCursorAfterSuccess(SweepPage page, boolean maxFixesHit, int resumeAssetId) {
+        if (maxFixesHit) return resumeAssetId;
+        if (page.rawExhausted) return 0;
+        return page.lastAssetId;
+    }
+
+    // poisoned-page guard (spec §5): after PAGE_FAIL_LIMIT consecutive failures
+    // on the same page, skip it so one bad page cannot stall the sweep forever
+    static boolean shouldSkipPoisonedPage(int consecutiveFailures) {
+        return consecutiveFailures >= PAGE_FAIL_LIMIT;
+    }
+
+    // did a sendMediaAssetsNew() round-trip actually register this acmId with
+    // WBIA? add_images_json returns the registered image UUIDs; require ours
+    // among them before counting (and committing) a heal — otherwise a locally
+    // pre-assigned acmId could be persisted although WBIA never registered it
+    static boolean sendConfirmedAcmId(org.json.JSONObject sendRtn, String expectedAcmId) {
+        if ((sendRtn == null) || (expectedAcmId == null)) return false;
+        org.json.JSONArray batches = sendRtn.optJSONArray("batchResults");
+        if (batches == null) return false;
+        for (int b = 0; b < batches.length(); b++) {
+            org.json.JSONObject rtn = batches.optJSONObject(b);
+            if (rtn == null) continue; // "EMPTY BATCH" marker string
+            org.json.JSONArray resp = rtn.optJSONArray("response");
+            if (resp == null) continue;
+            for (int i = 0; i < resp.length(); i++) {
+                org.json.JSONObject fancy = resp.optJSONObject(i);
+                if ((fancy != null) &&
+                    expectedAcmId.equals(fancy.optString("__UUID__", null))) return true;
+            }
+        }
+        return false;
+    }
+
     // background workers
     public static boolean startServices(String context) {
         startCollector(context);

--- a/src/main/java/org/ecocean/ia/plugin/WildbookIAM.java
+++ b/src/main/java/org/ecocean/ia/plugin/WildbookIAM.java
@@ -686,10 +686,12 @@ public class WildbookIAM extends IAPlugin {
      * Ask WBIA which of the given image acmIds it does NOT have, via
      * GET /api/image/rowid/uuid/ in {@link #PROBE_CHUNK_SIZE} chunks
      * (a null rowid in the response marks that UUID unknown — see
-     * wildbook-ia get_image_gids_from_uuid). Null acmIds are skipped
-     * (callers treat those assets as heal candidates without probing).
-     * Throws IOException if any chunk fails so callers never mistake a
-     * failed probe for "all present". (AcmIdBot sweep spec §3.)
+     * wildbook-ia get_image_gids_from_uuid). Null or malformed (non-UUID)
+     * acmIds are skipped (callers treat those assets as heal candidates
+     * without probing; a malformed value in a chunk could otherwise make
+     * WBIA reject the whole chunk). Throws IOException if any chunk fails
+     * so callers never mistake a failed probe for "all present". (AcmIdBot
+     * sweep spec §3.)
      */
     public static List<String> iaMissingImageIds(List<String> acmIds, String context)
     throws IOException {
@@ -698,7 +700,7 @@ public class WildbookIAM extends IAPlugin {
         if (acmIds == null) return missing;
         List<String> probeable = new ArrayList<String>();
         for (String acmId : acmIds) {
-            if (acmId != null) probeable.add(acmId);
+            if (acmId != null && Util.isUUID(acmId)) probeable.add(acmId);
         }
         for (List<String> chunk : chunkList(probeable, PROBE_CHUNK_SIZE)) {
             StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/ecocean/ia/plugin/WildbookIAM.java
+++ b/src/main/java/org/ecocean/ia/plugin/WildbookIAM.java
@@ -683,6 +683,45 @@ public class WildbookIAM extends IAPlugin {
     }
 
     /**
+     * Ask WBIA which of the given image acmIds it does NOT have, via
+     * GET /api/image/rowid/uuid/ in {@link #PROBE_CHUNK_SIZE} chunks
+     * (a null rowid in the response marks that UUID unknown — see
+     * wildbook-ia get_image_gids_from_uuid). Null acmIds are skipped
+     * (callers treat those assets as heal candidates without probing).
+     * Throws IOException if any chunk fails so callers never mistake a
+     * failed probe for "all present". (AcmIdBot sweep spec §3.)
+     */
+    public static List<String> iaMissingImageIds(List<String> acmIds, String context)
+    throws IOException {
+        List<String> missing = new ArrayList<String>();
+
+        if (acmIds == null) return missing;
+        List<String> probeable = new ArrayList<String>();
+        for (String acmId : acmIds) {
+            if (acmId != null) probeable.add(acmId);
+        }
+        for (List<String> chunk : chunkList(probeable, PROBE_CHUNK_SIZE)) {
+            StringBuilder sb = new StringBuilder();
+            for (String acmId : chunk) {
+                if (sb.length() > 0) sb.append(",");
+                sb.append(toFancyUUID(acmId).toString());
+            }
+            JSONArray resp = null;
+            try {
+                resp = apiGetJSONArray("/api/image/rowid/uuid/?uuid_list=[" + sb.toString() +
+                    "]", context);
+            } catch (Exception ex) {
+                throw new IOException("WBIA /api/image/rowid/uuid/ probe failed: " +
+                        ex.getMessage(), ex);
+            }
+            // apiGetJSONArray returns null when status.success is false or
+            // the payload is unparseable; parseRowidProbeResponse throws on it
+            missing.addAll(parseRowidProbeResponse(chunk, resp));
+        }
+        return missing;
+    }
+
+    /**
      * Shared body for {@link #parseAnnotationIdsArrayStrict} and
      * {@link #parseImageIdsArrayStrict}. The {@code label} is the
      * source-array name (e.g. {@code "iaAnnotationIds"},

--- a/src/main/java/org/ecocean/ia/plugin/WildbookIAM.java
+++ b/src/main/java/org/ecocean/ia/plugin/WildbookIAM.java
@@ -638,6 +638,51 @@ public class WildbookIAM extends IAPlugin {
     }
 
     /**
+     * Chunk size for the /api/image/rowid/uuid/ existence probe. 50 fancy
+     * UUIDs is ~3.5 KB of query string — safely under common proxy URL
+     * limits. (AcmIdBot reconciliation sweep spec §3/§6.)
+     */
+    static final int PROBE_CHUNK_SIZE = 50;
+
+    /**
+     * Split a list into consecutive sublists of at most {@code size}
+     * elements, preserving order. Returns an empty list for null/empty
+     * input or a non-positive size.
+     */
+    static <T> java.util.List<java.util.List<T>> chunkList(java.util.List<T> items, int size) {
+        java.util.List<java.util.List<T>> out = new ArrayList<java.util.List<T>>();
+
+        if ((items == null) || items.isEmpty() || (size < 1)) return out;
+        for (int i = 0; i < items.size(); i += size) {
+            out.add(new ArrayList<T>(items.subList(i, Math.min(items.size(), i + size))));
+        }
+        return out;
+    }
+
+    /**
+     * Interpret one /api/image/rowid/uuid/ response chunk. WBIA returns a
+     * rowid per requested UUID, with JSON null where the UUID is unknown;
+     * those unknown acmIds are returned. Throws IOException on a null
+     * response or a request/response length mismatch so a malformed reply
+     * is treated as a failed probe, never as "all present". (AcmIdBot
+     * reconciliation sweep spec §3.)
+     */
+    static List<String> parseRowidProbeResponse(List<String> chunkAcmIds, JSONArray response)
+    throws IOException {
+        if (response == null)
+            throw new IOException("rowid probe returned null response for chunk of " +
+                    chunkAcmIds.size());
+        if (response.length() != chunkAcmIds.size())
+            throw new IOException("rowid probe response length " + response.length() +
+                    " != request length " + chunkAcmIds.size());
+        List<String> missing = new ArrayList<String>();
+        for (int i = 0; i < response.length(); i++) {
+            if (response.isNull(i)) missing.add(chunkAcmIds.get(i));
+        }
+        return missing;
+    }
+
+    /**
      * Shared body for {@link #parseAnnotationIdsArrayStrict} and
      * {@link #parseImageIdsArrayStrict}. The {@code label} is the
      * source-array name (e.g. {@code "iaAnnotationIds"},

--- a/src/main/java/org/ecocean/identity/IBEISIA.java
+++ b/src/main/java/org/ecocean/identity/IBEISIA.java
@@ -3677,9 +3677,19 @@ public class IBEISIA {
     public static JSONObject sendMediaAssetsNew(ArrayList<MediaAsset> mas, String context)
     throws RuntimeException, MalformedURLException, IOException, NoSuchAlgorithmException,
         InvalidKeyException {
+        return sendMediaAssetsNew(mas, context, true);
+    }
+
+    // checkFirst=false skips the full iaImageIds() existence pre-check; use when
+    // the caller has already established the assets are missing from WBIA
+    // (e.g. AcmIdBot sweep probe). (AcmIdBot sweep spec §4.)
+    public static JSONObject sendMediaAssetsNew(ArrayList<MediaAsset> mas, String context,
+        boolean checkFirst)
+    throws RuntimeException, MalformedURLException, IOException, NoSuchAlgorithmException,
+        InvalidKeyException {
         WildbookIAM plugin = getPluginInstance(context);
 
-        return plugin.sendMediaAssets(mas, true);
+        return plugin.sendMediaAssets(mas, checkFirst);
     }
 
     public static JSONObject sendAnnotationsNew(ArrayList<Annotation> anns, String context,

--- a/src/test/java/org/ecocean/AcmIdBotSweepTest.java
+++ b/src/test/java/org/ecocean/AcmIdBotSweepTest.java
@@ -105,6 +105,16 @@ class AcmIdBotSweepTest {
         assertEquals(0, page.nullAcmAssetIds.size());
     }
 
+    @Test void routesMalformedAcmIdToNullBucket() {
+        MediaAsset ma = asset(7);
+
+        ma.setAcmId("not-a-valid-uuid");
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(Arrays.asList(ma).iterator(), 10);
+        assertEquals(1, page.nullAcmAssetIds.size());
+        assertEquals(Integer.valueOf(7), page.nullAcmAssetIds.get(0));
+        assertEquals(0, page.acmIdToAssetId.size());
+    }
+
     // ---------- nextCursorAfterSuccess ----------
 
     @Test void normalPageAdvancesToLastAssetId() {

--- a/src/test/java/org/ecocean/AcmIdBotSweepTest.java
+++ b/src/test/java/org/ecocean/AcmIdBotSweepTest.java
@@ -1,0 +1,177 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.ecocean.media.MediaAsset;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure-logic coverage of the AcmIdBot reconciliation sweep helpers
+ * (spec docs/superpowers/specs/2026-07-01-acmidbot-reconciliation-sweep-design.md):
+ * page collection (dedup, bucketing, exhaustion), cursor advancement
+ * (wrap-around, maxFixes clamp), and the poisoned-page skip threshold.
+ */
+class AcmIdBotSweepTest {
+
+    private static MediaAsset asset(int id) {
+        // constructor defaults acmId to the asset's own UUID
+        return new MediaAsset(id, null, null);
+    }
+
+    private static MediaAsset nullAcmAsset(int id) {
+        MediaAsset ma = asset(id);
+
+        ma.setAcmId(null); // legacy row: never assigned
+        return ma;
+    }
+
+    private static MediaAsset invalidAsset(int id) {
+        MediaAsset ma = asset(id);
+
+        ma.setIsValidImageForIA(false);
+        return ma;
+    }
+
+    // ---------- collectSweepPage ----------
+
+    @Test void bucketsNullAcmSeparatelyFromProbeable() {
+        List<MediaAsset> in = Arrays.asList(asset(1), nullAcmAsset(2), asset(3));
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 10);
+
+        assertEquals(2, page.acmIdToAssetId.size());
+        assertEquals(1, page.nullAcmAssetIds.size());
+        assertEquals(Integer.valueOf(2), page.nullAcmAssetIds.get(0));
+        assertTrue(page.rawExhausted, "short input should exhaust");
+        assertEquals(3, page.lastAssetId);
+    }
+
+    @Test void dedupesRepeatedAssets() {
+        MediaAsset one = asset(1);
+        List<MediaAsset> in = Arrays.asList(one, one, asset(2), one);
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 10);
+
+        assertEquals(2, page.acmIdToAssetId.size());
+        assertTrue(page.rawExhausted);
+    }
+
+    @Test void skipsKnownInvalidButStillCountsThemTowardPage() {
+        List<MediaAsset> in = Arrays.asList(invalidAsset(1), asset(2));
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 10);
+
+        assertEquals(1, page.acmIdToAssetId.size());
+        assertEquals(0, page.nullAcmAssetIds.size());
+        assertEquals(2, page.lastAssetId);
+    }
+
+    @Test void skipsNullAssetsFromDanglingFeatures() {
+        List<MediaAsset> in = Arrays.asList(null, asset(2));
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 10);
+
+        assertEquals(1, page.acmIdToAssetId.size());
+        assertTrue(page.rawExhausted);
+    }
+
+    @Test void pageLimitStopsCollectionAndMarksNotExhausted() {
+        List<MediaAsset> in = new ArrayList<MediaAsset>();
+        for (int i = 1; i <= 5; i++) in.add(asset(i));
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 3);
+
+        assertEquals(3, page.acmIdToAssetId.size());
+        assertFalse(page.rawExhausted, "limit hit before input end: not exhausted");
+        assertEquals(3, page.lastAssetId);
+    }
+
+    @Test void exactlyFullPageWithNoMoreInputIsExhausted() {
+        List<MediaAsset> in = Arrays.asList(asset(1), asset(2), asset(3));
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(in.iterator(), 3);
+
+        assertEquals(3, page.acmIdToAssetId.size());
+        assertTrue(page.rawExhausted, "input ended exactly at limit: exhausted");
+    }
+
+    @Test void emptyInputIsExhaustedWithSentinelLastId() {
+        AcmIdBot.SweepPage page =
+            AcmIdBot.collectSweepPage(new ArrayList<MediaAsset>().iterator(), 10);
+
+        assertTrue(page.rawExhausted);
+        assertEquals(-1, page.lastAssetId);
+        assertEquals(0, page.acmIdToAssetId.size());
+        assertEquals(0, page.nullAcmAssetIds.size());
+    }
+
+    // ---------- nextCursorAfterSuccess ----------
+
+    @Test void normalPageAdvancesToLastAssetId() {
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(
+            Arrays.asList(asset(7), asset(9)).iterator(), 1); // limit -> not exhausted
+        assertFalse(page.rawExhausted);
+        assertEquals(7, AcmIdBot.nextCursorAfterSuccess(page, false, page.lastAssetId));
+    }
+
+    @Test void exhaustionWrapsCursorToZero() {
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(
+            Arrays.asList(asset(7)).iterator(), 10);
+        assertTrue(page.rawExhausted);
+        assertEquals(0, AcmIdBot.nextCursorAfterSuccess(page, false, page.lastAssetId));
+    }
+
+    @Test void maxFixesClampBeatsExhaustionWrap() {
+        AcmIdBot.SweepPage page = AcmIdBot.collectSweepPage(
+            Arrays.asList(asset(7), asset(9)).iterator(), 10);
+        assertTrue(page.rawExhausted);
+        // cap hit while healing asset 7: resume from 7, do NOT wrap
+        assertEquals(7, AcmIdBot.nextCursorAfterSuccess(page, true, 7));
+    }
+
+    // ---------- shouldSkipPoisonedPage ----------
+
+    @Test void skipsOnlyAtFailLimit() {
+        assertFalse(AcmIdBot.shouldSkipPoisonedPage(1));
+        assertFalse(AcmIdBot.shouldSkipPoisonedPage(2));
+        assertTrue(AcmIdBot.shouldSkipPoisonedPage(3));
+        assertTrue(AcmIdBot.shouldSkipPoisonedPage(4));
+    }
+
+    // ---------- sendConfirmedAcmId ----------
+
+    private static org.json.JSONObject sendRtnWithUuids(String... uuids) {
+        org.json.JSONArray resp = new org.json.JSONArray();
+
+        for (String u : uuids) {
+            org.json.JSONObject fancy = new org.json.JSONObject();
+            fancy.put("__UUID__", u);
+            resp.put(fancy);
+        }
+        org.json.JSONObject rtn = new org.json.JSONObject();
+        rtn.put("response", resp);
+        org.json.JSONArray batches = new org.json.JSONArray();
+        batches.put(rtn);
+        org.json.JSONObject all = new org.json.JSONObject();
+        all.put("batchResults", batches);
+        return all;
+    }
+
+    @Test void confirmsWhenResponseContainsExpectedAcmId() {
+        assertTrue(AcmIdBot.sendConfirmedAcmId(sendRtnWithUuids("abc", "def"), "def"));
+    }
+
+    @Test void doesNotConfirmWhenUuidAbsentOrBatchEmpty() {
+        assertFalse(AcmIdBot.sendConfirmedAcmId(sendRtnWithUuids("abc"), "def"));
+        org.json.JSONObject all = new org.json.JSONObject();
+        org.json.JSONArray batches = new org.json.JSONArray();
+        batches.put("EMPTY BATCH");
+        all.put("batchResults", batches);
+        assertFalse(AcmIdBot.sendConfirmedAcmId(all, "def"));
+    }
+
+    @Test void doesNotConfirmOnNulls() {
+        assertFalse(AcmIdBot.sendConfirmedAcmId(null, "abc"));
+        assertFalse(AcmIdBot.sendConfirmedAcmId(sendRtnWithUuids("abc"), null));
+    }
+}

--- a/src/test/java/org/ecocean/ia/plugin/WildbookIAMRowidProbeParseTest.java
+++ b/src/test/java/org/ecocean/ia/plugin/WildbookIAMRowidProbeParseTest.java
@@ -1,0 +1,91 @@
+package org.ecocean.ia.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Coverage of the pure helpers behind
+ * {@link WildbookIAM#iaMissingImageIds(java.util.List, String)}:
+ * {@link WildbookIAM#chunkList(List, int)} and
+ * {@link WildbookIAM#parseRowidProbeResponse(List, JSONArray)}.
+ * The WBIA endpoint /api/image/rowid/uuid/ returns a rowid per requested
+ * image UUID, with JSON null where the UUID is unknown; null entries mark
+ * the acmId as missing from WBIA. (AcmIdBot reconciliation sweep spec §3.)
+ */
+class WildbookIAMRowidProbeParseTest {
+
+    // ---------- chunkList ----------
+
+    @Test void chunkListSplitsAtExactBoundary() {
+        List<String> in = new ArrayList<String>();
+        for (int i = 0; i < 100; i++) in.add("u" + i);
+        List<List<String>> out = WildbookIAM.chunkList(in, 50);
+        assertEquals(2, out.size());
+        assertEquals(50, out.get(0).size());
+        assertEquals(50, out.get(1).size());
+        assertEquals("u0", out.get(0).get(0));
+        assertEquals("u99", out.get(1).get(49));
+    }
+
+    @Test void chunkListHandlesRemainderAndSmallInput() {
+        List<List<String>> out = WildbookIAM.chunkList(Arrays.asList("a", "b", "c"), 2);
+        assertEquals(2, out.size());
+        assertEquals(2, out.get(0).size());
+        assertEquals(1, out.get(1).size());
+        out = WildbookIAM.chunkList(Arrays.asList("solo"), 50);
+        assertEquals(1, out.size());
+        assertEquals("solo", out.get(0).get(0));
+    }
+
+    @Test void chunkListEmptyOrNullOrBadSizeReturnsEmpty() {
+        assertEquals(0, WildbookIAM.chunkList(new ArrayList<String>(), 50).size());
+        assertEquals(0, WildbookIAM.chunkList(null, 50).size());
+        assertEquals(0, WildbookIAM.chunkList(Arrays.asList("a"), 0).size());
+    }
+
+    // ---------- parseRowidProbeResponse ----------
+
+    @Test void nullRowidEntriesAreMissing() throws IOException {
+        List<String> chunk = Arrays.asList("aaa", "bbb", "ccc");
+        JSONArray resp = new JSONArray();
+        resp.put(101);
+        resp.put(org.json.JSONObject.NULL);
+        resp.put(303);
+        List<String> missing = WildbookIAM.parseRowidProbeResponse(chunk, resp);
+        assertEquals(1, missing.size());
+        assertEquals("bbb", missing.get(0));
+    }
+
+    @Test void allKnownReturnsEmpty() throws IOException {
+        List<String> chunk = Arrays.asList("aaa", "bbb");
+        JSONArray resp = new JSONArray();
+        resp.put(1);
+        resp.put(2);
+        assertEquals(0, WildbookIAM.parseRowidProbeResponse(chunk, resp).size());
+    }
+
+    @Test void lengthMismatchThrows() {
+        List<String> chunk = Arrays.asList("aaa", "bbb");
+        JSONArray resp = new JSONArray();
+        resp.put(1);
+        IOException ex = assertThrows(IOException.class,
+            () -> WildbookIAM.parseRowidProbeResponse(chunk, resp));
+        assertTrue(ex.getMessage().contains("length"),
+            "message should mention length: " + ex.getMessage());
+    }
+
+    @Test void nullResponseThrows() {
+        List<String> chunk = Arrays.asList("aaa");
+        assertThrows(IOException.class,
+            () -> WildbookIAM.parseRowidProbeResponse(chunk, null));
+    }
+}


### PR DESCRIPTION
## Problem

AcmIdBot's second query only healed assets with `acmId == null` from Encounters submitted in the last 24 hours. That misses (1) the actual set that matters — every MediaAsset backing a `matchAgainst==true` Annotation — and (2) desync WBIA-side: since Wildbook owns acmId assignment, an asset can hold a plausible acmId that WBIA never registered, invisible to any null-check. Only asking WBIA "do you know this UUID?" finds those.

## What this does

Replaces Query 2 with a **cursor-paged reconciliation sweep** (Query 1, the completed-ImportTask fast path, stays):

- **Read phase** — JDOQL page over `matchAgainst==true` Features, `asset.id` ascending, up to 10,000 distinct assets per 15-minute run (streamed via fetchSize 1000; ~1M-row installs sweep in ~1 day). Reduced to primitives; transaction closed before any HTTP.
- **Probe phase** — `GET /api/image/rowid/uuid/` in 50-UUID chunks via new `WildbookIAM.iaMissingImageIds()`; a null rowid marks the acmId unknown to WBIA. Fail-closed: malformed replies throw, never read as "all present".
- **Heal phase** — fresh transaction; missing + null/malformed-acmId assets re-registered via `sendMediaAssetsNew(…, checkFirst=false)` (new overload; 2-arg behavior unchanged). Commit and success-count are gated on WBIA echoing the expected UUID (`sendConfirmedAcmId`); failure paths revert any pre-assigned acmId. Capped by the existing `maxFixes=500`.
- **Cursor** — in-memory; wraps only on raw-result exhaustion; maxFixes clamps mid-page; 3-strike poisoned-page skip covers both probe and read failures so one bad page can't stall the sweep.

## Bugs fixed along the way

- `fixFeats` healed acmIds could be silently rolled back by `fixAcmIds`'s closing `rollbackAndClose()` — now committed explicitly.
- `fixFeats` sent with the static `"context0"` instead of the caller's context.
- Unbox NPE on non-LOCAL (S3/URL) asset stores in the validity check.
- Scheduler: double `startServices()` leaked executors; `cleanup()` never shut the executor down; public `fixAcmIds()` now has a concurrent-run guard.

## Testing

29 unit tests green (`AcmIdBotSweepTest` 15, `WildbookIAMRowidProbeParseTest` 7, plus existing strict-parse regression classes). Design docs (spec + plan) included under `docs/superpowers/`.

Reviewed by Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
