### PR TITLE
Vector-match throughput: batch prospect loads, stateless match search, configurable IA concurrency

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -1162,8 +1162,7 @@ public class Annotation extends Base implements java.io.Serializable {
             try {
                 pageSize = os.getSettings("annotation").optInt("max_result_window", 10000);
             } catch (Exception ex) {}
-            os.deletePit("annotation");
-            queryRes = os.queryPit("annotation", query, 0, pageSize, null, null);
+            queryRes = os.querySearch("annotation", query, 0, pageSize);
             hitSize = queryRes.optJSONObject("hits").optJSONObject("total").optInt("value");
         } catch (Exception ex) {
             System.out.println("getMatchingSet() exception: " + ex);
@@ -1297,8 +1296,7 @@ public class Annotation extends Base implements java.io.Serializable {
             try {
                 pageSize = os.getSettings("annotation").optInt("max_result_window", 10000);
             } catch (Exception ex) {}
-            os.deletePit("annotation");
-            queryRes = os.queryPit("annotation", matchQuery, 0, pageSize, null, null);
+            queryRes = os.querySearch("annotation", matchQuery, 0, pageSize);
             hitSize = queryRes.optJSONObject("hits").optJSONObject("total").optInt("value");
         } catch (Exception ex) {
             System.out.println("getMatches() exception: " + ex);

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -49,10 +49,16 @@ import java.util.concurrent.TimeUnit;
 // https://github.com/opensearch-project/opensearch-java/blob/main/USER_GUIDE.md
 
 public class OpenSearch {
-    public static OpenSearchClient client = null;
-    public static RestClient restClient = null;
+    public static volatile OpenSearchClient client = null;
+    public static volatile RestClient restClient = null;
     public static Map<String, Boolean> INDEX_EXISTS_CACHE = new HashMap<String, Boolean>();
-    public static Map<String, String> PIT_CACHE = new HashMap<String, String>();
+    // ConcurrentHashMap: PIT_CACHE is read/mutated from concurrent request threads (SearchApi,
+    // EncounterQueryProcessor, MediaResolveApi) and, once IA match consumers can run concurrently,
+    // from those too. This only removes the structural-corruption hazard of an unsynchronized
+    // HashMap; it does NOT make the shared one-PIT-per-index lifecycle request-safe (a deletePit on
+    // one caller can still drop another's snapshot; queryPit's retry self-heals it). Match read
+    // paths avoid PIT entirely via querySearch(); proper per-request PIT scoping is a separate change.
+    public static Map<String, String> PIT_CACHE = new java.util.concurrent.ConcurrentHashMap<String, String>();
     public static String SEARCH_SCROLL_TIME = (String)getConfigurationValue("searchScrollTime",
         "10m");
     public static String SEARCH_PIT_TIME = (String)getConfigurationValue("searchPitTime", "10m");
@@ -102,7 +108,18 @@ public class OpenSearch {
     private int pitRetry = 0;
 
     public OpenSearch() {
+        // Double-checked, synchronized one-time init: concurrent first-callers (e.g. parallel match
+        // consumers hitting cold init) must not each build and overwrite the shared static client.
+        // client/restClient are volatile; initializeClient sets restClient before client, so any
+        // thread that observes client != null also observes a fully-built restClient.
         if (client != null) return;
+        synchronized (OpenSearch.class) {
+            if (client != null) return;
+            initializeClientOnce();
+        }
+    }
+
+    private static void initializeClientOnce() {
         // System.setProperty("javax.net.ssl.trustStore", "/full/path/to/keystore");
         // System.setProperty("javax.net.ssl.trustStorePassword", "password-to-keystore");
 
@@ -166,6 +183,20 @@ public class OpenSearch {
             new JacksonJsonpMapper());
 
         client = new OpenSearchClient(transport);
+    }
+
+    // Stateless single-page search (no PIT, no shared static state) -- safe under concurrency.
+    // Used by the match read paths (getMatches / getMatchingSet), which fetch one page (from=0) and
+    // never paginate across pages. track_total_hits=true keeps hits.total.value exact so callers
+    // that read it (e.g. getMatchingSet hitSize) are unaffected.
+    public JSONObject querySearch(String indexName, final JSONObject query, int from, int size)
+    throws IOException {
+        if (!isValidIndexName(indexName)) throw new IOException("invalid index name: " + indexName);
+        Request searchRequest = new Request("POST", indexName + "/_search?track_total_hits=true");
+        query.put("from", from);
+        query.put("size", size);
+        searchRequest.setJsonEntity(query.toString());
+        return new JSONObject(getRestResponse(searchRequest));
     }
 
     public static boolean isValidIndexName(String indexName) {

--- a/src/main/java/org/ecocean/StartupWildbook.java
+++ b/src/main/java/org/ecocean/StartupWildbook.java
@@ -176,6 +176,10 @@ public class StartupWildbook implements ServletContextListener {
             return;
         }
         Setting.initialize(context);
+        // Eagerly build the shared OpenSearch REST client BEFORE any consumer threads start, so no
+        // match thread ever hits the (now double-checked, synchronized) cold init concurrently.
+        // Constructing the client does not contact OpenSearch, so this is safe here.
+        new OpenSearch();
         // initialize the plugin (instances)
         IAPluginManager.initPlugins(context);
         // this should be handling all plugin startups
@@ -355,10 +359,22 @@ public class StartupWildbook implements ServletContextListener {
             return;
         }
         IAMessageHandler qh = new IAMessageHandler();
+        // Concurrent IA match-consumer threads, applied to the IA queue ONLY (detection stays serial)
+        // so the aggregate stays <= N+1. The queue's consume(handler,int) is the authoritative gate:
+        // it probes the filesystem and clamps to 1 (serial) if atomic moves are unsupported, so a
+        // misconfigured value can never start unsafe concurrent consumers.
+        int iaWorkers = 1;
+        String cfg = CommonConfiguration.getProperty("iaMatchConsumerThreads", context);
+        if ((cfg != null) && (cfg.trim().length() > 0)) {
+            try { iaWorkers = Integer.parseInt(cfg.trim()); } catch (NumberFormatException nfe) {
+                System.out.println("+ WARNING: iaMatchConsumerThreads not an int ('" + cfg +
+                    "'); using 1");
+            }
+        }
         try {
-            queue.consume(qh);
+            queue.consume(qh, iaWorkers);
             System.out.println("+ StartupWildbook.startIAQueues() queue.consume() started on " +
-                queue.toString());
+                queue.toString() + " (requested " + iaWorkers + " worker(s))");
         } catch (IOException iox) {
             System.out.println("+ StartupWildbook.startIAQueues() queue.consume() FAILED on " +
                 queue.toString() + ": " + iox.toString());

--- a/src/main/java/org/ecocean/ia/MatchResult.java
+++ b/src/main/java/org/ecocean/ia/MatchResult.java
@@ -315,8 +315,20 @@ public class MatchResult implements java.io.Serializable {
             new HashMap<String, List<Annotation> >();
         List<Annotation> singletons = new ArrayList<Annotation>();
 
+        // Batch-load all parent encounters up front (was: one findEncounter JDOQL per prospect).
+        // No Shepherd -> no DB access possible; degrade to no indiv grouping (the annot-scored
+        // prospects are populated separately and do not need it), matching the prior findEncounter
+        // behavior when no encounter could be resolved.
+        List<String> annIds = new ArrayList<String>();
         for (Annotation ann : annots) {
-            Encounter enc = ann.findEncounter(myShepherd);
+            if ((ann != null) && (ann.getId() != null)) annIds.add(ann.getId());
+        }
+        Map<String, Encounter> encByAnnId = (myShepherd == null)
+            ? java.util.Collections.<String, Encounter>emptyMap()
+            : myShepherd.getEncountersByAnnotationIds(annIds);
+
+        for (Annotation ann : annots) {
+            Encounter enc = (ann == null) ? null : encByAnnId.get(ann.getId());
             // No encounter at all: skip (no individual axis possible).
             if (enc == null) continue;
             MarkedIndividual indiv = enc.getIndividual();

--- a/src/main/java/org/ecocean/queue/FileQueue.java
+++ b/src/main/java/org/ecocean/queue/FileQueue.java
@@ -19,6 +19,43 @@ public class FileQueue extends Queue {
     private static String TYPE_NAME = "File";
     private static File queueBaseDir = null;
     private File queueDir = null;
+    // True only when more than one consumer thread runs on this queue: concurrent claims MUST be
+    // atomic to avoid double-processing. With a single (serial) consumer we keep the original
+    // non-atomic rename claim, which works on every filesystem (the concurrency gate would otherwise
+    // stall consumption on a filesystem that does not support atomic moves).
+    private volatile boolean requireAtomicClaim = false;
+    // Guards against a second consume() starting extra worker threads (double the claimers) or
+    // resetting requireAtomicClaim while earlier workers are still live. Two levels: `consuming`
+    // stops a repeat call on the SAME instance; CONSUMING_DIRS stops a SECOND FileQueue instance
+    // (getBest() makes a new one per call) from consuming the SAME directory concurrently. Released
+    // only in QueueUtil.cleanup(), after all consumer executors are confirmed terminated, so an
+    // in-place redeploy can consume again without ever overlapping a live consumer.
+    private static final java.util.Set<String> CONSUMING_DIRS =
+        java.util.concurrent.ConcurrentHashMap.newKeySet();
+    private boolean consuming = false;
+    private String consumingKey = null;
+
+    private synchronized boolean markConsuming() {
+        if (consuming) {
+            System.out.println("WARNING: " + this.toString() +
+                " consume() already started; ignoring repeat call");
+            return false;
+        }
+        String key;
+        try {
+            key = (queueDir == null) ? null : queueDir.getCanonicalPath();
+        } catch (IOException ex) {
+            key = queueDir.getAbsolutePath();
+        }
+        if ((key != null) && !CONSUMING_DIRS.add(key)) {
+            System.out.println("WARNING: " + this.toString() +
+                " another consumer is already running on " + key + "; ignoring");
+            return false;
+        }
+        consumingKey = key;
+        consuming = true;
+        return true;
+    }
 
     public static boolean isAvailable(String context) {
         return true; 
@@ -75,8 +112,89 @@ public class FileQueue extends Queue {
 
     public void consume(final QueueMessageHandler msgHandler)
     throws IOException {
+        if (!markConsuming()) return;
         this.messageHandler = msgHandler;
         QueueUtil.background(this);
+    }
+
+    // Authoritative concurrency gate: this is the ONLY place worker count is enforced, so no caller
+    // (StartupWildbook or otherwise) can start N>1 consumers unsafely. If the queue filesystem does
+    // not support atomic moves, the effective count is clamped to 1 (serial, non-atomic claim). Only
+    // when the effective count is >1 do we require atomic claims in getNext().
+    public void consume(final QueueMessageHandler msgHandler, int workers)
+    throws IOException {
+        if (!markConsuming()) return;
+        this.messageHandler = msgHandler;
+        boolean atomicOk = supportsAtomicMove(queueDir);
+        int eff = QueueUtil.effectiveWorkers(workers, atomicOk);
+        if (eff < workers) {
+            String why = atomicOk ? "exceeds max (8)"
+                : "queue filesystem does not support atomic moves";
+            System.out.println("WARNING: " + this.toString() + " requested " + workers +
+                " consumer(s) but " + why + "; running " + eff);
+        }
+        this.requireAtomicClaim = (eff > 1);
+        QueueUtil.backgroundWithWorkers(this, eff);
+    }
+
+    public File getQueueDir() {
+        return queueDir;
+    }
+
+    // Probe whether the given directory's filesystem supports atomic file moves. Concurrent
+    // consumers rely on ATOMIC_MOVE to claim a queue file exactly once; on a filesystem that does
+    // not support it (some NFS/overlay/NTFS mounts) callers must fall back to a single consumer.
+    public static boolean supportsAtomicMove(File dir) {
+        if ((dir == null) || !dir.isDirectory()) return false;
+        File a = new File(dir, ".atomicmove-probe-" + Thread.currentThread().getId());
+        File b = new File(dir, ".atomicmove-probe-" + Thread.currentThread().getId() + ".moved");
+        try {
+            Files.write(a.toPath(), "probe".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            Files.move(a.toPath(), b.toPath(), java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+            return true;
+        } catch (java.nio.file.AtomicMoveNotSupportedException ex) {
+            return false;
+        } catch (Exception ex) {
+            System.out.println("FileQueue.supportsAtomicMove() probe failed on " + dir + ": " + ex);
+            return false;
+        } finally {
+            a.delete();
+            b.delete();
+        }
+    }
+
+    // Claim src -> dst, returning true on success. Uses an ATOMIC_MOVE when concurrent consumers run
+    // (requireAtomicClaim), so exactly one worker can win; otherwise (single serial consumer) uses
+    // the original destination-exists check + renameTo, which works on every filesystem. A pre-check
+    // on the destination preserves the original "skip if the target already exists" behavior (e.g. a
+    // stale .active/.complete from a crashed run) that a bare ATOMIC_MOVE would otherwise overwrite.
+    private boolean moveClaim(File src, File dst) {
+        if (dst.exists()) {
+            System.out.println("WARNING: " + this.toString() + " wanted to create " +
+                dst.toString() + " but it exists; skipping");
+            return false;
+        }
+        if (!requireAtomicClaim) {
+            if (!src.renameTo(dst)) {
+                System.out.println("WARNING: " + this.toString() + " wanted to create " +
+                    dst.toString() + " but rename failed; skipping");
+                return false;
+            }
+            return true;
+        }
+        try {
+            Files.move(src.toPath(), dst.toPath(), java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+            return true;
+        } catch (java.nio.file.FileAlreadyExistsException ex) {
+            return false; // another worker already claimed it
+        } catch (java.nio.file.NoSuchFileException ex) {
+            return false; // another worker moved the source out from under us
+        } catch (IOException ex) {
+            // includes AtomicMoveNotSupportedException; fail closed (never a non-atomic fallback here)
+            System.out.println("WARNING: " + this.toString() + " atomic claim failed for " + src +
+                ": " + ex);
+            return false;
+        }
     }
 
     public String getNext()
@@ -87,14 +205,9 @@ public class FileQueue extends Queue {
         if (nextFile == null) return null; // wait and try again...
 
         File activeFile = new File(nextFile.toString() + ".active");
-        if (activeFile.exists()) {
-            System.out.println("WARNING: " + this.toString() + " wanted to create " +
-                activeFile.toString() + " but it exists; skipping");
-            return null;
-        }
-        if (!nextFile.renameTo(activeFile)) {
-            System.out.println("WARNING: " + this.toString() + " wanted to create " +
-                activeFile.toString() + " but rename failed; skipping");
+        // Claim the file. With concurrent consumers this is an atomic move so only one worker wins;
+        // with a single serial consumer it is the original rename. The loser/skip returns null.
+        if (!moveClaim(nextFile, activeFile)) {
             return null;
         }
         System.out.println("INFO: " + this.toString() + " successfully engaged file " +
@@ -110,14 +223,9 @@ public class FileQueue extends Queue {
                     ": " + ex.toString());
         }
         File completedFile = new File(nextFile.toString() + ".complete");
-        if (completedFile.exists()) {
-            System.out.println("WARNING: " + this.toString() + " wanted to create " +
-                completedFile.toString() + " but it exists; skipping");
-            return null;
-        }
-        if (!activeFile.renameTo(completedFile)) {
-            System.out.println("WARNING: " + this.toString() + " wanted to create " +
-                completedFile.toString() + " but rename failed; skipping");
+        if (!moveClaim(activeFile, completedFile)) {
+            System.out.println("WARNING: " + this.toString() + " could not mark " +
+                completedFile.toString() + " complete; skipping");
             return null;
         }
         if (this.isConsumerShutdownMessage(fcontents))
@@ -178,6 +286,17 @@ public class FileQueue extends Queue {
     }
 
     public void shutdown() {
+        // Intentionally does NOT release the consume guards: the worker threads are owned by
+        // QueueUtil's executors, and releasing here (without stopping them) would let a subsequent
+        // consume() start new workers / rewrite requireAtomicClaim while the old workers still run.
+        // The guards are cleared in QueueUtil.cleanup(), which stops AND awaits all executors first.
+    }
+
+    // Called by QueueUtil.cleanup() ONLY after all consumer executors are shut down and awaited, so
+    // no worker is live. Lets an in-place redeploy (contextDestroyed -> contextInitialized in the
+    // same JVM) consume these directories again.
+    static void releaseAllConsumeGuards() {
+        CONSUMING_DIRS.clear();
     }
 
     @Override public String toString() {

--- a/src/main/java/org/ecocean/queue/Queue.java
+++ b/src/main/java/org/ecocean/queue/Queue.java
@@ -21,6 +21,14 @@ public abstract class Queue {
     public abstract void consume(QueueMessageHandler msgHandler)
     throws java.io.IOException;
 
+    // Consume with a requested number of concurrent worker threads. Concrete default preserves the
+    // single-consumer behavior (ignores the count) so existing subclasses and any future ones keep
+    // working unchanged; FileQueue overrides this to honor the worker count.
+    public void consume(QueueMessageHandler msgHandler, int workers)
+    throws java.io.IOException {
+        consume(msgHandler);
+    }
+
     // this is "internal" and is mostly used for manually backgrounded needs (like FileQueue)
     // NOTE: when used, return of null means messageHandler will NOT be called!
     public abstract String getNext()

--- a/src/main/java/org/ecocean/queue/QueueUtil.java
+++ b/src/main/java/org/ecocean/queue/QueueUtil.java
@@ -21,11 +21,56 @@ public class QueueUtil {
         return new FileQueue(name);
     }
 
-    // helper method for backgrounding queue consumers who dont background themselves
-    public static void background(final Queue queue)
+    // Clamp a configured worker count to a safe effective value. Fails closed to 1 when the queue
+    // filesystem does not support atomic moves (see FileQueue.supportsAtomicMove), so a misconfigured
+    // deployment can never run multiple consumers that might double-claim a message.
+    public static int effectiveWorkers(int configured, boolean atomicMoveSupported) {
+        if (!atomicMoveSupported) return 1;
+        return Math.max(1, Math.min(configured, 8));
+    }
+
+    // helper method for backgrounding queue consumers who dont background themselves.
+    // Package-private ON PURPOSE (like backgroundWithWorkers): consumers must start via
+    // FileQueue.consume(...), which holds the single-start / atomic-move guards.
+    static void background(final Queue queue)
     throws IOException {
-        final ScheduledExecutorService schedExec = Executors.newScheduledThreadPool(2);
-        final ScheduledFuture schedFuture = schedExec.scheduleWithFixedDelay(new Runnable() {
+        backgroundWithWorkers(queue, 1);
+    }
+
+    // Background `workers` concurrent consumers for the queue. workers==1 reproduces the original
+    // single-consumer behavior exactly. Concurrent consumers are safe only when the queue's getNext()
+    // claims each message atomically (FileQueue uses ATOMIC_MOVE). Package-private ON PURPOSE: the
+    // atomic-move gate lives in FileQueue.consume(handler,int); no external caller may start N>1
+    // consumers without going through that gate.
+    static void backgroundWithWorkers(final Queue queue, int workers)
+    throws IOException {
+        final int n = Math.max(1, workers);
+        final ScheduledExecutorService schedExec = Executors.newScheduledThreadPool(n + 1);
+        for (int w = 0; w < n; w++) {
+            ScheduledFuture schedFuture = schedExec.scheduleWithFixedDelay(
+                newConsumerRunnable(queue, schedExec),
+                1, // initial delay
+                1, // period delay *after* execution finishes
+                TimeUnit.SECONDS);
+            runningSF.add(schedFuture);
+        }
+        runningSES.add(schedExec);
+
+        System.out.println("---- about to awaitTermination() (" + n + " worker(s)) ----");
+        try {
+            schedExec.awaitTermination(5000, TimeUnit.MILLISECONDS);
+        } catch (java.lang.InterruptedException ex) {
+            System.out.println("WARNING: queue interrupted! " + ex.toString());
+        }
+        System.out.println("==== schedExec.shutdown() called, apparently");
+    }
+
+    // One consumer poll loop. Each call returns a fresh Runnable with its own `count`, so multiple
+    // workers on the same queue do not share mutable state. Logic is unchanged from the original
+    // single-consumer implementation.
+    private static Runnable newConsumerRunnable(final Queue queue,
+        final ScheduledExecutorService schedExec) {
+        return new Runnable() {
             int count = 0;
             public void run() {
                 ++count;
@@ -58,41 +103,46 @@ public class QueueUtil {
                     schedExec.shutdown();
                 }
             }
-        }, 1, // initial delay
-            1, // period delay *after* execution finishes
-            TimeUnit.SECONDS);
-
-        runningSES.add(schedExec);
-        runningSF.add(schedFuture);
-
-        System.out.println("---- about to awaitTermination() ----");
-        try {
-            schedExec.awaitTermination(5000, TimeUnit.MILLISECONDS);
-        } catch (java.lang.InterruptedException ex) {
-            System.out.println("WARNING: queue interrupted! " + ex.toString());
-        }
-        System.out.println("==== schedExec.shutdown() called, apparently");
+        };
     }
 
     // mostly for ContextDestroyed in StartupWildbook..... i think?
     public static void cleanup() {
+        boolean allTerminated = true;
         for (ScheduledExecutorService ses : runningSES) {
             ses.shutdown();
             try {
-                if (ses.awaitTermination(20, TimeUnit.SECONDS)) {
+                // If it doesn't quiesce on shutdown(), force with shutdownNow(); only then is a
+                // still-running executor a real leak. (The prior logic was inverted: it forced only
+                // AFTER a clean termination and reported "did not terminate" when it actually had.)
+                if (!ses.awaitTermination(20, TimeUnit.SECONDS)) {
                     ses.shutdownNow();
-                    if (ses.awaitTermination(20, TimeUnit.SECONDS)) {
+                    if (!ses.awaitTermination(20, TimeUnit.SECONDS)) {
+                        allTerminated = false;
                         System.out.println(
                             "!!! QueueUtil.cleanup() -- ExecutorService did not terminate");
                     }
                 }
             } catch (InterruptedException ie) {
                 ses.shutdownNow();
+                allTerminated = false; // could not confirm termination
                 Thread.currentThread().interrupt();
             }
         }
         for (ScheduledFuture sf : runningSF) {
             sf.cancel(true);
+        }
+        if (allTerminated) {
+            // Every consumer executor is confirmed stopped (no worker is live), so it is safe to drop
+            // tracking and release the single-consumer directory guards; an in-place redeploy can
+            // then consume again. If a worker survived, we KEEP both the guards and the tracking so a
+            // redeploy cannot start a second consumer on a directory that still has a live consumer.
+            runningSES.clear();
+            runningSF.clear();
+            FileQueue.releaseAllConsumeGuards();
+        } else {
+            System.out.println("QueueUtil.cleanup() -- not all executors terminated; retaining " +
+                "consume guards and executor tracking to avoid a double consumer on redeploy");
         }
         System.out.println("QueueUtil.cleanup() finished.");
     }

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -610,6 +610,56 @@ public class Shepherd {
         return out;
     }
 
+    /**
+     * Batch reverse-lookup: annotation id -&gt; its (single) parent Encounter. Replaces per-annotation
+     * Encounter.findByAnnotation calls in hot paths (e.g. MatchResult prospect grouping), which did
+     * one JDOQL join per prospect. Runs one query per chunk of ids, mapping back by walking each
+     * returned encounter's annotations.
+     *
+     * Annotation ids with no parent encounter are omitted from the map. An annotation shared by
+     * more than one encounter is anomalous (Encounter.findByAnnotation warns and returns an
+     * arbitrary one too); the first encounter seen wins and a WARNING is logged. Query failures are
+     * NOT swallowed -- they propagate, matching the per-prospect findEncounter behavior this
+     * replaces (a partial map would silently drop prospects).
+     */
+    public Map<String, Encounter> getEncountersByAnnotationIds(Collection<String> annotationIds) {
+        Map<String, Encounter> out = new HashMap<String, Encounter>();
+        if ((annotationIds == null) || annotationIds.isEmpty()) return out;
+        LinkedHashSet<String> wanted = new LinkedHashSet<String>();
+        for (String a : annotationIds) {
+            if ((a != null) && (a.trim().length() > 0)) wanted.add(a.trim());
+        }
+        if (wanted.isEmpty()) return out;
+        List<String> all = new ArrayList<String>(wanted);
+        final int CHUNK = 1000;
+        for (int i = 0; i < all.size(); i += CHUNK) {
+            List<String> sub = all.subList(i, Math.min(i + CHUNK, all.size()));
+            Query q = pm.newQuery(Encounter.class, "annotations.contains(ann) && :ids.contains(ann.id)");
+            q.declareVariables("org.ecocean.Annotation ann");
+            try {
+                @SuppressWarnings("unchecked")
+                Collection<Encounter> res = (Collection<Encounter>) q.execute(sub);
+                for (Encounter enc : res) {
+                    if ((enc == null) || (enc.getAnnotations() == null)) continue;
+                    for (Annotation ann : enc.getAnnotations()) {
+                        if ((ann == null) || (ann.getId() == null)) continue;
+                        if (!wanted.contains(ann.getId())) continue;
+                        Encounter prev = out.put(ann.getId(), enc);
+                        if ((prev != null) && !prev.equals(enc)) {
+                            System.out.println("WARNING: Shepherd.getEncountersByAnnotationIds() " +
+                                "found more than one Encounter containing Annotation " +
+                                ann.getId() + "; keeping the first seen");
+                            out.put(ann.getId(), prev);
+                        }
+                    }
+                }
+            } finally {
+                q.closeAll();
+            }
+        }
+        return out;
+    }
+
     public MediaAsset getMediaAsset(String num) {
         MediaAsset tempMA = null;
 

--- a/src/main/resources/bundles/commonConfiguration.properties
+++ b/src/main/resources/bundles/commonConfiguration.properties
@@ -93,6 +93,14 @@ useModifiedGroth = false
 patternMatchingEndPointServletName = WriteOutScanTask
 patternMatchingResultsPage = encounters/scanEndApplet.jsp
 
+# Concurrent IA match-consumer threads on the IA queue. Default 1 (serial).
+# Applied to the IA queue only (detection stays serial) so the aggregate stays <= N+1.
+# Raising this increases match throughput but also concurrent load on OpenSearch,
+# the DB connection pool, and the ml-service. Requires a filesystem that supports atomic
+# file moves (validated at startup; clamped to 1 if not). Safe range 1-8; size against DB
+# pool free connections and OpenSearch page-cache headroom before raising.
+iaMatchConsumerThreads = 1
+
 
 #nicknames
 allowNicknames=true

--- a/src/test/java/org/ecocean/ia/MatchResultIndivProspectsTest.java
+++ b/src/test/java/org/ecocean/ia/MatchResultIndivProspectsTest.java
@@ -3,17 +3,22 @@ package org.ecocean.ia;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.ecocean.Annotation;
 import org.ecocean.Encounter;
 import org.ecocean.MarkedIndividual;
 import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -38,12 +43,42 @@ class MatchResultIndivProspectsTest {
 
     private static final double EPS = 1e-9;
 
+    // Per-test registry mirroring the DB: annotation id -> its parent Encounter. mockAnn populates
+    // it; newShepherd() stubs Shepherd.getEncountersByAnnotationIds(...) to read it (the batch seam
+    // that replaced the per-prospect Annotation.findEncounter).
+    private final Map<String, Encounter> encByAnnId = new HashMap<String, Encounter>();
+    private int annCounter = 0;
+
+    @BeforeEach void reset() {
+        encByAnnId.clear();
+        annCounter = 0;
+    }
+
+    // A Shepherd mock whose getEncountersByAnnotationIds reflects the per-test registry, exactly as
+    // the real batch loader would (returns only ids that have a parent encounter).
+    private Shepherd newShepherd() {
+        Shepherd s = mock(Shepherd.class);
+        lenient().when(s.getEncountersByAnnotationIds(any())).thenAnswer(inv -> {
+            Collection<String> ids = inv.getArgument(0);
+            Map<String, Encounter> out = new HashMap<String, Encounter>();
+            if (ids != null) {
+                for (String id : ids) {
+                    if (encByAnnId.containsKey(id)) out.put(id, encByAnnId.get(id));
+                }
+            }
+            return out;
+        });
+        return s;
+    }
+
     private Annotation mockAnn(double score, MarkedIndividual indiv, Shepherd shepherd) {
         Annotation a = mock(Annotation.class);
+        String id = "ann-" + (++annCounter);
+        lenient().when(a.getId()).thenReturn(id);
         lenient().when(a.getOpensearchScore()).thenReturn(score);
         Encounter enc = mock(Encounter.class);
         lenient().when(enc.getIndividual()).thenReturn(indiv);
-        lenient().when(a.findEncounter(shepherd)).thenReturn(enc);
+        encByAnnId.put(id, enc);
         return a;
     }
 
@@ -55,8 +90,10 @@ class MatchResultIndivProspectsTest {
 
     private Annotation mockAnnNoEncounter(double score, Shepherd shepherd) {
         Annotation a = mock(Annotation.class);
+        // A real id, but no registry entry -> the batch loader returns no encounter for it, so it is
+        // skipped in the indiv tab (same as the old findEncounter == null).
+        lenient().when(a.getId()).thenReturn("ann-" + (++annCounter));
         lenient().when(a.getOpensearchScore()).thenReturn(score);
-        lenient().when(a.findEncounter(shepherd)).thenReturn(null);
         return a;
     }
 
@@ -78,7 +115,7 @@ class MatchResultIndivProspectsTest {
 
     @Test void multiAnnIndividual_scoredByBestCosine()
     throws Exception {
-        Shepherd s = mock(Shepherd.class);
+        Shepherd s = newShepherd();
         MarkedIndividual indivA = mockIndiv("indiv-A");
 
         // Three candidate annotations belong to the same individual.
@@ -102,7 +139,7 @@ class MatchResultIndivProspectsTest {
 
     @Test void unIdentifiedAnnotation_emittedAsSingletonInIndivTab()
     throws Exception {
-        Shepherd s = mock(Shepherd.class);
+        Shepherd s = newShepherd();
         // No individual on this encounter.
         Annotation a1 = mockAnn(0.7, null, s);
 
@@ -119,7 +156,7 @@ class MatchResultIndivProspectsTest {
 
     @Test void mixedIdentifiedAndUnidentified_bothPresent()
     throws Exception {
-        Shepherd s = mock(Shepherd.class);
+        Shepherd s = newShepherd();
         MarkedIndividual indivA = mockIndiv("indiv-A");
         MarkedIndividual indivB = mockIndiv("indiv-B");
 
@@ -146,7 +183,7 @@ class MatchResultIndivProspectsTest {
 
     @Test void multipleUnidentified_allEmittedAsSeparateSingletons()
     throws Exception {
-        Shepherd s = mock(Shepherd.class);
+        Shepherd s = newShepherd();
         Annotation a1 = mockAnn(0.3, null, s);
         Annotation a2 = mockAnn(0.8, null, s);
         Annotation a3 = mockAnn(0.55, null, s);
@@ -167,7 +204,7 @@ class MatchResultIndivProspectsTest {
 
     @Test void indivAndAnnotTabs_useSameCosineScale()
     throws Exception {
-        Shepherd s = mock(Shepherd.class);
+        Shepherd s = newShepherd();
         MarkedIndividual indivA = mockIndiv("indiv-A");
         Annotation a1 = mockAnn(0.65, indivA, s);
         Annotation a2 = mockAnn(0.42, null, s);
@@ -193,7 +230,7 @@ class MatchResultIndivProspectsTest {
 
     @Test void annotationWithNoEncounter_skippedInIndivTab()
     throws Exception {
-        Shepherd s = mock(Shepherd.class);
+        Shepherd s = newShepherd();
         // a1: belongs to indivA — should emit a prospect.
         MarkedIndividual indivA = mockIndiv("indiv-A");
         Annotation a1 = mockAnn(0.5, indivA, s);
@@ -212,7 +249,7 @@ class MatchResultIndivProspectsTest {
 
     @Test void emptyCandidates_noIndivProspects()
     throws Exception {
-        Shepherd s = mock(Shepherd.class);
+        Shepherd s = newShepherd();
         Task task = mock(Task.class);
         when(task.countObjectAnnotations()).thenReturn(1);
         Annotation queryAnn = mock(Annotation.class);
@@ -238,7 +275,7 @@ class MatchResultIndivProspectsTest {
 
     @Test void multipleMarkedIndividualInstancesWithSameId_groupedAsOne()
     throws Exception {
-        Shepherd s = mock(Shepherd.class);
+        Shepherd s = newShepherd();
         // Two distinct MarkedIndividual objects, same id "shark-42".
         MarkedIndividual indivA1 = mock(MarkedIndividual.class);
         MarkedIndividual indivA2 = mock(MarkedIndividual.class);
@@ -263,7 +300,7 @@ class MatchResultIndivProspectsTest {
 
     @Test void markedIndividualWithNullId_treatedAsSingleton()
     throws Exception {
-        Shepherd s = mock(Shepherd.class);
+        Shepherd s = newShepherd();
         MarkedIndividual indivWithNullId = mock(MarkedIndividual.class);
         lenient().when(indivWithNullId.getId()).thenReturn(null);
         Annotation a1 = mockAnn(0.6, indivWithNullId, s);
@@ -280,7 +317,7 @@ class MatchResultIndivProspectsTest {
 
     @Test void allAnnotationsHaveNoEncounter_noProspectsEmitted()
     throws Exception {
-        Shepherd s = mock(Shepherd.class);
+        Shepherd s = newShepherd();
         Annotation a1 = mockAnnNoEncounter(0.5, s);
         Annotation a2 = mockAnnNoEncounter(0.7, s);
 

--- a/src/test/java/org/ecocean/queue/FileQueueSerialClaimTest.java
+++ b/src/test/java/org/ecocean/queue/FileQueueSerialClaimTest.java
@@ -1,0 +1,37 @@
+package org.ecocean.queue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for the single-consumer (serial) claim path. A single IA consumer must be able to
+ * claim and consume messages on ANY filesystem -- the concurrency gate clamps to one worker when
+ * atomic moves are unsupported, and that lone worker must still make progress (it uses the original
+ * non-atomic rename claim, not ATOMIC_MOVE). No containers required.
+ */
+public class FileQueueSerialClaimTest {
+    @Test void serialConsumerClaimsEveryMessage() throws Exception {
+        FileQueue.init("context0");
+        // Unique queue name -> isolated subdir under the (possibly shared) base dir.
+        FileQueue q = new FileQueue("test-serial-" + System.nanoTime());
+        // requireAtomicClaim defaults to false: this is the serial, non-atomic path.
+        q.publish("{\"msg\":\"a\"}");
+        q.publish("{\"msg\":\"b\"}");
+        q.publish("{\"msg\":\"c\"}");
+
+        Set<String> got = new HashSet<String>();
+        String m;
+        int guard = 0;
+        while (((m = q.getNext()) != null) && (guard++ < 100)) {
+            got.add(m);
+        }
+        assertEquals(3, got.size(), "serial consumer must claim all 3 messages on a normal filesystem");
+        assertTrue(got.contains("{\"msg\":\"a\"}"), "got message a");
+        assertTrue(got.contains("{\"msg\":\"b\"}"), "got message b");
+        assertTrue(got.contains("{\"msg\":\"c\"}"), "got message c");
+    }
+}

--- a/src/test/java/org/ecocean/queue/QueueGatingTest.java
+++ b/src/test/java/org/ecocean/queue/QueueGatingTest.java
@@ -1,0 +1,45 @@
+package org.ecocean.queue;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the Task C concurrency gate: {@link QueueUtil#effectiveWorkers} (the fail-closed
+ * clamp) and {@link FileQueue#supportsAtomicMove} (the deployment probe). No containers required.
+ */
+public class QueueGatingTest {
+    @Test void effectiveWorkersClampsAndFailsClosed() {
+        // atomic move supported -> clamp into [1,8]
+        assertEquals(4, QueueUtil.effectiveWorkers(4, true), "honors configured count when atomic");
+        assertEquals(8, QueueUtil.effectiveWorkers(99, true), "clamps to max 8");
+        assertEquals(1, QueueUtil.effectiveWorkers(0, true), "clamps to min 1");
+        assertEquals(1, QueueUtil.effectiveWorkers(-5, true), "negative clamps to 1");
+        // atomic move NOT supported -> always 1, regardless of the requested count (fail closed)
+        assertEquals(1, QueueUtil.effectiveWorkers(4, false), "fail closed to 1 when non-atomic");
+        assertEquals(1, QueueUtil.effectiveWorkers(8, false), "fail closed to 1 when non-atomic");
+    }
+
+    @Test void supportsAtomicMoveIsSafeForBadInput() {
+        assertFalse(FileQueue.supportsAtomicMove(null), "null dir -> false");
+        assertFalse(FileQueue.supportsAtomicMove(new File("/no/such/dir/here")), "missing dir -> false");
+    }
+
+    @Test void supportsAtomicMoveDetectsARealDir() throws Exception {
+        File tmp = Files.createTempDirectory("atomicmove-probe-test").toFile();
+        try {
+            // A normal local temp filesystem supports atomic moves; the probe must not throw and
+            // must clean up after itself (no probe files left behind).
+            boolean ok = FileQueue.supportsAtomicMove(tmp);
+            assertTrue(ok, "local temp dir should support atomic move");
+            File[] leftovers = tmp.listFiles();
+            assertNotNull(leftovers, "temp dir listable");
+            assertEquals(0, leftovers.length, "probe must clean up its temp files");
+        } finally {
+            tmp.delete();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Raises MiewID v2 vector-match throughput on a standard Wildbook VM by removing the software serializations that bound it, and fixes a shared-state hazard on the match/search read path along the way. Match results are unchanged on a stable index.

Three ordered changes:

### A — Batch prospect encounter loading
`MatchResult._populateProspectsByIndividual` did one `Encounter.findByAnnotation` JDOQL join per prospect. Replaced with a single chunked `Shepherd.getEncountersByAnnotationIds(...)` batch load (mirrors the existing `getAnnotations` pattern). Failures propagate (no silent partial map); multi-parent annotations keep the first-seen encounter and log a warning; a null Shepherd degrades to no indiv grouping (matches prior behavior).

### B — Stateless `_search` for the match read paths + PIT/client thread-safety
`getMatches` and `getMatchingSet` both fetched a single page (`from=0`) via a shared per-index point-in-time (`deletePit` + `queryPit`), racing the static `PIT_CACHE` — which is also touched by concurrent search request threads today. Both now use a new stateless `OpenSearch.querySearch` (plain `_search`, `track_total_hits=true`). `PIT_CACHE` is now a `ConcurrentHashMap`, and the OpenSearch client init is double-checked + `synchronized` with `volatile` fields and eagerly constructed at startup.

### C — Configurable IA match-consumer concurrency (default 1, gated)
Adds `iaMatchConsumerThreads` (default **1**), applied to the **IA queue only** (detection stays serial, so aggregate ≤ N+1). `FileQueue.consume(handler,int)` is the sole gate: it probes the queue filesystem and **fails closed to 1** when atomic file moves are unsupported, because concurrent consumers rely on an atomic (`Files.move(ATOMIC_MOVE)`) claim to avoid double-processing. Single-consume and per-directory guards prevent a second consumer starting on a live queue; guards are released only in `QueueUtil.cleanup()` after all executors are confirmed terminated.

## Why

The v2 vector-match ceiling is set by software, not OpenSearch or CPU: a strictly-serial `FileQueue` consumer, plus (secondarily) a per-prospect DB fanout. See the analysis and corrected model in `docs/superpowers/plans/2026-07-10-vector-match-throughput.md`. Task C is the throughput multiplier; A trims per-thread DB work; B is the correctness precondition that makes concurrency safe.

## Capacity note (read before raising `iaMatchConsumerThreads` > 1)
Concurrency is bound by RAM (OpenSearch page cache — the cold-segment cliff), the DB connection pool, and the shared ml-service, in that order. Raise N incrementally and size the pool/RAM first. Default is 1, so this PR changes no runtime behavior until an operator opts in on an atomic-move-capable filesystem.

## Testing
- `mvn clean install` — **BUILD SUCCESS, 740 tests, 0 failures**.
- New: `QueueGatingTest` (fail-closed clamp + atomic-move probe), `FileQueueSerialClaimTest` (serial-path regression).
- Updated `MatchResultIndivProspectsTest` / `MatchResultTest` to the new batch seam.

## Review
Every step (plan through implementation) was adversarially reviewed with Codex to convergence; Task C's concurrency/lifecycle went several rounds (a Critical self-introduced regression — atomic-only claim stalling serial consumption — was caught and fixed).

## Follow-up (not in this PR)
`MatchResult.annotationDetails` has the same per-prospect `findEncounter` in the match-result **serialization** path (view latency, not throughput). It can reuse `getEncountersByAnnotationIds`; tracked as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
