### PR TITLE
catchUpEmbeddings: only backfill embeddings for match candidates (matchAgainst=true)

### DIFF
--- a/src/main/java/org/ecocean/Embedding.java
+++ b/src/main/java/org/ecocean/Embedding.java
@@ -209,6 +209,9 @@ public class Embedding implements java.io.Serializable {
     // only match candidates (matchAgainst=true) need embeddings backfilled --
     // they are the target set of every vector match. query-side annotations get
     // embeddings extracted on the fly by findMatchProspects() when they match.
+    // an annotation flipped to matchAgainst=true after the cursor passed its id
+    // is picked up on the next full pass: an exhausted sweep clears _lastId
+    // (JSONObject.put(key, null) removes the key), so the following run restarts.
     static String catchUpEmbeddingsSql(String startId, int batchSize) {
         String sql =
             "select \"ANNOTATION\".\"ID\" as \"ID\" from \"ANNOTATION\" left join \"EMBEDDING\" on (\"ANNOTATION\".\"ID\" = \"ANNOTATION_ID\") where \"VECTORFLOATARRAY\" is null and \"MATCHAGAINST\" = true";

--- a/src/main/java/org/ecocean/Embedding.java
+++ b/src/main/java/org/ecocean/Embedding.java
@@ -205,6 +205,18 @@ public class Embedding implements java.io.Serializable {
         return Arrays.equals(this.vectorFloatArray, emb.vectorFloatArray);
     }
 
+    // builds the batch query for catchUpEmbeddings(); package-visible for testing.
+    // only match candidates (matchAgainst=true) need embeddings backfilled --
+    // they are the target set of every vector match. query-side annotations get
+    // embeddings extracted on the fly by findMatchProspects() when they match.
+    static String catchUpEmbeddingsSql(String startId, int batchSize) {
+        String sql =
+            "select \"ANNOTATION\".\"ID\" as \"ID\" from \"ANNOTATION\" left join \"EMBEDDING\" on (\"ANNOTATION\".\"ID\" = \"ANNOTATION_ID\") where \"VECTORFLOATARRAY\" is null and \"MATCHAGAINST\" = true";
+        if (Util.isUUID(startId)) sql += " AND \"ANNOTATION\".\"ID\" > '" + startId + "'";
+        sql += " order by \"ANNOTATION\".\"ID\" limit " + batchSize;
+        return sql;
+    }
+
     // returns final annot id
     public static JSONObject catchUpEmbeddings(Shepherd myShepherd, String startId, int batchSize) {
         if (batchSize < 1) batchSize = BACKGROUND_BATCH_SIZE;
@@ -217,10 +229,7 @@ public class Embedding implements java.io.Serializable {
         System.out.println("catchUpEmbeddings: beginning at " + startId + "; batch size=" +
             batchSize);
 
-        String sql =
-            "select \"ANNOTATION\".\"ID\" as \"ID\" from \"ANNOTATION\" left join \"EMBEDDING\" on (\"ANNOTATION\".\"ID\" = \"ANNOTATION_ID\") where \"VECTORFLOATARRAY\" is null";
-        if (Util.isUUID(startId)) sql += " AND \"ANNOTATION\".\"ID\" > '" + startId + "'";
-        sql += " order by \"ANNOTATION\".\"ID\" limit " + batchSize;
+        String sql = catchUpEmbeddingsSql(startId, batchSize);
         Query q = myShepherd.getPM().newQuery("javax.jdo.query.SQL", sql);
         q.setClass(Annotation.class);
         Collection c = (Collection)q.execute();

--- a/src/main/java/org/ecocean/ia/MLService.java
+++ b/src/main/java/org/ecocean/ia/MLService.java
@@ -421,7 +421,17 @@ public class MLService {
             throw new IAException("MLService.createPayload() no MediaAsset for ann=" + ann);
         JSONObject payload = new JSONObject(config.toString());
         payload.remove("api_endpoint");
-        payload.put("image_uri", ma.webURL());
+        // historic assets can carry absolute paths from a previous install; webURL()
+        // then throws IllegalArgumentException("Path not under given root") from
+        // LocalAssetStore.checkPath(). convert to IAException so callers that batch
+        // over annotations (e.g. Embedding.catchUpEmbeddings()) skip the bad asset
+        // instead of aborting the whole sweep.
+        try {
+            payload.put("image_uri", ma.webURL());
+        } catch (IllegalArgumentException ex) {
+            throw new IAException("MLService.createPayload() cannot resolve image for ann=" +
+                    ann + ": " + ex);
+        }
         payload.put("bbox", ann.getBbox());
         payload.put("theta", ann.getTheta());
         return payload;

--- a/src/main/webapp/appadmin/catchUpEmbeddings.jsp
+++ b/src/main/webapp/appadmin/catchUpEmbeddings.jsp
@@ -38,7 +38,11 @@ myShepherd.beginDBTransaction();
 try {
     // see Embedding.catchUpEmbeddings() for details on what this does
     JSONObject res = Embedding.catchUpEmbeddings(myShepherd, null, batchSize);
-    myShepherd.commitDBTransaction();
+    // commitDBTransaction() swallows commit failures; use the status variant
+    // so a failed commit reports an error instead of success json
+    if (!myShepherd.commitDBTransactionWithStatus()) {
+        throw new RuntimeException("commit failed; see logs");
+    }
 
     JSONObject show = new JSONObject();
     show.put("_batchSize", batchSize);
@@ -47,7 +51,7 @@ try {
     show.put("_runIds", res.get("_runIds"));
     out.println(show.toString(4));
 } catch (Exception ex) {
-    myShepherd.rollbackDBTransaction();
+    if (myShepherd.isDBTransactionActive()) myShepherd.rollbackDBTransaction();
     ex.printStackTrace();
     response.setStatus(500);
     out.println(new JSONObject().put("error", ex.toString()).toString(4));

--- a/src/main/webapp/appadmin/catchUpEmbeddings.jsp
+++ b/src/main/webapp/appadmin/catchUpEmbeddings.jsp
@@ -11,22 +11,47 @@ java.io.File, java.io.FileNotFoundException, org.ecocean.*" %>
 <%
 
 String context = ServletUtilities.getContext(request);
+
+// batchSize url param sets how many annotations to sweep this run (default 100)
+int batchSize = 100;
+String batchParam = request.getParameter("batchSize");
+if (batchParam != null) {
+    try {
+        batchSize = Integer.parseInt(batchParam.trim());
+    } catch (NumberFormatException nfe) {
+        response.setStatus(400);
+        out.println(new JSONObject().put("error",
+            "invalid batchSize parameter: " + batchParam).toString(4));
+        return;
+    }
+    if (batchSize < 1) {
+        response.setStatus(400);
+        out.println(new JSONObject().put("error",
+            "batchSize must be a positive integer; got: " + batchParam).toString(4));
+        return;
+    }
+}
+
 Shepherd myShepherd = new Shepherd(context);
+myShepherd.setAction("appadmin.catchUpEmbeddings");
 myShepherd.beginDBTransaction();
+try {
+    // see Embedding.catchUpEmbeddings() for details on what this does
+    JSONObject res = Embedding.catchUpEmbeddings(myShepherd, null, batchSize);
+    myShepherd.commitDBTransaction();
 
-// integer arg below is how big a batch to run; adjust if desired
-// see Embedding.catchUpEmbeddings() for details on what this does
-JSONObject res = Embedding.catchUpEmbeddings(myShepherd, null, 100);
-
-JSONObject show = new JSONObject();
-show.put("_runCount", res.get("_runCount"));
-show.put("_runOk", res.get("_runOk"));
-show.put("_runIds", res.get("_runIds"));
-
-out.println(show.toString(4));
-
-
-myShepherd.commitDBTransaction();
+    JSONObject show = new JSONObject();
+    show.put("_batchSize", batchSize);
+    show.put("_runCount", res.get("_runCount"));
+    show.put("_runOk", res.get("_runOk"));
+    show.put("_runIds", res.get("_runIds"));
+    out.println(show.toString(4));
+} catch (Exception ex) {
+    myShepherd.rollbackDBTransaction();
+    ex.printStackTrace();
+    response.setStatus(500);
+    out.println(new JSONObject().put("error", ex.toString()).toString(4));
+} finally {
+    myShepherd.closeDBTransaction();
+}
 %>
-
-

--- a/src/test/java/org/ecocean/EmbeddingTest.java
+++ b/src/test/java/org/ecocean/EmbeddingTest.java
@@ -89,4 +89,29 @@ class EmbeddingTest {
         assertTrue(task.statusInEndState());
         assertNotNull(task.getCompletionDateInMilliseconds());
     }
+
+    // catchUpEmbeddings backfill must only target match candidates
+    // (matchAgainst=true); non-candidates never appear in a matching set and
+    // query-side annots get embeddings on the fly via findMatchProspects().
+
+    @Test void catchUpEmbeddingsSql_filtersToMatchAgainst() {
+        String sql = Embedding.catchUpEmbeddingsSql(null, 50);
+        assertTrue(sql.contains("\"MATCHAGAINST\" = true"));
+        assertTrue(sql.contains("\"VECTORFLOATARRAY\" is null"));
+        assertTrue(sql.endsWith("limit 50"));
+        // no cursor clause without a startId
+        assertFalse(sql.contains("\"ANNOTATION\".\"ID\" > "));
+    }
+
+    @Test void catchUpEmbeddingsSql_includesCursorForValidUUID() {
+        String startId = "00000000-0000-0000-0000-000000000000";
+        String sql = Embedding.catchUpEmbeddingsSql(startId, 100);
+        assertTrue(sql.contains("\"ANNOTATION\".\"ID\" > '" + startId + "'"));
+        assertTrue(sql.contains("\"MATCHAGAINST\" = true"));
+    }
+
+    @Test void catchUpEmbeddingsSql_ignoresNonUUIDStartId() {
+        String sql = Embedding.catchUpEmbeddingsSql("not-a-uuid'; drop table", 50);
+        assertFalse(sql.contains("not-a-uuid"));
+    }
 }

--- a/src/test/java/org/ecocean/EmbeddingTest.java
+++ b/src/test/java/org/ecocean/EmbeddingTest.java
@@ -94,24 +94,26 @@ class EmbeddingTest {
     // (matchAgainst=true); non-candidates never appear in a matching set and
     // query-side annots get embeddings on the fly via findMatchProspects().
 
+    static final String CATCHUP_SQL_BASE =
+        "select \"ANNOTATION\".\"ID\" as \"ID\" from \"ANNOTATION\" left join \"EMBEDDING\" on (\"ANNOTATION\".\"ID\" = \"ANNOTATION_ID\") where \"VECTORFLOATARRAY\" is null and \"MATCHAGAINST\" = true";
+
     @Test void catchUpEmbeddingsSql_filtersToMatchAgainst() {
-        String sql = Embedding.catchUpEmbeddingsSql(null, 50);
-        assertTrue(sql.contains("\"MATCHAGAINST\" = true"));
-        assertTrue(sql.contains("\"VECTORFLOATARRAY\" is null"));
-        assertTrue(sql.endsWith("limit 50"));
-        // no cursor clause without a startId
-        assertFalse(sql.contains("\"ANNOTATION\".\"ID\" > "));
+        // exact query shape: join, null-vector filter, matchAgainst filter,
+        // ordering, limit -- and no cursor clause without a startId
+        assertEquals(CATCHUP_SQL_BASE + " order by \"ANNOTATION\".\"ID\" limit 50",
+            Embedding.catchUpEmbeddingsSql(null, 50));
     }
 
     @Test void catchUpEmbeddingsSql_includesCursorForValidUUID() {
         String startId = "00000000-0000-0000-0000-000000000000";
-        String sql = Embedding.catchUpEmbeddingsSql(startId, 100);
-        assertTrue(sql.contains("\"ANNOTATION\".\"ID\" > '" + startId + "'"));
-        assertTrue(sql.contains("\"MATCHAGAINST\" = true"));
+        assertEquals(CATCHUP_SQL_BASE + " AND \"ANNOTATION\".\"ID\" > '" + startId +
+            "' order by \"ANNOTATION\".\"ID\" limit 100",
+            Embedding.catchUpEmbeddingsSql(startId, 100));
     }
 
     @Test void catchUpEmbeddingsSql_ignoresNonUUIDStartId() {
-        String sql = Embedding.catchUpEmbeddingsSql("not-a-uuid'; drop table", 50);
-        assertFalse(sql.contains("not-a-uuid"));
+        // non-UUID startId must not reach the SQL (injection guard + cursor reset)
+        assertEquals(CATCHUP_SQL_BASE + " order by \"ANNOTATION\".\"ID\" limit 50",
+            Embedding.catchUpEmbeddingsSql("not-a-uuid'; drop table", 50));
     }
 }

--- a/src/test/java/org/ecocean/ia/MLServiceCreatePayloadTest.java
+++ b/src/test/java/org/ecocean/ia/MLServiceCreatePayloadTest.java
@@ -1,0 +1,62 @@
+package org.ecocean.ia;
+
+import java.nio.file.Paths;
+
+import org.ecocean.Annotation;
+import org.ecocean.media.Feature;
+import org.ecocean.media.FeatureType;
+import org.ecocean.media.LocalAssetStore;
+import org.ecocean.media.MediaAsset;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MLServiceCreatePayloadTest {
+    static Annotation annotationWithPath(String assetPath) {
+        LocalAssetStore store = new LocalAssetStore("test-store",
+            Paths.get("/usr/local/tomcat/webapps/wildbook_data_dir"),
+            "http://localhost/wildbook_data_dir", false);
+        // construct with a valid path, then swap in the target path afterward: the
+        // constructor itself resolves the path (store.hashCode()), so a stale
+        // absolute path can only exist on assets hydrated from the database --
+        // which is exactly the state this mimics.
+        MediaAsset ma = new MediaAsset(store, new JSONObject().put("path", "placeholder.jpg"));
+        ma.setParameters(new JSONObject().put("path", assetPath));
+        JSONObject fparams = new JSONObject().put("x", 0).put("y", 0).put("width", 10).put("height",
+            10).put("theta", 0.0d);
+        Feature ft = new Feature(new FeatureType("org.ecocean.boundingBox"), fparams);
+
+        ma.addFeature(ft);
+        return new Annotation("Testus testus", ft, "test");
+    }
+
+    // historic installs stored absolute asset paths; after a server move they fall
+    // outside the current store root and webURL() throws IllegalArgumentException
+    // ("Path not under given root") from LocalAssetStore.checkPath(). createPayload()
+    // must convert that to IAException so batch callers (Embedding.catchUpEmbeddings)
+    // record and skip the annotation instead of aborting the whole sweep.
+    @Test void createPayloadStaleAbsolutePathThrowsIAException() {
+        Annotation ann = annotationWithPath(
+            "/var/lib/tomcat7/webapps/wildbook_data_dir/8/9/some-uuid/frame00484.jpg");
+        MLService mls = new MLService();
+        JSONObject conf = new JSONObject().put("api_endpoint", "http://ml.example.com").put(
+            "model_id", "test-v1");
+        IAException ex = assertThrows(IAException.class, () -> mls.createPayload(ann, conf));
+
+        assertTrue(ex.getMessage().contains("cannot resolve image"),
+            "message should explain the unresolvable image: " + ex.getMessage());
+    }
+
+    @Test void createPayloadRelativePathBuildsPayload() throws IAException {
+        Annotation ann = annotationWithPath("8/9/some-uuid/frame00484.jpg");
+        MLService mls = new MLService();
+        JSONObject conf = new JSONObject().put("api_endpoint", "http://ml.example.com").put(
+            "model_id", "test-v1");
+        JSONObject payload = mls.createPayload(ann, conf);
+
+        assertEquals("http://localhost/wildbook_data_dir/8/9/some-uuid/frame00484.jpg",
+            payload.get("image_uri").toString());
+        assertFalse(payload.has("api_endpoint"), "api_endpoint must be stripped from payload");
+        assertEquals("test-v1", payload.getString("model_id"));
+    }
+}


### PR DESCRIPTION
## What

`Embedding.catchUpEmbeddings()` (the background/appadmin embedding backfill) now only targets annotations with **`matchAgainst=true`**. Previously it swept *every* annotation lacking an embedding.

## Why

- **Non-candidates never need embeddings.** `matchAgainst=false` annotations (trivial/unity crops, etc.) never appear in a vector matching set — see the same design choice in the OpenSearch indexer (skip non-candidate annotation index). Backfilling their vectors burns ml-service GPU calls on data nothing will ever query.
- **The query side is already covered.** When any annotation *initiates* a match, `Embedding.findMatchProspects()` extracts embeddings on the fly if none exist — so catch-up skipping non-candidates loses nothing.
- **Scale.** On large installs a big fraction of annotations are non-candidates; the sweep gets proportionally cheaper and finishes the real work sooner.

## How

- Extracted the batch SQL into a package-visible `catchUpEmbeddingsSql(startId, batchSize)` and added `and "MATCHAGAINST" = true` to the `WHERE` (same column idiom as `Annotation.getAllVersionsSql`).
- Cursor semantics (`_lastId` resumption in the `EMBEDDING_CATCHUP` SystemValue) are unchanged — the cursor is by annotation ID, so a filtered set just yields sparser batches.

## Known trade-off (verified in review)

An annotation flipped to `matchAgainst=true` *after* the cursor has passed its ID isn't revisited until the sweep wraps around — which it does automatically: an exhausted (empty) batch clears `_lastId` (`JSONObject.put(key, null)` removes the key), so the next run restarts from the beginning and picks up interim flips. The only at-risk group is legacy no-embedding annotations flipped true *between* sweep passes. Modern-pipeline annotations are unaffected: `MlServiceProcessor` persists an embedding for every detected annotation with no matchAgainst gate.

**Possible follow-up (out of scope here):** extract embeddings at the flip call sites (`AnnotationSetMatchAgainst`, `Encounter.useAnnotationsForMatching()`) so a flipped legacy annotation becomes matchable immediately rather than after the next sweep pass.

## Also: `appadmin/catchUpEmbeddings.jsp` hardening

- Proper Shepherd lifecycle: `try { commit } catch { rollback-if-active, 500 json } finally { close }`. Commit now uses `commitDBTransactionWithStatus()` — the void `commitDBTransaction()` swallows `JDOUserException`, so a failed commit used to return success JSON.
- New `?batchSize=N` url parameter (default 100; 400 on unparseable or < 1); the effective batch size is echoed back as `_batchSize` in the response.

## Also: don't let one stale-path asset wedge the sweep (found in production)

Running the sweep in production hit `IllegalArgumentException: Path not under given root` — a historic media asset with an absolute path from a previous install (`/var/lib/tomcat7/...`) thrown by `LocalAssetStore.checkPath()` via `MediaAsset.webURL()`. Being unchecked, it escaped the loop's `catch (IAException)`, aborted the whole batch, **and** skipped the `_lastId` cursor update — so every subsequent run re-hit the same annotation and the sweep was permanently wedged.

Fix (per Codex round 5): convert the `IllegalArgumentException` to `IAException` at the source, in `MLService.createPayload(Annotation, …)` around `ma.webURL()`, so the existing catch arm records the failure in `embData` and continues. This is deliberately narrower than catching `RuntimeException` in the loop, which could swallow a vector-parse failure *after* `new Embedding(ann, …)` has already linked a bad embedding to the annotation. Skipped annotations are retried on the next wraparound pass, so repairing the asset path later makes them embeddable again.

## Tests

3 new unit tests in `EmbeddingTest` assert the exact SQL (join, null-vector + matchAgainst filters, cursor-only-for-valid-UUID, ordering, limit). `mvn test -Dtest=EmbeddingTest`: 9/9 pass. New `MLServiceCreatePayloadTest` covers the stale-path → `IAException` conversion and the happy-path payload shape (`image_uri` from webRoot, `api_endpoint` stripped): 2/2 pass.

Codex adversarial review: 6 rounds. Round 1 found a Major (flip-to-true starvation; verified real-but-bounded, documented above) and a Minor (loose test assertions; fixed). Round 2: converged on the Java change. Round 3 (JSP) found a Major (swallowed commit failure → fixed with `commitDBTransactionWithStatus`) and a Minor (unguarded rollback; fixed). Round 4: converged. Round 5 (stale-path fix) found a Major (loop-level `catch (RuntimeException)` too broad — could commit a null-vector embedding linked before a parse failure; fixed by moving the conversion into `createPayload`). Round 6: **converged, no findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
