### PR TITLE
Fix no-op single-id updateStandardChildrenBackground overload

### DIFF
--- a/src/main/java/org/ecocean/media/MediaAsset.java
+++ b/src/main/java/org/ecocean/media/MediaAsset.java
@@ -1233,7 +1233,8 @@ public class MediaAsset extends Base implements java.io.Serializable {
 
     // convenience, XXX  BUT see not above about sending multiple ids when possible!  XXX
     public static void updateStandardChildrenBackground(final String context, int id) {
-        updateStandardChildrenBackground(context, new ArrayList<Integer>(id));
+        // note: new ArrayList<Integer>(id) here would be the *capacity* constructor (empty list)
+        updateStandardChildrenBackground(context, Collections.singletonList(id));
     }
 
     public void updateStandardChildrenBackground(String context) { // convenience


### PR DESCRIPTION
## Summary

Fixes #1671 — the single-id convenience overload of `MediaAsset.updateStandardChildrenBackground` called `new ArrayList<Integer>(id)`, which is the **capacity** constructor: it produces an *empty* list with initial capacity `id`. The list-based overload then hit its empty-list guard and returned immediately, so this overload (and the instance convenience method `updateStandardChildrenBackground(String context)` that funnels into it) has always been a silent no-op — no `_master`/`_mid`/`_thumb`/`_watermark` children were ever generated through this path.

## Change

Pass `Collections.singletonList(id)` instead. The receiving overload only checks `size()` and iterates the list (never mutates it), so an immutable singleton list is safe.

## Behavior note

Callers of the previously-dead overloads will now actually generate derivatives in the background — that is the intended behavior per the method's contract (the asset must already be persisted, as documented on the list-based overload). No in-tree callers currently use these overloads; this fixes the public-API footgun.

Verified: `mvn compile` passes; LF endings preserved.

## Credits

- **Lead / implementation:** Claude (Fable 5)
- **Review:** OpenAI Codex (`gpt-5.6-terra`) — verdict posted in comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)