### PR TITLE
FEAT: add svg loading spinner after submit button is clicked

### DIFF
--- a/src/main/webapp/submit.jsp
+++ b/src/main/webapp/submit.jsp
@@ -577,6 +577,12 @@ $('#social_files_iframe').on('load', function(ev) {
 
 //this is a simple wrapper to this, as it is called from 2 places (so far)
 function submitForm() {
+	var btn = document.getElementById('submitEncounterButton');
+	if (btn) {
+		btn.disabled = true;
+		btn.style.cursor = 'not-allowed';
+		btn.insertAdjacentHTML('afterbegin', '<svg fill="#fff" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><style>.spinner_P7sC{transform-origin:center;animation:spinner_svv2 .75s infinite linear}@keyframes spinner_svv2{100%{transform:rotate(360deg)}}</style><path d="M10.14,1.16a11,11,0,0,0-9,8.92A1.59,1.59,0,0,0,2.46,12,1.52,1.52,0,0,0,4.11,10.7a8,8,0,0,1,6.66-6.61A1.42,1.42,0,0,0,12,2.69h0A1.57,1.57,0,0,0,10.14,1.16Z" class="spinner_P7sC"/></svg>');
+	}
 	document.forms['encounterForm'].submit();
 }
 


### PR DESCRIPTION
A spinner to the jsp page once the button is clicked. 
Java routes to a new page after cliicking so no need for re-enable on error. 
the user gets routed to a new page on error/success.

React page already has a bootstrap spinner setup so no work needed there.

Closes #1616 


## Scrots
<img width="954" height="809" alt="image" src="https://github.com/user-attachments/assets/effcea01-7217-40c4-b7ca-350e4515db52" />
<img width="385" height="165" alt="image" src="https://github.com/user-attachments/assets/efd3a1fa-dfd6-4263-94d5-684eb7e5f22a" />
<img width="604" height="351" alt="image" src="https://github.com/user-attachments/assets/896f8296-4b27-45d5-b530-05e4ed0a88ed" />
<img width="945" height="510" alt="image" src="https://github.com/user-attachments/assets/dbb64ad3-9b9d-4810-a6b3-2f79f62a2d92" />

