### PR TITLE
Shut down bulkOpensearchIndex executor after its single task

### DIFF
--- a/src/main/java/org/ecocean/api/bulk/BulkImportUtil.java
+++ b/src/main/java/org/ecocean/api/bulk/BulkImportUtil.java
@@ -273,6 +273,9 @@ public class BulkImportUtil {
             }
         };
         executor.execute(rn);
+        // let the submitted task finish, then terminate the worker thread;
+        // without this every call leaks an idle non-daemon thread for the JVM lifetime
+        executor.shutdown();
     }
 
     public static String bulkImportArchiveFilepath(String id, String suffix) {


### PR DESCRIPTION
## Summary

Fixes #1672 — `BulkImportUtil.bulkOpensearchIndex()` created a new `Executors.newFixedThreadPool(numThreads)` on every call, submitted exactly one `Runnable`, and never shut the pool down. Fixed-pool core threads never time out, so the lazily created non-daemon worker thread survived for the life of the JVM — one leaked idle thread per bulk import (and per `Encounter.afterPatch`), polluting thread dumps and delaying Tomcat shutdown.

## Change

Call `executor.shutdown()` immediately after `executor.execute(rn)`. Shutdown rejects *future* submissions but lets the already-accepted indexing task run to completion without interruption; the worker thread then terminates. Callers (`BulkImporter.createImport`, `Encounter.afterPatch`) don't depend on task completion before return, so behavior is unchanged apart from the leak.

Reviewer note: with exactly one task, `new Thread(rn).start()` would be simpler still (and would make the `indexingNumAllowedThreads` config read irrelevant rather than merely ineffective) — kept the minimal targeted fix here; happy to switch if maintainers prefer.

Verified: `mvn compile` passes; LF endings preserved.

## Credits

- **Lead / implementation:** Claude (Fable 5)
- **Review:** OpenAI Codex (`gpt-5.6-terra`) — verdict posted in comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)