### PR TITLE
PIE/WBIA target set: fetch ids only (_source:false) — fix large-set match timeout

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -1131,6 +1131,13 @@ public class Annotation extends Base implements java.io.Serializable {
         long startTime = System.currentTimeMillis();
 
         if (query == null) return anns;
+        // This path uses ONLY hit._id and hit._score (the Annotations themselves are loaded from
+        // the DB below), so returning _source is pure waste. Fetching full _source for up to
+        // pageSize (10k) candidate docs cost ~20ms/doc, and for large matching sets (e.g. a 34k
+        // whaleshark location) that blew past the OpenSearch socket timeout -> empty target set ->
+        // WBIA rejects "Empty target annotation list" -> the PIE/WBIA match failed with a generic
+        // "Unknown error". Return ids/scores only so the query is fast regardless of set size.
+        query.put("_source", false);
         JSONObject queryRes = null;
         int hitSize = -1;
         try {


### PR DESCRIPTION
## Problem
PIE v2 (WBIA/IBEISIA) matching **failed with a generic "Unknown error"** on large candidate sets. Traced to a stack trace:
```
java.net.SocketTimeoutException: 240,000 milliseconds timeout
  at OpenSearch.queryPit → Annotation.getMatchingSet(1159) → IBEISIA.beginIdentifyAnnotations(900)
```
`getMatchingSet()` builds the WBIA target-annotation set with a PIT query fetching up to 10,000 candidate docs, whose body requests **full `_source`** (all fields except embeddings) — but the method only reads `hit._id` + `hit._score` and loads the real `Annotation` objects **from Postgres**. The `_source` retrieval (~20 ms/doc) is pure waste and, for large sets, exceeds the 240 s socket timeout → **empty target set → WBIA rejects `Empty target annotation list` → task fails → `scanEndApplet.jsp` NPE → UI "Unknown error."**

Confirmed by scale (deterministic, not cold-cache): Eastern US Coast (64) and Tofo (6.5k, ~150 s) succeeded; **North Ningaloo (34k) timed out every time.**

## Fix
Set `_source: false` on the target-set query so it returns only ids/scores — completes in seconds regardless of set size. Local to `getMatchingSet` (`getMatchingSetQuery` returns a fresh object per call), so the MiewID/vector `getMatchQuery` path is untouched.

## Review
Codex-reviewed — **no findings**. Verified all callers (IAQueryCache, IBEISIA ×2, IAGateway) use the DB-loaded `Annotation` objects, not OS `_source`; `_score` survives `_source:false`; MiewID path unaffected; no NPE risk.

**Pre-existing follow-up (out of scope):** `getMatchingSet` still returns only the first `max_result_window` (10k) page, so a >10k target pool is truncated. Separate from this timeout fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)