### PR TITLE
Close MediaAsset background/URL Shepherds in finally to stop connection leaks

### DIFF
--- a/src/main/java/org/ecocean/media/MediaAsset.java
+++ b/src/main/java/org/ecocean/media/MediaAsset.java
@@ -733,10 +733,14 @@ public class MediaAsset extends Base implements java.io.Serializable {
         Shepherd myShepherd = new Shepherd(context);
         myShepherd.setAction("MediaAsset.safeURL");
         myShepherd.beginDBTransaction();
-        URL u = safeURL(myShepherd, request);
-        myShepherd.rollbackDBTransaction();
-        myShepherd.closeDBTransaction();
-        return u;
+        // try/finally so a throw from safeURL(myShepherd, request) -- e.g. a JDO lazy-load/query
+        // failure inside bestSafeAsset() -- cannot skip the close and leak the PersistenceManager.
+        // Those leaks are the "MediaAsset.safeURL:begin" Shepherds stuck on dbconnections.jsp.
+        try {
+            return safeURL(myShepherd, request);
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
     }
 
     public URL safeURL() {
@@ -1191,6 +1195,10 @@ public class MediaAsset extends Base implements java.io.Serializable {
                 Shepherd myShepherd = new Shepherd(context);
                 myShepherd.setAction("updateStandardChildrenBackground:" + tid);
                 myShepherd.beginDBTransaction();
+                // try/finally so a throw from load/updateStandardChildren cannot skip the close and
+                // leak this background Shepherd. commit stays inside try; the finally rollback is a
+                // harmless no-op once the commit has succeeded.
+                try {
                 int ct = 0;
                 for (Integer id : ids) {
                     ct++;
@@ -1202,7 +1210,9 @@ public class MediaAsset extends Base implements java.io.Serializable {
                         "] completed " + kids.size() + " children for id=" + id);
                 }
                 myShepherd.commitDBTransaction();
-                myShepherd.closeDBTransaction();
+                } finally {
+                    myShepherd.rollbackAndClose();
+                }
             }
         };
         new Thread(rn).start();

--- a/src/main/java/org/ecocean/media/YouTubeAssetStore.java
+++ b/src/main/java/org/ecocean/media/YouTubeAssetStore.java
@@ -367,6 +367,10 @@ public class YouTubeAssetStore extends AssetStore {
             public void run() {
                 myShepherd.setAction("YouTubeAssetStore.backgroundGrabAndParse");
                 myShepherd.beginDBTransaction();
+                // try/finally so a throw from load/save/metadata cannot skip the close and leak this
+                // background Shepherd. commit stays inside try; the finally rollback is a harmless
+                // no-op once the commit has succeeded.
+                try {
                 MediaAsset ma = MediaAssetFactory.load(otherMa.getIdInt(), myShepherd);
                 System.out.println("about to grab!");
                 boolean ok = false;
@@ -379,7 +383,9 @@ public class YouTubeAssetStore extends AssetStore {
                     null) ? "(null metadata)" : ma.getMetadata().getDataAsString()));
                 MediaAssetFactory.save(ma, myShepherd);
                 myShepherd.commitDBTransaction();
-                myShepherd.closeDBTransaction();
+                } finally {
+                    myShepherd.rollbackAndClose();
+                }
             }
         };
         new Thread(rn).start();


### PR DESCRIPTION
## Problem

After the scan-page leak fix ([#1667](https://github.com/WildMeOrg/Wildbook/pull/1667)) quieted Sharkbook, a stable group of `MediaAsset.safeURL_*` Shepherds remained stuck at `:begin` on `dbconnections.jsp` and never cleared. Since `Shepherd.closeDBTransaction()` removes the entry from `ShepherdState`, a persistent entry = a Shepherd that was never closed. The `:begin` state (vs `rollback-failed`) means the throw happened *before* the rollback call — a leaked-on-throw PersistenceManager.

## Root cause

`MediaAsset.safeURL(HttpServletRequest)` had the same defect class as `scanEndApplet.jsp`:

```java
myShepherd.beginDBTransaction();
URL u = safeURL(myShepherd, request);   // throws -> next two lines skipped
myShepherd.rollbackDBTransaction();
myShepherd.closeDBTransaction();
```

No `try/finally`. The inner `safeURL()` → `bestSafeAsset()` path does DB/JDO work (parent load, child lookup, lazy fields), and any throw there (missing parent, lazy-load failure, bad asset params) leaks the connection. `safeURL()` runs on ordinary media serialization (`toJSONObject`, etc.), so leaks accumulate over time and eventually pressure the pool.

## Fix

Wrap the body in `try { … } finally { rollbackAndClose(); }`, mirroring the already-correct `sanitizeJson()`. An adversarial Codex review confirmed the diagnosis and surfaced two sibling background workers with the same missing-`finally` shape, swept in here:

- `MediaAsset.safeURL(HttpServletRequest)` — the reported leak
- `MediaAsset.updateStandardChildrenBackground()` — commit-in-`try`, cleanup-in-`finally`
- `YouTubeAssetStore.backgroundGrabAndParse()` — same

For the background workers that commit, the commit stays inside the `try`; the `finally` rollback is a harmless no-op after a successful commit.

## Pairs with #1667

These call `rollbackAndClose()`, which #1667 hardens so `close` runs even if `rollback` throws. Together they fully close the leaked-on-throw case. This PR's primary fix (guaranteeing the `finally` is reached) stands on its own; the hardening covers the rarer "rollback itself throws" residual.

## Leaked vs. hung

Codex confirmed the `webURL` path does no blocking network I/O — only URL-object construction — so a transaction held across a slow remote call is not the mechanism here. Combined with the observed group being **stable and non-growing**, this is leaked-on-throw, which `try/finally` fully addresses. (If the group were ever seen *growing*, that would indicate a hung-DB variant needing a different fix.)

## Testing

Structurally verified (brace/scope balance across all three edits, including the nested `try/catch` in the YouTube worker). Needs a deploy smoke-test: exercise media serialization / a `safeURL`-invoking path and confirm no `MediaAsset.safeURL:begin` accumulates on `dbconnections.jsp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)