### PR TITLE
Close scan-result Shepherds in finally to stop DB connection leak

### DIFF
--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -106,8 +106,15 @@ public class Shepherd {
 
     // handy with a newActiveShepherd
     public void rollbackAndClose() {
-        rollbackDBTransaction();
-        closeDBTransaction();
+        // closeDBTransaction() MUST run even if rollbackDBTransaction() throws. Otherwise a rollback
+        // that fails (e.g. on an already-broken connection) skips the close, leaking the
+        // PersistenceManager/DB connection and leaving a stale ShepherdState entry -- exactly the
+        // "rollback-failed" rows seen accumulating on dbconnections.jsp until the pool exhausts.
+        try {
+            rollbackDBTransaction();
+        } finally {
+            closeDBTransaction();
+        }
     }
 
     public String getContext() {

--- a/src/main/webapp/encounters/scanEndApplet.jsp
+++ b/src/main/webapp/encounters/scanEndApplet.jsp
@@ -35,6 +35,9 @@ File encountersDir=new File(shepherdDataDir.getAbsolutePath()+"/encounters");
 	Shepherd myShepherd=new Shepherd(context);
 	myShepherd.setAction("scanEndApplet.jsp");
 	myShepherd.beginDBTransaction();
+	// try/finally guarantees the Shepherd is closed even if the body throws; otherwise the
+	// PersistenceManager/DB connection leaks (see dbconnections.jsp pool exhaustion).
+	try {
 	if(myShepherd.isEncounter(ServletUtilities.preventCrossSiteScriptingAttacks(request.getParameter("number")))){
   		num = ServletUtilities.preventCrossSiteScriptingAttacks(request.getParameter("number"));
 	}
@@ -62,8 +65,9 @@ File encountersDir=new File(shepherdDataDir.getAbsolutePath()+"/encounters");
 			}
 		}
 	}
-	myShepherd.rollbackDBTransaction();
-	myShepherd.closeDBTransaction();
+	} finally {
+		myShepherd.rollbackAndClose();
+	}
   }
   String encSubdir = Encounter.subdir(num);
 
@@ -606,6 +610,11 @@ function fitRightImage() {
           indShepherd.setAction("scanEndApplet.jsp_displayNames");
           indShepherd.beginDBTransaction();
           java.util.HashMap<String, String> displayNameCache = new java.util.HashMap<>();
+          // try/finally guarantees indShepherd is closed even if the rendering block below throws
+          // (XML parse, substring, Double parse, dom4j iteration). Without it, a throw here leaks
+          // the PersistenceManager/DB connection -- the dominant source of pool exhaustion under
+          // heavy scan-result rendering (see dbconnections.jsp).
+          try {
 
           if (!xmlOK) {
 
@@ -784,8 +793,9 @@ class="tr-location-<%=(locationIDs.contains(enc1.attributeValue("locationID")) ?
 
 
   <%
-          indShepherd.rollbackDBTransaction();
-          indShepherd.closeDBTransaction();
+          } finally {
+              indShepherd.rollbackAndClose();
+          }
 
 
 


### PR DESCRIPTION
## Problem

On Sharkbook (heavy synchronous Groth/I3S scan traffic), `dbconnections.jsp` showed ~250 open Shepherds — most stuck at `rollback-failed` — dominated (100+) by the `scanEndApplet.jsp_displayNames` action. Since `Shepherd.closeDBTransaction()` removes the entry from `ShepherdState`, every row in that table is a Shepherd that was **never closed**: a leaked `PersistenceManager`/DB connection. With `datanucleus.connectionPool.maxPoolSize=300` and `maxWait=-1`, once the pool approaches the cap new work blocks **indefinitely**, wedging the app and cascading `rollback-failed` across unrelated actions (indexing included).

## Root cause

`scanEndApplet.jsp` opened two Shepherds and closed them only on the normal path, with **no `try/finally`**:

- the scan-status lookup near the top of the page, and
- the `scanEndApplet.jsp_displayNames` result renderer, whose body parses XML (`SAXReader.read`), calls `String.substring` on possibly-short strings, parses `Double`s, and iterates dom4j nodes — all throw-prone.

Any exception skipped the close and leaked the connection. The I3S twin `i3sScanEndApplet.jsp` already guards its equivalent Shepherds with `try/finally`, which is why its entries were rare in the snapshot while `scanEndApplet.jsp` flooded it.

## Fix

1. Wrap both Shepherds in `scanEndApplet.jsp` in `try { … } finally { rollbackAndClose(); }`, matching the already-correct I3S page. (Body not reindented, to keep the diff reviewable.)
2. Harden `Shepherd.rollbackAndClose()` so `closeDBTransaction()` runs even if `rollbackDBTransaction()` throws — so a failed rollback can no longer strand an open connection *anywhere* the method is used (defense in depth; also explains the persistent `rollback-failed` rows).

## Scope / risk

- Read-only rendering paths; no behavior change on the success path.
- Diagnosis was independently confirmed by an adversarial Codex review (leak = Critical; the `rollbackAndClose` hardening was its suggested follow-up).

## Not included (follow-ups)

- Changing `maxWait=-1` to a finite value so pool exhaustion fails fast instead of hanging — a cross-installation tuning decision, left separate.
- A separate, still-open investigation into continuous `opensearchIndexDeep` (a save-driven storm), which this leak aggravates but does not cause.

## Testing

Structurally verified (brace/scope balance; `doc`/`root`/`matches` remain declared outside the wrapped block). Needs a deploy smoke-test of a scan-results page render on a dev Wildbook before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)