### PR TITLE
Fix bulk import index ordering after media derivatives

### DIFF
--- a/src/main/java/org/ecocean/api/bulk/BulkImporter.java
+++ b/src/main/java/org/ecocean/api/bulk/BulkImporter.java
@@ -171,8 +171,11 @@ public class BulkImporter {
             "------------ persistence complete; background indexing and MA children -------------\n");
         // clears shepherd/pmf cache, which we seem to do when we create encounters (?)
         myShepherd.cacheEvictAll();
-        BulkImportUtil.bulkOpensearchIndex(needIndexing);
-        MediaAsset.updateStandardChildrenBackground(myShepherd.getContext(), maIds);
+        MediaAsset.updateStandardChildrenBackground(myShepherd.getContext(), maIds, new Runnable() {
+            public void run() {
+                BulkImportUtil.bulkOpensearchIndex(needIndexing);
+            }
+        });
         logProgress("end createImport()");
         return rtn;
     }

--- a/src/main/java/org/ecocean/media/MediaAsset.java
+++ b/src/main/java/org/ecocean/media/MediaAsset.java
@@ -1186,7 +1186,20 @@ public class MediaAsset extends Base implements java.io.Serializable {
  */
     public static void updateStandardChildrenBackground(final String context,
         final List<Integer> ids) {
-        if ((ids == null) || (ids.size() < 1)) return;
+        updateStandardChildrenBackground(context, ids, null);
+    }
+
+    /**
+     * Creates standard child assets in the background, then runs {@code afterCommit} only after
+     * the child assets have been committed. Callers that index a parent object from its child URLs
+     * can use the callback to avoid indexing before a _master child is visible.
+     */
+    public static void updateStandardChildrenBackground(final String context,
+        final List<Integer> ids, final Runnable afterCommit) {
+        if ((ids == null) || (ids.size() < 1)) {
+            if (afterCommit != null) afterCommit.run();
+            return;
+        }
         final String tid = Util.generateUUID().substring(0, 8);
         System.out.println("updateStandardChildrenBackground() [" + tid + "] forking for " +
             ids.size() + " MediaAsset ids >>>>");
@@ -1199,17 +1212,25 @@ public class MediaAsset extends Base implements java.io.Serializable {
                 // leak this background Shepherd. commit stays inside try; the finally rollback is a
                 // harmless no-op once the commit has succeeded.
                 try {
-                int ct = 0;
-                for (Integer id : ids) {
-                    ct++;
-                    MediaAsset ma = MediaAssetFactory.load(id, myShepherd);
-                    if (ma == null) continue;
-                    ma.setSkipAutoIndexing(true);
-                    ArrayList<MediaAsset> kids = ma.updateStandardChildren(myShepherd);
-                    System.out.println("+ [" + ct + "] updateStandardChildrenBackground() [" + tid +
-                        "] completed " + kids.size() + " children for id=" + id);
-                }
-                myShepherd.commitDBTransaction();
+                    int ct = 0;
+                    for (Integer id : ids) {
+                        ct++;
+                        try {
+                            MediaAsset ma = MediaAssetFactory.load(id, myShepherd);
+                            if (ma == null) continue;
+                            ma.setSkipAutoIndexing(true);
+                            ArrayList<MediaAsset> kids = ma.updateStandardChildren(myShepherd);
+                            System.out.println("+ [" + ct + "] updateStandardChildrenBackground() [" +
+                                tid + "] completed " + kids.size() + " children for id=" + id);
+                        } catch (Exception ex) {
+                            System.out.println("updateStandardChildrenBackground() [" + tid +
+                                "] failed for id=" + id + ": " + ex);
+                            ex.printStackTrace();
+                        }
+                    }
+                    if (myShepherd.commitDBTransactionWithStatus() && (afterCommit != null)) {
+                        afterCommit.run();
+                    }
                 } finally {
                     myShepherd.rollbackAndClose();
                 }


### PR DESCRIPTION
## Summary

Fixes #1590 — during bulk import, encounter documents were written to the OpenSearch `encounter` index **before** their `_master` derivative MediaAsset existed, so `safeURL(..., "master")` returned null and the documents were indexed with no `mediaAssets[].url`, rendering as broken thumbnails on `/react/encounter-search`. There was no guaranteed re-index after derivative generation, so ~34% of encounters in one observed import stayed permanently URL-less.

This implements proposed fix (2) from the issue: **order import indexing after derivative generation.**

## Changes

- `MediaAsset.updateStandardChildrenBackground()` gains an overload with an `afterCommit` callback that runs **only after the child assets have been durably committed** (via the new-ish `commitDBTransactionWithStatus()`). The empty-ids path still runs the callback, so media-less imports still index.
- `BulkImporter.createImport()` now passes `BulkImportUtil.bulkOpensearchIndex(needIndexing)` as that callback instead of firing it in parallel with derivative generation — so the first encounter index pass already sees the `_master` child and serializes the URL.
- Derivative generation is now per-asset fault-tolerant: one corrupt/failed asset is logged and skipped instead of aborting (and rolling back) children for the entire batch.

## Notes / trade-offs

- Encounters from an import are indexed once **all** derivatives finish. For large imports the periodic reconciler (`Base.opensearchSyncIndex`) may index committed encounters mid-generation (temporarily URL-less); the callback's unconditional reindex then backfills them. Net behavior is "guaranteed eventually correct" vs. main's "sometimes permanently broken."
- If the derivative commit fails, indexing is skipped rather than writing URL-less docs; the reconciler treats missing docs as `needIndexing`, so encounters still appear.
- Already-affected data needs no repair — re-indexing the affected encounters backfills the URLs (see #1590 workaround).
- Two pre-existing adjacent bugs found during review were filed separately: #1671 (single-id `updateStandardChildrenBackground` overload is a no-op) and #1672 (`bulkOpensearchIndex` leaks an ExecutorService).

## Credits

- **Lead / implementation:** OpenAI Codex
- **QA review:** Claude (Fable 5) — full review posted in comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)