### PR TITLE
Batch-load + cap match prospects; raise match socket timeout to 240s

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -1146,12 +1146,24 @@ public class Annotation extends Base implements java.io.Serializable {
             ex.printStackTrace();
         }
         JSONArray hits = OpenSearch.getHits(queryRes);
+        // Batch-load the candidate set in one query instead of one getAnnotation() per hit (O(N)
+        // DB round-trips over the full matching set). No top-N cap here: this is the candidate
+        // POOL (e.g. for WBIA matchers), not the ranked prospect list. Preserve hit order.
+        java.util.LinkedHashMap<String, Double> idToScore = new java.util.LinkedHashMap<String, Double>();
         for (int i = 0; i < hits.length(); i++) {
             JSONObject hit = hits.optJSONObject(i);
             if (hit == null) continue;
-            Annotation ann = myShepherd.getAnnotation(hit.optString("_id", null));
+            String hid = hit.optString("_id", null);
+            if (hid != null) idToScore.put(hid, hit.optDouble("_score", 0.0d));
+        }
+        java.util.Map<String, Annotation> byId = new java.util.HashMap<String, Annotation>();
+        for (Annotation a : myShepherd.getAnnotations(idToScore.keySet())) {
+            if ((a != null) && (a.getId() != null)) byId.put(a.getId(), a);
+        }
+        for (java.util.Map.Entry<String, Double> e : idToScore.entrySet()) {
+            Annotation ann = byId.get(e.getKey());
             if (ann != null) {
-                ann.setOpensearchScore(hit.optDouble("_score", 0.0d));
+                ann.setOpensearchScore(e.getValue());
                 anns.add(ann);
             }
         }
@@ -1269,14 +1281,29 @@ public class Annotation extends Base implements java.io.Serializable {
             ex.printStackTrace();
         }
         JSONArray hits = OpenSearch.getHits(queryRes);
-        for (int i = 0; i < hits.length(); i++) {
+        // Take the top-N hits (OpenSearch returns them score-sorted) and BATCH-load them in one
+        // query. Previously this did one myShepherd.getAnnotation() per hit -- O(N) DB round-trips
+        // that dominated match time (hundreds of prospects -> tens of seconds to minutes, often
+        // tripping the socket timeout -> empty result). Cap at MAXIMUM_PROSPECTS_STORED since
+        // nothing downstream keeps more than that. LinkedHashMap preserves the kNN score order.
+        int cap = org.ecocean.ia.MatchResult.MAXIMUM_PROSPECTS_STORED;
+        java.util.LinkedHashMap<String, Double> idToScore = new java.util.LinkedHashMap<String, Double>();
+        for (int i = 0; (i < hits.length()) && (idToScore.size() < cap); i++) {
             JSONObject hit = hits.optJSONObject(i);
             if (hit == null) continue;
-            Annotation ann = myShepherd.getAnnotation(hit.optString("_id", null));
+            String hid = hit.optString("_id", null);
+            // See osHitScore javadoc for why the OS score is persisted unchanged
+            // (vector <-> WBIA-MiewID parity).
+            if (hid != null) idToScore.put(hid, osHitScore(hit));
+        }
+        java.util.Map<String, Annotation> byId = new java.util.HashMap<String, Annotation>();
+        for (Annotation a : myShepherd.getAnnotations(idToScore.keySet())) {
+            if ((a != null) && (a.getId() != null)) byId.put(a.getId(), a);
+        }
+        for (java.util.Map.Entry<String, Double> e : idToScore.entrySet()) {
+            Annotation ann = byId.get(e.getKey());
             if (ann != null) {
-                // See osHitScore javadoc for why the OS score is
-                // persisted unchanged (vector ↔ WBIA-MiewID parity).
-                ann.setOpensearchScore(osHitScore(hit));
+                ann.setOpensearchScore(e.getValue());
                 anns.add(ann);
             }
         }

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -125,15 +125,17 @@ public class OpenSearch {
     }
 
     public static void initializeClient(HttpHost host) {
-        // Raise the socket timeout above the 30s default. A slow query (e.g. a
-        // cold/large kNN) otherwise throws SocketTimeoutException, which
-        // getMatches() swallows into an empty result -- surfacing to users as
-        // "0 matches". The top-level-vector match query keeps searches fast;
-        // this is a safety net so a slow query degrades to "slow", not silently
-        // "empty".
+        // Raise the socket timeout well above the 30s default. A slow query (e.g. a
+        // cold/large kNN, or a match over a big candidate set) otherwise throws
+        // SocketTimeoutException, which the match path surfaces to users as an empty
+        // "0 matches" result -- and a failed match reads as "no match found", which is
+        // WORSE for a user than a slow one. 240s gives cold/large matches room to
+        // complete rather than silently returning empty. (The batch-load + top-N cap in
+        // Annotation.getMatches keep normal matches to a few seconds; this is the safety
+        // net for the cold/outlier case.)
         restClient = RestClient.builder(host)
             .setRequestConfigCallback(
-                rc -> rc.setConnectTimeout(10000).setSocketTimeout(120000))
+                rc -> rc.setConnectTimeout(10000).setSocketTimeout(240000))
             .build();
         final OpenSearchTransport transport = new RestClientTransport(restClient,
             new JacksonJsonpMapper());

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -571,6 +571,38 @@ public class Shepherd {
         return annot;
     }
 
+    // Batch-load annotations by id in as few queries as possible (chunked IN), instead of one
+    // getAnnotation()/getObjectById() per id. The match pipeline can produce hundreds of
+    // prospects/candidates; a round-trip each was O(N) and dominated match time (tens of seconds
+    // to minutes). Returned order is NOT the input order -- callers needing the kNN score order
+    // should re-map by id.
+    public List<Annotation> getAnnotations(Collection<String> uuids) {
+        List<Annotation> out = new ArrayList<Annotation>();
+        if ((uuids == null) || uuids.isEmpty()) return out;
+        LinkedHashSet<String> ids = new LinkedHashSet<String>();
+        for (String u : uuids) {
+            if ((u != null) && (u.trim().length() > 0)) ids.add(u.trim());
+        }
+        if (ids.isEmpty()) return out;
+        List<String> all = new ArrayList<String>(ids);
+        final int CHUNK = 1000;
+        for (int i = 0; i < all.size(); i += CHUNK) {
+            List<String> sub = all.subList(i, Math.min(i + CHUNK, all.size()));
+            Query q = pm.newQuery(Annotation.class, ":ids.contains(id)");
+            try {
+                @SuppressWarnings("unchecked")
+                Collection<Annotation> res = (Collection<Annotation>) q.execute(sub);
+                out.addAll(new ArrayList<Annotation>(res));
+            } catch (Exception ex) {
+                System.out.println("getAnnotations(batch) chunk failed: " + ex);
+                ex.printStackTrace();
+            } finally {
+                q.closeAll();
+            }
+        }
+        return out;
+    }
+
     public MediaAsset getMediaAsset(String num) {
         MediaAsset tempMA = null;
 


### PR DESCRIPTION
## Problem
Vector (MiewID) matching was slow-to-empty for large candidate sets. `Annotation.getMatches()` and `getMatchingSet()` looped over OpenSearch hits doing **one `myShepherd.getAnnotation()` DB round-trip per hit**. A match returning 500–900 prospects took **23–118s** (measured live), frequently tripping the socket timeout and surfacing as an **empty '0 matches'** result. The kNN itself is ~29ms — the per-prospect DB fanout was the entire cost. (`MatchResult`'s vector path notes it doesn't cap prospects because 'vector search tends to return relatively few' — an assumption that breaks at 34k-candidate scale.)

## Fix
- **`Shepherd.getAnnotations(Collection<String>)`** — batch-load by id via a chunked JDOQL `:ids.contains(id)` IN query (one query instead of N round-trips; same pattern already used in `EncounterExport`).
- **`Annotation.getMatches()`** — cap to the **top-N hits by score** (N = `MatchResult.MAXIMUM_PROSPECTS_STORED` = 500, since nothing downstream stores more) and **batch-load** them, preserving kNN score order via a `LinkedHashMap`. The candidate-pool count still comes separately from `queryCount`.
- **`Annotation.getMatchingSet()`** — batch-load the candidate pool (no cap; it's the full pool for WBIA matchers).
- **Socket timeout 120s → 240s** — a cold/large match must degrade to *slow*, never to a silent empty result. A failed match reads to a user as 'no match found', which is worse than a slow one.

Net: large matches go from ~2 min (→ empty on timeout) to a few seconds, returning the same top matches.

## Review
Codex-reviewed — no Critical/Major. Verified: JDOQL matches an existing DataNucleus pattern, order/score mapping correct, managed objects fine, cap safe for callers.

**Known bounded follow-up:** `MatchResult._populateProspectsByIndividual` still does a per-prospect `findEncounter` (now capped at ≤500). Batch that next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)