### PR TITLE
Give the annotation knn_vector an explicit Lucene HNSW method (fix exact-kNN timeout)

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -205,6 +205,23 @@ public class Annotation extends Base implements java.io.Serializable {
         embVect.put("type", "knn_vector");
         embVect.put("dimension", Embedding.getVectorDimension());
         embVect.put("space_type", "cosinesimil");
+        // Explicit HNSW method. Do NOT rely on the engine default: OpenSearch 3.x removed nmslib
+        // (the old implicit default), so a methodless knn_vector silently degrades to exact/flat
+        // brute-force kNN -- which scales with candidate count and times out over large matching
+        // sets (surfacing as an empty match result). Lucene engine (over faiss) for this scale:
+        // supports cosinesimil, HNSW lives in the Lucene segment (no native memory, no _knn/warmup,
+        // so no cold-start graph load), and filters well at ~260k vectors. space_type stays
+        // top-level (do not also put it in method). NOTE: adding/changing this method on an
+        // existing index requires a full reindex -- the ANN graph is built into segments at index
+        // time and cannot be added in place.
+        JSONObject knnMethod = new JSONObject();
+        knnMethod.put("name", "hnsw");
+        knnMethod.put("engine", "lucene");
+        JSONObject knnParams = new JSONObject();
+        knnParams.put("m", 24);
+        knnParams.put("ef_construction", 200);
+        knnMethod.put("parameters", knnParams);
+        embVect.put("method", knnMethod);
         embProps.put("vector", embVect);
         embMap.put("properties", embProps);
         map.put("embeddings", embMap);


### PR DESCRIPTION
## Root cause (confirmed on the upgraded Sharkbook cluster)
`Annotation.opensearchMapping()` created `embeddings.vector` as a `knn_vector` with **no ANN `method`** — it relied on the old implicit **nmslib HNSW** default. **OpenSearch 3.x removed nmslib**, so a methodless `knn_vector` now resolves to a **flat/exact** vector mapper. kNN became **brute-force**, scaling with candidate count:
- Large matching sets (~30k candidates) exceed the 240s socket timeout → swallowed → **empty '0 matches'** result.
- Small sets return in seconds; first-slow/second-fast was just page cache, not a real ANN graph.

Live mapping confirmed: `{type: knn_vector, dimension: 2152, space_type: cosinesimil}`, **no `method`**.

This is why #1660 (batch-load) and #1661 (warmup) helped their targets but couldn't fix matching — there was no ANN index at all.

## Fix
Add an explicit HNSW `method`. **Lucene engine** (over faiss) for this scale (~260k vectors, 2152-dim, single node): supports `cosinesimil`, HNSW lives in the Lucene segment (no native memory, **no `_knn/warmup` and no cold-start graph load**), and filters well. `space_type` stays top-level (not duplicated inside `method`). Params `m: 24, ef_construction: 200`.

Codex-reviewed (engine choice + exact mapping shape + reindex requirement).

## Deploy requires a one-time reindex
The ANN graph is built into segments at index time — a methodless→HNSW field change **cannot** be applied in place. After deploying this WAR, delete + recreate + reindex the `annotation` index (foreground, via `opensearchSync.jsp`). No force-merge/resharding needed — Lucene builds the graph during normal indexing.

## Deferred follow-up
The candidate filter is a root-level bool sibling of the nested `knn` (a *post-filter*, can return <k). Restoring efficient filtered-ANN means denormalizing filter keys into the nested docs — the dedicated-embeddings-index redesign. Out of scope here; adding the HNSW method restores the pre-upgrade behavior, which is the 100× win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)