### PR TITLE
Batch prospect encounter loads in match-result serialization (follow-up to #1676)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-matchresult-serialization-batch.md
+++ b/docs/superpowers/plans/2026-07-10-matchresult-serialization-batch.md
@@ -1,0 +1,150 @@
+# MatchResult serialization: batch prospect encounter loads
+
+> **For agentic workers:** small, contained follow-up. Steps use `- [ ]`. Stacked on `perf/vector-match-throughput` (PR #1676), which introduces `Shepherd.getEncountersByAnnotationIds`.
+
+**Goal:** Remove the per-prospect `Encounter.findEncounter` JDOQL fanout in `MatchResult.annotationDetails` (the match-result **serialization** path), reusing the batch loader from PR #1676. Cuts up to ~500 sequential encounter queries in that path down to one batch loader call (`ceil(uniqueIds/1000)` physical queries).
+
+**Architecture:** Batch-load the annotation→encounter map once in `MatchResult.prospectsForApiGet` (covering every prospect across all score types), thread it down through `MatchResultProspect.jsonForApiGet` into a new `annotationDetails(ann, myShepherd, encByAnnId)` overload. The overload falls back to `findEncounter` when the map has no entry (or the map is null), so the single `queryAnnotation` call and any other caller are unchanged.
+
+**Tech Stack:** Java 17, DataNucleus JDO, JUnit 5 + Mockito.
+
+## Global Constraints
+- **Serialized JSON is identical for the normal single-parent case** (the real world): the batch loader returns the same managed `Encounter` for an annotation with one parent, so the `encounter`/`individual` sub-JSON is identical. **Multi-parent annotations are anomalous** — `Encounter.findByAnnotation` (old) and `getEncountersByAnnotationIds` (new) each pick an arbitrary parent from an unordered query, so for those the selected parent may differ. This is NOT a new correctness change: both paths were already arbitrary, and PR #1676 accepts the same treatment for the indiv-grouping path. Do not claim byte-identity for multi-parent data.
+- **Scope of the perf claim:** this removes the fanout in `annotationDetails` only. When `projectIds` is non-empty, `prospectsSorted` → `MatchResultProspect.isInProjects` still calls `findEncounter` per prospect — that is a separate lookup, left out of scope here (possible future follow-up). State the win as "one batch load for serialization," not "one query per view."
+- Keep the existing public 2-arg `annotationDetails(Annotation, Shepherd)` and 1-arg `MatchResultProspect.jsonForApiGet(Shepherd)` methods working (delegate), so no other caller breaks.
+- Null `myShepherd` must behave exactly as today (no new NPE): when null, do not batch — pass a null map so `annotationDetails` takes its existing `findEncounter(myShepherd)` path.
+- Commit LF; `perl -i -pe 's/\r\n/\n/g'` + `grep -cP '\r$'` == 0 on every touched file.
+
+## Baseline (verified on the stacked branch)
+- `MatchResult.annotationDetails(Annotation ann, Shepherd myShepherd)` (~707) calls `ann.findEncounter(myShepherd)` (~735) to build the `encounter`/`individual` JSON.
+- Callers: `MatchResultProspect.jsonForApiGet` (:85, per prospect) and `MatchResult.jsonForApiGet` (:698, once for `queryAnnotation`).
+- `MatchResult.prospectsForApiGet` (~681) loops `prospectScoreTypes()` × `prospectsSorted(type,…)` and calls `mrp.jsonForApiGet(myShepherd)` per prospect — the fanout. The same annotation can recur across the `annot` and `indiv` types.
+- `MatchResultProspect.getAnnotation()` (:52) exists. `Shepherd.getEncountersByAnnotationIds(Collection<String>)` exists (PR #1676).
+
+---
+
+## Task 1: Batch the serialization encounter loads
+
+**Files:**
+- Modify: `src/main/java/org/ecocean/ia/MatchResult.java` (`annotationDetails` overload; `prospectsForApiGet`)
+- Modify: `src/main/java/org/ecocean/ia/MatchResultProspect.java` (`jsonForApiGet` overload)
+- Test: `src/test/java/org/ecocean/ia/MatchResultSerializationBatchTest.java` (new)
+
+**Interfaces:**
+- `JSONObject MatchResult.annotationDetails(Annotation ann, Shepherd myShepherd, Map<String,Encounter> encByAnnId)` — resolves the encounter from `encByAnnId` when present, else `ann.findEncounter(myShepherd)`. Existing 2-arg delegates with `null`.
+- `JSONObject MatchResultProspect.jsonForApiGet(Shepherd myShepherd, Map<String,Encounter> encByAnnId)` — passes the map into `annotationDetails`. Existing 1-arg delegates with `null`.
+
+- [ ] **Step 1: Add the `annotationDetails` map overload; 2-arg delegates**
+
+```java
+public static JSONObject annotationDetails(Annotation ann, Shepherd myShepherd) {
+    return annotationDetails(ann, myShepherd, null);
+}
+
+public static JSONObject annotationDetails(Annotation ann, Shepherd myShepherd,
+    java.util.Map<String, Encounter> encByAnnId) {
+    JSONObject aj = new JSONObject();
+    if (ann == null) return aj;
+    // ... existing body unchanged UP TO the findEncounter line ...
+    Encounter enc = resolveEncounter(ann, myShepherd, encByAnnId);
+    // ... existing body unchanged AFTER, using enc ...
+}
+
+// Prefer the pre-batched map (one query for the whole result); fall back to the per-annotation
+// query when the map is absent or lacks this id (e.g. the single queryAnnotation call).
+private static Encounter resolveEncounter(Annotation ann, Shepherd myShepherd,
+    java.util.Map<String, Encounter> encByAnnId) {
+    if ((encByAnnId != null) && (ann.getId() != null) && encByAnnId.containsKey(ann.getId())) {
+        return encByAnnId.get(ann.getId());
+    }
+    return ann.findEncounter(myShepherd);
+}
+```
+Only the single `Encounter enc = ann.findEncounter(myShepherd);` line inside the existing 3-arg body changes to `Encounter enc = resolveEncounter(ann, myShepherd, encByAnnId);`. Everything else in the method is unchanged.
+
+- [ ] **Step 2: Add `MatchResultProspect.jsonForApiGet` map overload; 1-arg delegates**
+
+```java
+public JSONObject jsonForApiGet(Shepherd myShepherd) {
+    return jsonForApiGet(myShepherd, null);
+}
+
+public JSONObject jsonForApiGet(Shepherd myShepherd, java.util.Map<String, Encounter> encByAnnId) {
+    JSONObject rtn = new JSONObject();
+    rtn.put("annotation", MatchResult.annotationDetails(annotation, myShepherd, encByAnnId));
+    // ... rest of the existing body unchanged (score, asset) ...
+}
+```
+Add `import org.ecocean.Encounter;` if not already present.
+
+- [ ] **Step 3: Batch-load once in `prospectsForApiGet` and pass the map down**
+
+```java
+public JSONObject prospectsForApiGet(int cutoff, Set<String> projectIds, Shepherd myShepherd) {
+    JSONObject sj = new JSONObject();
+
+    // Batch-load every prospect's parent encounter once (was: one findEncounter per prospect per
+    // type in annotationDetails). `prospects` is a nullable Set; guard it (Codex: NPE when empty/
+    // null). Null shepherd -> no batch (annotationDetails keeps its per-annotation fallback),
+    // preserving current behavior.
+    java.util.Map<String, Encounter> encByAnnId = java.util.Collections.emptyMap();
+    if ((myShepherd != null) && (prospects != null) && !prospects.isEmpty()) {
+        java.util.List<String> annIds = new java.util.ArrayList<String>();
+        for (MatchResultProspect mrp : prospects) {
+            Annotation a = (mrp == null) ? null : mrp.getAnnotation();
+            if ((a != null) && (a.getId() != null)) annIds.add(a.getId());
+        }
+        encByAnnId = myShepherd.getEncountersByAnnotationIds(annIds);
+    }
+
+    for (String type : prospectScoreTypes()) {
+        JSONArray jarr = new JSONArray();
+        for (MatchResultProspect mrp : prospectsSorted(type, cutoff, projectIds, myShepherd)) {
+            jarr.put(mrp.jsonForApiGet(myShepherd, encByAnnId));
+        }
+        sj.put(type, jarr);
+    }
+    return sj;
+}
+```
+`prospects` is the full prospect collection already on the object (used by `prospectsSorted`/`numberProspects`). Confirm its exact field name and iterate it; if it is not directly iterable here, gather ids by unioning `prospectsSorted(type,…)` over `prospectScoreTypes()` into a `Set` first.
+
+- [ ] **Step 4: Write the equivalence + no-fanout test**
+
+Create `MatchResultSerializationBatchTest`. Mock `Task`; use **`spy`** (not plain mock) annotations so `findEncounter` can be both stubbed AND counted, mirroring `MatchResultIndivProspectsTest`'s `newShepherd()` that stubs `getEncountersByAnnotationIds` from a per-test `id→Encounter` registry. Stub spies with `doReturn(...).when(spy).method(...)` form (not `when(spy.method())`) so the real method is never invoked while stubbing.
+
+**Critical setup note (Codex):** `new MatchResult(task, candidates, …, shepherd)` ALREADY calls `getEncountersByAnnotationIds` once inside `_populateProspectsByIndividual` (Task A). So after constructing the `MatchResult`, call `org.mockito.Mockito.clearInvocations(shepherd)` (and reset the `findEncounter` spy counters) BEFORE exercising `prospectsForApiGet` — otherwise the `times(1)` / `never()` assertions count the construction call too. Prove all three properties precisely:
+  1. **Identical JSON (single-parent):** capture `prospectsForApiGet(...)` JSON with the batch stub active (`batchJson`), then with `getEncountersByAnnotationIds` stubbed to return an EMPTY map so every prospect takes the `findEncounter` fallback (`fallbackJson`). Assert the **complete** JSON strings are equal (`batchJson.toString().equals(fallbackJson.toString())`) — not just the sub-objects. Reset `findEncounter` counters between the two runs.
+  2. **Fanout gone:** in the batch run where every prospect id IS in the map, assert `findEncounter` is invoked **0 times** across all prospect annotations (`verify(ann, never()).findEncounter(any())`), and `getEncountersByAnnotationIds` exactly once (`times(1)`) — note in a comment this is one loader call = `ceil(uniqueIds/1000)` physical queries, here 1.
+  3. **Fallback for a missing id:** one prospect whose annotation id is deliberately absent from the map → assert exactly one `findEncounter` on that annotation and its encounter still appears in the JSON.
+- Also cover the empty-prospects case: a `MatchResult` with no prospects → `prospectsForApiGet` returns `{}`-shaped JSON with no NPE and `getEncountersByAnnotationIds` never called.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+mvn -o -Dtest=MatchResultSerializationBatchTest,MatchResultIndivProspectsTest,MatchResultTest -DfailIfNoTests=false test
+```
+Expected: PASS.
+
+- [ ] **Step 6: Normalize + commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' src/main/java/org/ecocean/ia/MatchResult.java \
+  src/main/java/org/ecocean/ia/MatchResultProspect.java \
+  src/test/java/org/ecocean/ia/MatchResultSerializationBatchTest.java
+git add -A && git commit -m "perf(match): batch prospect encounter loads in match-result serialization"
+```
+
+- [ ] **Step 7: Full build**
+
+```bash
+mvn clean install   # BUILD SUCCESS, 0 failures
+```
+
+## Self-Review (post-Codex round 1)
+- Output-identical for single-parent (the real case): `resolveEncounter` returns the same managed encounter `findEncounter` would; multi-parent is anomalous and arbitrary in both paths (scoped, not claimed identical). ✓
+- Empty/null `prospects` guarded — no NPE (Codex #1). ✓
+- queryAnnotation path untouched (2-arg → null map → findEncounter). ✓
+- Null-shepherd behavior preserved (fallback to findEncounter, same as today). ✓
+- Perf claim scoped to the serialization path; `isInProjects`/projectIds encounter lookups explicitly out of scope (Codex #4). ✓
+- Test proves full-JSON equality (batch vs fallback), zero `findEncounter` when fully mapped, and one fallback for a missing id (Codex #3). ✓

--- a/src/main/java/org/ecocean/ia/MatchResult.java
+++ b/src/main/java/org/ecocean/ia/MatchResult.java
@@ -681,10 +681,25 @@ public class MatchResult implements java.io.Serializable {
     public JSONObject prospectsForApiGet(int cutoff, Set<String> projectIds, Shepherd myShepherd) {
         JSONObject sj = new JSONObject();
 
+        // Batch-load every prospect's parent encounter once (was: one findEncounter per prospect per
+        // type inside annotationDetails). `prospects` is a nullable Set; guard it. Null shepherd ->
+        // no batch (annotationDetails keeps its per-annotation fallback), preserving prior behavior.
+        // NOTE: this removes the fanout in the SERIALIZATION path only; when projectIds is non-empty
+        // prospectsSorted -> isInProjects still resolves encounters per prospect (separate, unchanged).
+        java.util.Map<String, Encounter> encByAnnId = java.util.Collections.emptyMap();
+        if ((myShepherd != null) && (prospects != null) && !prospects.isEmpty()) {
+            List<String> annIds = new ArrayList<String>();
+            for (MatchResultProspect mrp : prospects) {
+                Annotation a = (mrp == null) ? null : mrp.getAnnotation();
+                if ((a != null) && (a.getId() != null)) annIds.add(a.getId());
+            }
+            encByAnnId = myShepherd.getEncountersByAnnotationIds(annIds);
+        }
+
         for (String type : prospectScoreTypes()) {
             JSONArray jarr = new JSONArray();
             for (MatchResultProspect mrp : prospectsSorted(type, cutoff, projectIds, myShepherd)) {
-                jarr.put(mrp.jsonForApiGet(myShepherd));
+                jarr.put(mrp.jsonForApiGet(myShepherd, encByAnnId));
             }
             sj.put(type, jarr);
         }
@@ -705,6 +720,22 @@ public class MatchResult implements java.io.Serializable {
     }
 
     public static JSONObject annotationDetails(Annotation ann, Shepherd myShepherd) {
+        return annotationDetails(ann, myShepherd, null);
+    }
+
+    // Prefer a pre-batched annotation-id -> Encounter map (one loader call for the whole result) and
+    // fall back to the per-annotation query when the map is absent or lacks this id (e.g. the single
+    // queryAnnotation call). Absent id -> findEncounter; the map never holds null values.
+    private static Encounter resolveEncounter(Annotation ann, Shepherd myShepherd,
+        java.util.Map<String, Encounter> encByAnnId) {
+        if ((encByAnnId != null) && (ann.getId() != null) && encByAnnId.containsKey(ann.getId())) {
+            return encByAnnId.get(ann.getId());
+        }
+        return ann.findEncounter(myShepherd);
+    }
+
+    public static JSONObject annotationDetails(Annotation ann, Shepherd myShepherd,
+        java.util.Map<String, Encounter> encByAnnId) {
         JSONObject aj = new JSONObject();
 
         if (ann == null) return aj;
@@ -732,7 +763,7 @@ public class MatchResult implements java.io.Serializable {
             mj.put("rotationInfo", ma.getRotationInfo());
             aj.put("asset", mj);
         }
-        Encounter enc = ann.findEncounter(myShepherd);
+        Encounter enc = resolveEncounter(ann, myShepherd, encByAnnId);
         if (enc != null) {
             JSONObject ej = new JSONObject();
             // TODO add "access" permission value if needed?

--- a/src/main/java/org/ecocean/ia/MatchResultProspect.java
+++ b/src/main/java/org/ecocean/ia/MatchResultProspect.java
@@ -80,9 +80,14 @@ public class MatchResultProspect implements java.io.Serializable, Comparable<Mat
     }
 
     public JSONObject jsonForApiGet(Shepherd myShepherd) {
+        return jsonForApiGet(myShepherd, null);
+    }
+
+    public JSONObject jsonForApiGet(Shepherd myShepherd,
+        java.util.Map<String, org.ecocean.Encounter> encByAnnId) {
         JSONObject rtn = new JSONObject();
 
-        rtn.put("annotation", MatchResult.annotationDetails(annotation, myShepherd));
+        rtn.put("annotation", MatchResult.annotationDetails(annotation, myShepherd, encByAnnId));
         rtn.put("score", score);
         // skipping scoreType since this is currently only used filtered by scoreType already
         if (asset != null) {

--- a/src/test/java/org/ecocean/ia/MatchResultSerializationBatchTest.java
+++ b/src/test/java/org/ecocean/ia/MatchResultSerializationBatchTest.java
@@ -1,0 +1,189 @@
+package org.ecocean.ia;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.ecocean.Annotation;
+import org.ecocean.Encounter;
+import org.ecocean.MarkedIndividual;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the match-result serialization path batch-loads prospect encounters (one loader
+ * call for the whole result) instead of one Annotation.findEncounter per prospect, WITHOUT changing
+ * the serialized JSON.
+ */
+class MatchResultSerializationBatchTest {
+
+    // Per-test registry: annotation id -> parent Encounter. mockAnn populates it; newShepherd()
+    // stubs getEncountersByAnnotationIds from it (the batch seam).
+    private final Map<String, Encounter> encByAnnId = new HashMap<String, Encounter>();
+    private final List<Annotation> allAnns = new ArrayList<Annotation>();
+    private int annCounter = 0;
+
+    @BeforeEach void reset() {
+        encByAnnId.clear();
+        allAnns.clear();
+        annCounter = 0;
+    }
+
+    private Shepherd newShepherd() {
+        Shepherd s = mock(Shepherd.class);
+        lenient().when(s.getEncountersByAnnotationIds(any())).thenAnswer(inv -> {
+            Collection<String> ids = inv.getArgument(0);
+            Map<String, Encounter> out = new HashMap<String, Encounter>();
+            if (ids != null) {
+                for (String id : ids) {
+                    if (encByAnnId.containsKey(id)) out.put(id, encByAnnId.get(id));
+                }
+            }
+            return out;
+        });
+        return s;
+    }
+
+    // A shepherd whose batch loader always returns an empty map -> every prospect takes the
+    // findEncounter fallback. Used to prove the batch and fallback JSON are identical.
+    private Shepherd emptyMapShepherd() {
+        Shepherd s = mock(Shepherd.class);
+        lenient().when(s.getEncountersByAnnotationIds(any())).thenReturn(
+            Collections.<String, Encounter>emptyMap());
+        return s;
+    }
+
+    private MarkedIndividual mockIndiv(String id) {
+        MarkedIndividual indiv = mock(MarkedIndividual.class);
+        lenient().when(indiv.getId()).thenReturn(id);
+        lenient().when(indiv.getTaxonomyString()).thenReturn("Genus species");
+        lenient().when(indiv.getDisplayName()).thenReturn("disp-" + id);
+        lenient().when(indiv.getNickName()).thenReturn("nick-" + id);
+        lenient().when(indiv.getSex()).thenReturn("unknown");
+        lenient().when(indiv.getNumEncounters()).thenReturn(3);
+        return indiv;
+    }
+
+    // mock Annotation with a unique id, a registered parent Encounter (in encByAnnId), and
+    // findEncounter stubbed to the SAME encounter so the fallback path yields identical JSON.
+    // registerInMap=false leaves it out of the batch map (forces the fallback in the batch run).
+    private Annotation mockAnn(double score, MarkedIndividual indiv, boolean registerInMap) {
+        Annotation a = mock(Annotation.class);
+        String id = "ann-" + (++annCounter);
+        lenient().when(a.getId()).thenReturn(id);
+        lenient().when(a.getOpensearchScore()).thenReturn(score);
+        Encounter enc = mock(Encounter.class);
+        lenient().when(enc.getId()).thenReturn("enc-" + id);
+        lenient().when(enc.getTaxonomyString()).thenReturn("Genus species");
+        lenient().when(enc.getLocationID()).thenReturn("loc-1");
+        lenient().when(enc.getIndividual()).thenReturn(indiv);
+        lenient().when(a.findEncounter(any())).thenReturn(enc);
+        if (registerInMap) encByAnnId.put(id, enc);
+        allAnns.add(a);
+        return a;
+    }
+
+    private MatchResult buildMatchResult(List<Annotation> candidates, Shepherd shepherd)
+    throws Exception {
+        Task task = mock(Task.class);
+        when(task.countObjectAnnotations()).thenReturn(1);
+        Annotation queryAnn = mock(Annotation.class);
+        ArrayList<Annotation> queryList = new ArrayList<Annotation>();
+        queryList.add(queryAnn);
+        when(task.getObjectAnnotations()).thenReturn(queryList);
+        return new MatchResult(task, candidates, candidates.size(), shepherd);
+    }
+
+    @Test void serializedJsonIdenticalBatchVsFallback()
+    throws Exception {
+        Shepherd s = newShepherd();
+        MarkedIndividual indivA = mockIndiv("indiv-A");
+        List<Annotation> cands = new ArrayList<Annotation>();
+        cands.add(mockAnn(0.81, indivA, true));
+        cands.add(mockAnn(0.62, indivA, true));
+        cands.add(mockAnn(0.55, null, true)); // un-ID'd
+
+        MatchResult mr = buildMatchResult(cands, s);
+
+        // Batch run (map-backed) vs fallback run (empty map -> findEncounter). Same MatchResult.
+        JSONObject batchJson = mr.prospectsForApiGet(-1, null, s);
+        JSONObject fallbackJson = mr.prospectsForApiGet(-1, null, emptyMapShepherd());
+
+        assertEquals(fallbackJson.toString(), batchJson.toString(),
+            "serialized prospects JSON must be identical whether encounters came from the batch " +
+            "map or the per-annotation findEncounter fallback");
+    }
+
+    @Test void noFindEncounterFanoutWhenFullyMapped()
+    throws Exception {
+        Shepherd s = newShepherd();
+        MarkedIndividual indivA = mockIndiv("indiv-A");
+        List<Annotation> cands = new ArrayList<Annotation>();
+        cands.add(mockAnn(0.81, indivA, true));
+        cands.add(mockAnn(0.62, indivA, true));
+        cands.add(mockAnn(0.9, null, true));
+
+        MatchResult mr = buildMatchResult(cands, s);
+        // The constructor already called getEncountersByAnnotationIds once (Task A indiv grouping);
+        // clear so the assertions below count only the serialization pass.
+        clearInvocations(s);
+        for (Annotation a : allAnns) clearInvocations(a);
+
+        mr.prospectsForApiGet(-1, null, s);
+
+        // One batch loader call for the whole serialization (= ceil(uniqueIds/1000) physical queries;
+        // here 1), and ZERO per-prospect findEncounter.
+        verify(s, times(1)).getEncountersByAnnotationIds(any());
+        for (Annotation a : allAnns) verify(a, never()).findEncounter(any());
+    }
+
+    @Test void missingIdFallsBackToFindEncounter()
+    throws Exception {
+        Shepherd s = newShepherd();
+        MarkedIndividual indivA = mockIndiv("indiv-A");
+        Annotation mapped = mockAnn(0.8, indivA, true);
+        Annotation missing = mockAnn(0.6, indivA, false); // NOT in the batch map
+        List<Annotation> cands = new ArrayList<Annotation>();
+        cands.add(mapped); cands.add(missing);
+
+        MatchResult mr = buildMatchResult(cands, s);
+        clearInvocations(s);
+        for (Annotation a : allAnns) clearInvocations(a);
+
+        JSONObject json = mr.prospectsForApiGet(-1, null, s);
+
+        // Mapped annotation: served from the map (no findEncounter). Missing: exactly one fallback.
+        verify(mapped, never()).findEncounter(any());
+        verify(missing, times(1)).findEncounter(any());
+        assertTrue(json.toString().contains("enc-" + missing.getId()),
+            "missing-id prospect's encounter must still serialize via the fallback");
+    }
+
+    @Test void emptyProspects_noBatchCall_noNpe()
+    throws Exception {
+        Shepherd s = newShepherd();
+        MatchResult mr = buildMatchResult(new ArrayList<Annotation>(), s);
+        clearInvocations(s);
+
+        JSONObject json = mr.prospectsForApiGet(-1, null, s);
+        assertFalse(json == null, "empty prospects must still return a JSON object, not null");
+        verify(s, never()).getEncountersByAnnotationIds(any());
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #1676. Removes the per-prospect `Encounter.findEncounter` JDOQL fanout in the match-result **serialization** path (`MatchResult.annotationDetails`), reusing the `Shepherd.getEncountersByAnnotationIds` batch loader that #1676 introduces.

`MatchResult.prospectsForApiGet` now batch-loads every prospect's parent encounter once and threads the `annotationId → Encounter` map down through `MatchResultProspect.jsonForApiGet` into a new `annotationDetails(ann, shepherd, map)` overload. The overload falls back to `findEncounter` for ids absent from the map (e.g. the single `queryAnnotation` call), so serialized JSON is unchanged for the normal single-parent case.

**Impact:** a match-result API view (`/api/v3/match-inspection`, React match pages) that previously ran up to ~500 sequential `findEncounter` queries during serialization now runs one batch loader call (`ceil(uniqueIds/1000)` physical queries).

## Stacked on #1676
This branches off `perf/vector-match-throughput` (PR #1676) because it depends on `Shepherd.getEncountersByAnnotationIds`. **Base is set to `perf/vector-match-throughput`** so the diff shows only this change. Merge #1676 first, then rebase/merge this onto `main`.

## Scope / non-goals
- Removes the fanout in the **serialization** path only. When `projectIds` is non-empty, `prospectsSorted → MatchResultProspect.isInProjects` still resolves encounters per prospect — a separate lookup, intentionally left out of scope.
- **Multi-parent annotations** (an annotation on >1 encounter) are anomalous; both the old `findByAnnotation` and the batch loader select an arbitrary parent, so JSON for those is not guaranteed identical — this matches #1676's accepted treatment, not a new regression.

## Testing
- `mvn clean install` — **BUILD SUCCESS, 744 tests, 0 failures**.
- New `MatchResultSerializationBatchTest`: full-JSON batch-vs-fallback equality; zero `findEncounter` + exactly one loader call when fully mapped (after `clearInvocations`); one fallback for a deliberately unmapped id; empty-prospects no-NPE / no loader call.

## Review
Plan and implementation each reviewed with Codex to convergence (plan took two rounds — empty-set NPE guard, scoped multi-parent/perf claims, and a test that actually proves no-fanout; implementation clean, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
