### PR TITLE
Validate search pagination against index max_result_window; retry queryPit only on stale PIT

### DIFF
--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -546,13 +546,20 @@ public class OpenSearch {
         String pitId = PIT_CACHE.get(indexName);
 
         if (pitId == null) return;
+        deletePitId(pitId);
+        PIT_CACHE.remove(indexName);
+        System.out.println("OpenSearch.deletePit(" + indexName + ") [" + pitId + "] completed");
+    }
+
+    // server-side delete of one specific PIT id; no cache interaction
+    void deletePitId(String pitId)
+    throws IOException {
         Request req = new Request("DELETE", "/_search/point_in_time");
         JSONObject body = new JSONObject();
+
         body.put("pit_id", pitId);
         req.setJsonEntity(body.toString());
         getRestResponse(req);
-        PIT_CACHE.remove(indexName);
-        System.out.println("OpenSearch.deletePit(" + indexName + ") [" + pitId + "] completed");
     }
 
     public JSONObject queryPit(String indexName, final JSONObject query, int numFrom, int pageSize,
@@ -609,15 +616,16 @@ public class OpenSearch {
             || message.contains("No search context found");
     }
 
-    // best-effort: delete the (likely stale) server-side PIT before dropping it from
-    // cache - but only if the cache still holds the pit THIS request used, so we never
-    // destroy a fresh PIT installed by a concurrent request
-    private void discardPitQuietly(String indexName, String pitId) {
-        if ((pitId == null) || !pitId.equals(PIT_CACHE.get(indexName))) return;
+    // best-effort: drop the pit THIS request used from cache, then delete it server-side.
+    // The atomic remove(key, value) detaches ONLY our pit, so we never destroy a fresh
+    // PIT installed by a concurrent request between our failure and this cleanup.
+    void discardPitQuietly(String indexName, String pitId) {
+        if ((pitId == null) || !PIT_CACHE.remove(indexName, pitId)) return;
         try {
-            deletePit(indexName);
+            deletePitId(pitId);
         } catch (Exception ex) {
-            PIT_CACHE.remove(indexName);
+            // best-effort only: the stale id is already out of the cache; the server
+            // expires the orphaned PIT at keep_alive
         }
     }
 

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -546,9 +546,9 @@ public class OpenSearch {
             try {
                 return new JSONObject(getRestResponse(searchRequest));
             } catch (ResponseException ex) {
-                // always drop the cached PIT: a possibly-bad cached id would otherwise
+                // always drop OUR cached PIT: a possibly-bad cached id would otherwise
                 // poison every subsequent search on this index
-                discardPitQuietly(indexName);
+                discardPitQuietly(indexName, pitId);
                 if (!isStaleSearchContextError(ex.getMessage())) {
                     // deterministic rejection (bad query, result window exceeded, ...):
                     // retrying cannot succeed and would burn a new server-side PIT per attempt
@@ -575,8 +575,11 @@ public class OpenSearch {
             || message.contains("No search context found");
     }
 
-    // best-effort: delete the (likely stale) server-side PIT before dropping it from cache
-    private void discardPitQuietly(String indexName) {
+    // best-effort: delete the (likely stale) server-side PIT before dropping it from
+    // cache - but only if the cache still holds the pit THIS request used, so we never
+    // destroy a fresh PIT installed by a concurrent request
+    private void discardPitQuietly(String indexName, String pitId) {
+        if ((pitId == null) || !pitId.equals(PIT_CACHE.get(indexName))) return;
         try {
             deletePit(indexName);
         } catch (Exception ex) {

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -58,7 +58,7 @@ public class OpenSearch {
     // because Wildbook raises the setting on indexes that grow past the default
     private static final Map<String, long[]> MAX_RESULT_WINDOW_CACHE =
         new java.util.concurrent.ConcurrentHashMap<String, long[]>();
-    private static final long MAX_RESULT_WINDOW_CACHE_MILLIS = 600000L;
+    private static final long MAX_RESULT_WINDOW_CACHE_MILLIS = 60000L;
     public static String SEARCH_SCROLL_TIME = (String)getConfigurationValue("searchScrollTime",
         "10m");
     public static String SEARCH_PIT_TIME = (String)getConfigurationValue("searchPitTime", "10m");
@@ -105,7 +105,6 @@ public class OpenSearch {
     static String ACTIVE_TYPE_FOREGROUND = "opensearch_indexing_foreground";
     static String ACTIVE_TYPE_BACKGROUND = "opensearch_indexing_background";
 
-    private int pitRetry = 0;
 
     public OpenSearch() {
         if (client != null) return;
@@ -526,8 +525,6 @@ public class OpenSearch {
         String sort, String sortOrder)
     throws IOException {
         if (!isValidIndexName(indexName)) throw new IOException("invalid index name: " + indexName);
-        String pitId = createPit(indexName);
-        Request searchRequest = new Request("POST", "/_search?track_total_hits=true");
         query.put("from", numFrom);
         query.put("size", pageSize);
         // "sort": [ {"@timestamp": {"order": "asc"}} ]
@@ -537,49 +534,45 @@ public class OpenSearch {
             sortArr.put(new JSONObject("{\"" + sort + "\":{\"order\":\"" + sortOrder + "\"}}"));
             query.put("sort", sortArr);
         }
-        JSONObject jpit = new JSONObject();
-        jpit.put("id", pitId);
-        jpit.put("keep_alive", SEARCH_PIT_TIME);
-        query.put("pit", jpit);
-        searchRequest.setJsonEntity(query.toString());
-        String rtn = null;
-        try {
-            rtn = getRestResponse(searchRequest);
-            pitRetry = 0;
-        } catch (ResponseException ex) {
-            int statusCode = (ex.getResponse() == null) ? -1
-                : ex.getResponse().getStatusLine().getStatusCode();
-            if (!isStaleSearchContextError(statusCode, ex.getMessage())) {
-                // deterministic rejection (bad query, result window exceeded, ...):
-                // retrying cannot succeed and would burn a new server-side PIT per attempt
-                pitRetry = 0;
-                throw ex;
-            }
-            System.out.println("queryPit() using pitId=" + pitId + " failed[" + pitRetry +
-                "] with: " + ex);
-            pitRetry++;
-            if (pitRetry > 5) {
-                pitRetry = 0;
-                ex.printStackTrace();
+        int attempt = 0;
+        while (true) {
+            String pitId = createPit(indexName);
+            JSONObject jpit = new JSONObject();
+            jpit.put("id", pitId);
+            jpit.put("keep_alive", SEARCH_PIT_TIME);
+            query.put("pit", jpit);
+            Request searchRequest = new Request("POST", "/_search?track_total_hits=true");
+            searchRequest.setJsonEntity(query.toString());
+            try {
+                return new JSONObject(getRestResponse(searchRequest));
+            } catch (ResponseException ex) {
+                // always drop the cached PIT: a possibly-bad cached id would otherwise
+                // poison every subsequent search on this index
                 discardPitQuietly(indexName);
-                throw new IOException("queryPit() failed to POST query");
+                if (!isStaleSearchContextError(ex.getMessage())) {
+                    // deterministic rejection (bad query, result window exceeded, ...):
+                    // retrying cannot succeed and would burn a new server-side PIT per attempt
+                    throw ex;
+                }
+                attempt++;
+                System.out.println("queryPit() using pitId=" + pitId + " failed[" + attempt +
+                    "] with: " + ex);
+                if (attempt > 5) {
+                    ex.printStackTrace();
+                    throw new IOException("queryPit() failed to POST query");
+                }
+                // we try again with a fresh PIT
             }
-            // we try again, but attempt to get new PIT
-            discardPitQuietly(indexName);
-            return queryPit(indexName, query, numFrom, pageSize, sort, sortOrder);
         }
-        return new JSONObject(rtn);
     }
 
-    // queryPit()'s cached PIT can expire server-side; only those failures are worth a
-    // retry with a fresh PIT. Anything else is deterministic - retrying cannot succeed.
-    static boolean isStaleSearchContextError(int statusCode, String message) {
-        if (statusCode == 404) return true;
+    // queryPit()'s cached PIT can expire server-side; ONLY that failure class is worth
+    // a retry with a fresh PIT, matched on the typed OpenSearch cause. Anything else
+    // (including a bare 404) is deterministic - retrying cannot succeed.
+    static boolean isStaleSearchContextError(String message) {
         if (message == null) return false;
         return message.contains("search_context_missing")
-            || message.contains("No search context found")
-            || message.contains("point in time")
-            || message.contains("pit_id");
+            || message.contains("No search context found");
     }
 
     // best-effort: delete the (likely stale) server-side PIT before dropping it from cache
@@ -596,16 +589,17 @@ public class OpenSearch {
         if (indexName == null) return DEFAULT_MAX_RESULT_WINDOW;
         long[] cached = MAX_RESULT_WINDOW_CACHE.get(indexName);
         if ((cached != null) && (cached[1] > System.currentTimeMillis())) return (int)cached[0];
-        int window = DEFAULT_MAX_RESULT_WINDOW;
         try {
-            window = parseMaxResultWindow(getSettings(indexName));
+            int window = parseMaxResultWindow(getSettings(indexName));
+            MAX_RESULT_WINDOW_CACHE.put(indexName,
+                new long[] { window, System.currentTimeMillis() + MAX_RESULT_WINDOW_CACHE_MILLIS });
+            return window;
         } catch (Exception ex) {
+            // do NOT cache the fallback: retry the settings read on the next request
             System.out.println("OpenSearch.getMaxResultWindow(" + indexName +
                 ") settings unavailable, using default: " + ex);
+            return DEFAULT_MAX_RESULT_WINDOW;
         }
-        MAX_RESULT_WINDOW_CACHE.put(indexName,
-            new long[] { window, System.currentTimeMillis() + MAX_RESULT_WINDOW_CACHE_MILLIS });
-        return window;
     }
 
     static int parseMaxResultWindow(JSONObject indexSettings) {

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -53,6 +53,12 @@ public class OpenSearch {
     public static RestClient restClient = null;
     public static Map<String, Boolean> INDEX_EXISTS_CACHE = new HashMap<String, Boolean>();
     public static Map<String, String> PIT_CACHE = new HashMap<String, String>();
+    public static final int DEFAULT_MAX_RESULT_WINDOW = 10000;
+    // per-index max_result_window: {value, expiresAtMillis}; read live (briefly cached)
+    // because Wildbook raises the setting on indexes that grow past the default
+    private static final Map<String, long[]> MAX_RESULT_WINDOW_CACHE =
+        new java.util.concurrent.ConcurrentHashMap<String, long[]>();
+    private static final long MAX_RESULT_WINDOW_CACHE_MILLIS = 600000L;
     public static String SEARCH_SCROLL_TIME = (String)getConfigurationValue("searchScrollTime",
         "10m");
     public static String SEARCH_PIT_TIME = (String)getConfigurationValue("searchPitTime", "10m");
@@ -541,18 +547,77 @@ public class OpenSearch {
             rtn = getRestResponse(searchRequest);
             pitRetry = 0;
         } catch (ResponseException ex) {
+            int statusCode = (ex.getResponse() == null) ? -1
+                : ex.getResponse().getStatusLine().getStatusCode();
+            if (!isStaleSearchContextError(statusCode, ex.getMessage())) {
+                // deterministic rejection (bad query, result window exceeded, ...):
+                // retrying cannot succeed and would burn a new server-side PIT per attempt
+                pitRetry = 0;
+                throw ex;
+            }
             System.out.println("queryPit() using pitId=" + pitId + " failed[" + pitRetry +
                 "] with: " + ex);
             pitRetry++;
             if (pitRetry > 5) {
+                pitRetry = 0;
                 ex.printStackTrace();
+                discardPitQuietly(indexName);
                 throw new IOException("queryPit() failed to POST query");
             }
             // we try again, but attempt to get new PIT
-            PIT_CACHE.remove(indexName);
+            discardPitQuietly(indexName);
             return queryPit(indexName, query, numFrom, pageSize, sort, sortOrder);
         }
         return new JSONObject(rtn);
+    }
+
+    // queryPit()'s cached PIT can expire server-side; only those failures are worth a
+    // retry with a fresh PIT. Anything else is deterministic - retrying cannot succeed.
+    static boolean isStaleSearchContextError(int statusCode, String message) {
+        if (statusCode == 404) return true;
+        if (message == null) return false;
+        return message.contains("search_context_missing")
+            || message.contains("No search context found")
+            || message.contains("point in time")
+            || message.contains("pit_id");
+    }
+
+    // best-effort: delete the (likely stale) server-side PIT before dropping it from cache
+    private void discardPitQuietly(String indexName) {
+        try {
+            deletePit(indexName);
+        } catch (Exception ex) {
+            PIT_CACHE.remove(indexName);
+        }
+    }
+
+    // the effective pagination ceiling (from + size limit) for queries on this index
+    public int getMaxResultWindow(String indexName) {
+        if (indexName == null) return DEFAULT_MAX_RESULT_WINDOW;
+        long[] cached = MAX_RESULT_WINDOW_CACHE.get(indexName);
+        if ((cached != null) && (cached[1] > System.currentTimeMillis())) return (int)cached[0];
+        int window = DEFAULT_MAX_RESULT_WINDOW;
+        try {
+            window = parseMaxResultWindow(getSettings(indexName));
+        } catch (Exception ex) {
+            System.out.println("OpenSearch.getMaxResultWindow(" + indexName +
+                ") settings unavailable, using default: " + ex);
+        }
+        MAX_RESULT_WINDOW_CACHE.put(indexName,
+            new long[] { window, System.currentTimeMillis() + MAX_RESULT_WINDOW_CACHE_MILLIS });
+        return window;
+    }
+
+    static int parseMaxResultWindow(JSONObject indexSettings) {
+        if (indexSettings == null) return DEFAULT_MAX_RESULT_WINDOW;
+        try {
+            // _settings returns values as strings; tolerate numbers too
+            int window = Integer.parseInt(indexSettings.opt("max_result_window").toString());
+            // a broken/misconfigured value must never lock search out entirely
+            return (window < 1) ? DEFAULT_MAX_RESULT_WINDOW : window;
+        } catch (Exception ex) {
+            return DEFAULT_MAX_RESULT_WINDOW;
+        }
     }
 
     // just return the actual hit results
@@ -855,6 +920,7 @@ public class OpenSearch {
             putSettings(indexName,
                 new JSONObject("{\"index.max_result_window\": " +
                 Math.round(1.2 * versions.size()) + "}"));
+            MAX_RESULT_WINDOW_CACHE.remove(indexName);
         }
         return versions;
     }

--- a/src/main/java/org/ecocean/api/SearchApi.java
+++ b/src/main/java/org/ecocean/api/SearchApi.java
@@ -153,11 +153,27 @@ public class SearchApi extends ApiBase {
                     // so validate it here too: it may only sort on an allowlisted identity field.
                     boolean badSort = (sort != null) && !sort.trim().isEmpty()
                         && !OpenSearch.INDIVIDUAL_TOKEN_KEEP_SET.contains(sort.trim());
+                    OpenSearch os = new OpenSearch();
+                    // effective pagination ceiling (index.max_result_window) - per-index, since
+                    // Wildbook raises it on large indexes. Exposed as a header so the frontend
+                    // can cap its paginator instead of offering pages we cannot serve.
+                    int maxResultWindow = os.getMaxResultWindow(indexName);
+                    if (maxResultWindow < 1) maxResultWindow = OpenSearch.DEFAULT_MAX_RESULT_WINDOW;
+                    response.setHeader("X-Wildbook-Max-Result-Window",
+                        Integer.toString(maxResultWindow));
                     if (tokenAuth && !isAdmin && "individual".equals(indexName)
                         && (!OpenSearch.queryReferencesOnlyAllowedFields(query,
                             OpenSearch.INDIVIDUAL_TOKEN_KEEP_SET) || badSort)) {
                         response.setStatus(400);
                         res.put("error", "individual token search may only query/sort identity fields");
+                    } else if ((numFrom < 0) || (pageSize < 0)
+                        || ((long)numFrom + (long)pageSize > maxResultWindow)) {
+                        // reject up front: OpenSearch would refuse this anyway (as a 500 to the
+                        // client), and deep pages cannot be fetched no matter how we retry
+                        response.setStatus(400);
+                        res.put("error", "invalid pagination: from + size must be non-negative and"
+                            + " no greater than " + maxResultWindow);
+                        res.put("maxResultWindow", maxResultWindow);
                     } else {
                     // all token validation gates passed -> persist the clean new query now (before
                     // applyAclFilter embeds ACL fields into it); rejected bodies were never stored
@@ -172,7 +188,6 @@ public class SearchApi extends ApiBase {
                     System.out.println("SearchApi search indexName=" + indexName
                         + " tokenAuth=" + tokenAuth);
 
-                    OpenSearch os = new OpenSearch();
                     try {
                         if (deletePit) os.deletePit(indexName);
                         JSONObject queryRes = os.queryPit(indexName, query, numFrom, pageSize, sort,

--- a/src/test/java/org/ecocean/OpenSearchPaginationTest.java
+++ b/src/test/java/org/ecocean/OpenSearchPaginationTest.java
@@ -1,0 +1,72 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchPaginationTest {
+    // ===== parseMaxResultWindow: reads the live index setting, defaults to 10000 =====
+
+    @Test void parseMaxResultWindow_readsNumericStringSetting() {
+        // OpenSearch _settings returns values as strings
+        JSONObject settings = new JSONObject("{\"max_result_window\":\"12004\"}");
+
+        assertEquals(12004, OpenSearch.parseMaxResultWindow(settings));
+    }
+
+    @Test void parseMaxResultWindow_readsIntegerSetting() {
+        JSONObject settings = new JSONObject().put("max_result_window", 20000);
+
+        assertEquals(20000, OpenSearch.parseMaxResultWindow(settings));
+    }
+
+    @Test void parseMaxResultWindow_defaultsWhenAbsent() {
+        assertEquals(OpenSearch.DEFAULT_MAX_RESULT_WINDOW,
+            OpenSearch.parseMaxResultWindow(new JSONObject()));
+    }
+
+    @Test void parseMaxResultWindow_defaultsWhenNull() {
+        assertEquals(OpenSearch.DEFAULT_MAX_RESULT_WINDOW, OpenSearch.parseMaxResultWindow(null));
+    }
+
+    @Test void parseMaxResultWindow_defaultsOnUnparseableValue() {
+        JSONObject settings = new JSONObject("{\"max_result_window\":\"not-a-number\"}");
+
+        assertEquals(OpenSearch.DEFAULT_MAX_RESULT_WINDOW,
+            OpenSearch.parseMaxResultWindow(settings));
+    }
+
+    @Test void parseMaxResultWindow_defaultsOnNonPositiveValue() {
+        // a broken/misconfigured setting must never lock search out entirely
+        assertEquals(OpenSearch.DEFAULT_MAX_RESULT_WINDOW,
+            OpenSearch.parseMaxResultWindow(new JSONObject("{\"max_result_window\":\"0\"}")));
+        assertEquals(OpenSearch.DEFAULT_MAX_RESULT_WINDOW,
+            OpenSearch.parseMaxResultWindow(new JSONObject("{\"max_result_window\":\"-1\"}")));
+    }
+
+    // ===== isStaleSearchContextError: queryPit may retry ONLY stale/expired PIT errors =====
+
+    @Test void staleContext_missingSearchContextIsRetryable() {
+        assertTrue(OpenSearch.isStaleSearchContextError(404,
+            "{\"error\":{\"caused_by\":{\"type\":\"search_context_missing_exception\"}}}"));
+        assertTrue(OpenSearch.isStaleSearchContextError(400,
+            "search_context_missing_exception: No search context found for id"));
+    }
+
+    @Test void staleContext_404IsRetryable() {
+        assertTrue(OpenSearch.isStaleSearchContextError(404, "gone"));
+    }
+
+    @Test void staleContext_resultWindowRejectionIsNotRetryable() {
+        // the exact class of error observed in production 2026-07-10 (issue #1680):
+        // deterministic 400 that can never succeed on retry
+        assertFalse(OpenSearch.isStaleSearchContextError(400,
+            "Result window is too large, from + size must be less than or equal to:"
+            + " [12004] but was [147080]"));
+    }
+
+    @Test void staleContext_nullMessageIsNotRetryable() {
+        assertFalse(OpenSearch.isStaleSearchContextError(400, null));
+    }
+}

--- a/src/test/java/org/ecocean/OpenSearchPaginationTest.java
+++ b/src/test/java/org/ecocean/OpenSearchPaginationTest.java
@@ -45,28 +45,31 @@ class OpenSearchPaginationTest {
             OpenSearch.parseMaxResultWindow(new JSONObject("{\"max_result_window\":\"-1\"}")));
     }
 
-    // ===== isStaleSearchContextError: queryPit may retry ONLY stale/expired PIT errors =====
+    // ===== isStaleSearchContextError: queryPit may retry ONLY stale/expired PIT errors,
+    // matched on the typed OpenSearch error - not status codes or broad substrings =====
 
     @Test void staleContext_missingSearchContextIsRetryable() {
-        assertTrue(OpenSearch.isStaleSearchContextError(404,
+        assertTrue(OpenSearch.isStaleSearchContextError(
             "{\"error\":{\"caused_by\":{\"type\":\"search_context_missing_exception\"}}}"));
-        assertTrue(OpenSearch.isStaleSearchContextError(400,
-            "search_context_missing_exception: No search context found for id"));
+        assertTrue(OpenSearch.isStaleSearchContextError(
+            "No search context found for id [42]"));
     }
 
-    @Test void staleContext_404IsRetryable() {
-        assertTrue(OpenSearch.isStaleSearchContextError(404, "gone"));
+    @Test void staleContext_bareMessageIsNotRetryable() {
+        // a routing/proxy 404 or any other error without the typed cause must propagate
+        assertFalse(OpenSearch.isStaleSearchContextError("no handler found for uri"));
+        assertFalse(OpenSearch.isStaleSearchContextError("gone"));
     }
 
     @Test void staleContext_resultWindowRejectionIsNotRetryable() {
         // the exact class of error observed in production 2026-07-10 (issue #1680):
         // deterministic 400 that can never succeed on retry
-        assertFalse(OpenSearch.isStaleSearchContextError(400,
+        assertFalse(OpenSearch.isStaleSearchContextError(
             "Result window is too large, from + size must be less than or equal to:"
             + " [12004] but was [147080]"));
     }
 
     @Test void staleContext_nullMessageIsNotRetryable() {
-        assertFalse(OpenSearch.isStaleSearchContextError(400, null));
+        assertFalse(OpenSearch.isStaleSearchContextError(null));
     }
 }

--- a/src/test/java/org/ecocean/OpenSearchQueryPitRetryTest.java
+++ b/src/test/java/org/ecocean/OpenSearchQueryPitRetryTest.java
@@ -42,10 +42,20 @@ class OpenSearchQueryPitRetryTest {
         return new ResponseException(r);
     }
 
+    @org.junit.jupiter.api.BeforeEach
+    @org.junit.jupiter.api.AfterEach
+    void clearPitCache() {
+        OpenSearch.PIT_CACHE.clear();
+    }
+
     private OpenSearch spyOs() throws IOException {
         OpenSearch os = spy(new OpenSearch());
 
-        doReturn("pit-1").when(os).createPit(anyString());
+        // mirror the real createPit contract: returns the id AND caches it
+        doAnswer(inv -> {
+            OpenSearch.PIT_CACHE.put(inv.getArgument(0), "pit-1");
+            return "pit-1";
+        }).when(os).createPit(anyString());
         doNothing().when(os).deletePit(anyString());
         return os;
     }

--- a/src/test/java/org/ecocean/OpenSearchQueryPitRetryTest.java
+++ b/src/test/java/org/ecocean/OpenSearchQueryPitRetryTest.java
@@ -1,0 +1,110 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import org.apache.http.HttpHost;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicRequestLine;
+import org.apache.http.message.BasicStatusLine;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+/**
+ * Pins queryPit()'s retry contract: stale/expired PIT errors are retried with a fresh
+ * PIT (bounded), everything else propagates after a single attempt, and the cached PIT
+ * is always discarded on failure so a bad PIT cannot poison subsequent searches.
+ */
+class OpenSearchQueryPitRetryTest {
+    private static final String STALE_BODY =
+        "{\"error\":{\"root_cause\":[{\"type\":\"search_context_missing_exception\","
+        + "\"reason\":\"No search context found for id [123]\"}]},\"status\":404}";
+    private static final String WINDOW_BODY =
+        "{\"error\":{\"root_cause\":[{\"type\":\"illegal_argument_exception\",\"reason\":"
+        + "\"Result window is too large, from + size must be less than or equal to:"
+        + " [12004] but was [147080]\"}]},\"status\":400}";
+
+    private static ResponseException respEx(int status, String body) throws IOException {
+        ProtocolVersion http = new ProtocolVersion("HTTP", 1, 1);
+        Response r = mock(Response.class);
+
+        when(r.getRequestLine()).thenReturn(new BasicRequestLine("POST", "/_search", http));
+        when(r.getHost()).thenReturn(new HttpHost("opensearch", 9200, "http"));
+        when(r.getStatusLine()).thenReturn(new BasicStatusLine(http, status, ""));
+        when(r.getEntity()).thenReturn(new StringEntity(body, ContentType.APPLICATION_JSON));
+        return new ResponseException(r);
+    }
+
+    private OpenSearch spyOs() throws IOException {
+        OpenSearch os = spy(new OpenSearch());
+
+        doReturn("pit-1").when(os).createPit(anyString());
+        doNothing().when(os).deletePit(anyString());
+        return os;
+    }
+
+    @Test void deterministicRejection_singleAttempt_pitDiscarded() throws Exception {
+        OpenSearch os = spyOs();
+
+        doThrow(respEx(400, WINDOW_BODY)).when(os).getRestResponse(any(Request.class));
+        assertThrows(ResponseException.class,
+            () -> os.queryPit("encounter", new JSONObject(), 147060, 20, null, null));
+        verify(os, times(1)).getRestResponse(any(Request.class));
+        // the cached PIT is discarded even on non-retryable failures - a possibly-bad
+        // cached PIT must never poison every subsequent search on the index
+        verify(os, times(1)).deletePit("encounter");
+    }
+
+    @Test void stalePit_retriedOnceWithFreshPit() throws Exception {
+        OpenSearch os = spyOs();
+
+        doThrow(respEx(404, STALE_BODY)).doReturn("{\"hits\":{\"hits\":[]}}")
+            .when(os).getRestResponse(any(Request.class));
+        JSONObject res = os.queryPit("encounter", new JSONObject(), 0, 10, null, null);
+        assertNotNull(res.optJSONObject("hits"));
+        verify(os, times(2)).getRestResponse(any(Request.class));
+        verify(os, times(2)).createPit("encounter");
+    }
+
+    @Test void persistentStalePit_givesUpAfterBoundedAttempts() throws Exception {
+        OpenSearch os = spyOs();
+
+        doThrow(respEx(404, STALE_BODY)).when(os).getRestResponse(any(Request.class));
+        IOException ex = assertThrows(IOException.class,
+            () -> os.queryPit("encounter", new JSONObject(), 0, 10, null, null));
+        assertTrue(ex.getMessage().contains("failed to POST query"));
+        verify(os, times(6)).getRestResponse(any(Request.class));
+    }
+
+    @Test void bare404WithoutStaleContextBody_isNotRetried() throws Exception {
+        OpenSearch os = spyOs();
+
+        // e.g. a routing/proxy 404 - deterministic, must not burn 6 PITs
+        doThrow(respEx(404, "{\"error\":\"no handler found for uri\"}"))
+            .when(os).getRestResponse(any(Request.class));
+        assertThrows(ResponseException.class,
+            () -> os.queryPit("encounter", new JSONObject(), 0, 10, null, null));
+        verify(os, times(1)).getRestResponse(any(Request.class));
+    }
+
+    @Test void retryBudgetIsPerCall_notPerInstance() throws Exception {
+        OpenSearch os = spyOs();
+
+        // exhaust one call's budget...
+        doThrow(respEx(404, STALE_BODY)).when(os).getRestResponse(any(Request.class));
+        assertThrows(IOException.class,
+            () -> os.queryPit("encounter", new JSONObject(), 0, 10, null, null));
+        // ...then a fresh call on the SAME instance must get a full budget again
+        doThrow(respEx(404, STALE_BODY)).doReturn("{\"hits\":{\"hits\":[]}}")
+            .when(os).getRestResponse(any(Request.class));
+        JSONObject res = os.queryPit("encounter", new JSONObject(), 0, 10, null, null);
+        assertNotNull(res.optJSONObject("hits"));
+    }
+}

--- a/src/test/java/org/ecocean/OpenSearchQueryPitRetryTest.java
+++ b/src/test/java/org/ecocean/OpenSearchQueryPitRetryTest.java
@@ -56,7 +56,7 @@ class OpenSearchQueryPitRetryTest {
             OpenSearch.PIT_CACHE.put(inv.getArgument(0), "pit-1");
             return "pit-1";
         }).when(os).createPit(anyString());
-        doNothing().when(os).deletePit(anyString());
+        doNothing().when(os).deletePitId(anyString());
         return os;
     }
 
@@ -69,7 +69,19 @@ class OpenSearchQueryPitRetryTest {
         verify(os, times(1)).getRestResponse(any(Request.class));
         // the cached PIT is discarded even on non-retryable failures - a possibly-bad
         // cached PIT must never poison every subsequent search on the index
-        verify(os, times(1)).deletePit("encounter");
+        verify(os, times(1)).deletePitId("pit-1");
+        assertFalse(OpenSearch.PIT_CACHE.containsKey("encounter"));
+    }
+
+    @Test void discardNeverDeletesAConcurrentRequestsFreshPit() throws Exception {
+        OpenSearch os = spyOs();
+
+        // while OUR search was failing, a concurrent request replaced our stale pit-1
+        // with its own fresh pit-2; discarding pit-1 must leave pit-2 untouched
+        OpenSearch.PIT_CACHE.put("encounter", "pit-2");
+        os.discardPitQuietly("encounter", "pit-1");
+        assertEquals("pit-2", OpenSearch.PIT_CACHE.get("encounter"));
+        verify(os, never()).deletePitId(anyString());
     }
 
     @Test void stalePit_retriedOnceWithFreshPit() throws Exception {

--- a/src/test/java/org/ecocean/api/SearchApiPaginationWindowTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiPaginationWindowTest.java
@@ -64,6 +64,12 @@ class SearchApiPaginationWindowTest {
             doNothing().when(m).rollbackAndClose();
             when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
             when(user.isAdmin(m)).thenReturn(false);
+            // let the REAL OpenSearch.queryStore run against this mock: makePersistent is a
+            // no-op on the mock PM, the commit reports success, and the re-begun transaction
+            // reads as active (same pattern as SearchApiChildIndexTest)
+            when(m.getPM()).thenReturn(mock(javax.jdo.PersistenceManager.class));
+            when(m.commitDBTransactionWithStatus()).thenReturn(true);
+            when(m.isDBTransactionActive()).thenReturn(true);
         });
     }
 

--- a/src/test/java/org/ecocean/api/SearchApiPaginationWindowTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiPaginationWindowTest.java
@@ -132,6 +132,32 @@ class SearchApiPaginationWindowTest {
         verify(response).setHeader("X-Wildbook-Max-Result-Window", "10000");
     }
 
+    // a broken window value from the backend (mock default 0, misconfigured index)
+    // falls back to the default ceiling instead of rejecting every request
+    @Test void nonPositiveWindow_fallsBackToDefault() throws Exception {
+        when(request.getParameter("from")).thenReturn("9990");
+        when(request.getParameter("size")).thenReturn("10");
+        User user = mockUser("u1");
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user);
+            MockedConstruction<OpenSearch> os = openSearchWithWindow(0)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+        verify(response).setHeader("X-Wildbook-Max-Result-Window", "10000");
+    }
+
+    // size=0 (aggregation-style) stays valid, including exactly at the window boundary
+    @Test void sizeZeroAtWindowBoundary_isAllowed() throws Exception {
+        when(request.getParameter("from")).thenReturn("10000");
+        when(request.getParameter("size")).thenReturn("0");
+        User user = mockUser("u1");
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user);
+            MockedConstruction<OpenSearch> os = openSearchWithWindow(10000)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+    }
+
     // the check uses the PER-INDEX window (which Wildbook raises above 10k on big indexes)
     @Test void perIndexWindowIsRespected() throws Exception {
         when(request.getParameter("from")).thenReturn("12000");

--- a/src/test/java/org/ecocean/api/SearchApiPaginationWindowTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiPaginationWindowTest.java
@@ -1,0 +1,146 @@
+package org.ecocean.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.ecocean.OpenSearch;
+import org.ecocean.User;
+import org.ecocean.security.WildbookTokenAuthenticationFilter;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+class SearchApiPaginationWindowTest {
+    HttpServletRequest request;
+    HttpServletResponse response;
+    StringWriter out;
+    MockedStatic<ServletUtilities> su;
+
+    @BeforeEach void setUp() throws Exception {
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        out = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(out));
+        when(request.getServletContext()).thenReturn(null);
+        when(request.getContextPath()).thenReturn("");
+        when(request.getParameter(anyString())).thenReturn(null);
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(Boolean.TRUE);
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn("Bearer x");
+        su = mockStatic(ServletUtilities.class);
+        su.when(() -> ServletUtilities.getContext(any())).thenReturn("context0");
+        su.when(() -> ServletUtilities.jsonFromHttpServletRequest(any()))
+            .thenReturn(new JSONObject("{\"query\":{\"match_all\":{}}}"));
+    }
+
+    @AfterEach void tearDown() {
+        su.close();
+    }
+
+    private User mockUser(String id) {
+        User u = mock(User.class);
+
+        when(u.getId()).thenReturn(id);
+        when(u.getUUID()).thenReturn(id);
+        return u;
+    }
+
+    private MockedConstruction<Shepherd> shepherdReturning(User user) {
+        return mockConstruction(Shepherd.class, (m, c) -> {
+            doNothing().when(m).beginDBTransaction();
+            doNothing().when(m).setAction(anyString());
+            doNothing().when(m).rollbackAndClose();
+            when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
+            when(user.isAdmin(m)).thenReturn(false);
+        });
+    }
+
+    private static final JSONObject EMPTY_HITS =
+        new JSONObject("{\"hits\":{\"total\":{\"value\":0},\"hits\":[]}}");
+
+    private MockedConstruction<OpenSearch> openSearchWithWindow(int window) {
+        return mockConstruction(OpenSearch.class, (m, c) -> {
+            when(m.getMaxResultWindow(anyString())).thenReturn(window);
+            doNothing().when(m).deletePit(anyString());
+            when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(), any(), any()))
+                .thenReturn(EMPTY_HITS);
+        });
+    }
+
+    // from+size beyond the window -> 400 with the limit in the payload; OpenSearch never queried
+    @Test void beyondWindow_returns400_withoutQuerying() throws Exception {
+        when(request.getParameter("from")).thenReturn("147060");
+        when(request.getParameter("size")).thenReturn("20");
+        User user = mockUser("u1");
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user);
+            MockedConstruction<OpenSearch> os = openSearchWithWindow(10000)) {
+            new SearchApi().doPost(request, response);
+            verify(os.constructed().get(0), never()).queryPit(anyString(), any(JSONObject.class),
+                anyInt(), anyInt(), any(), any());
+        }
+        verify(response).setStatus(400);
+        JSONObject body = new JSONObject(out.toString());
+        assertEquals(10000, body.getInt("maxResultWindow"));
+        assertTrue(body.getString("error").contains("from + size"));
+    }
+
+    // integer-overflow pagination values must not slip past the window check
+    @Test void overflowingFromPlusSize_returns400() throws Exception {
+        when(request.getParameter("from")).thenReturn(Integer.toString(Integer.MAX_VALUE - 5));
+        when(request.getParameter("size")).thenReturn("1000");
+        User user = mockUser("u1");
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user);
+            MockedConstruction<OpenSearch> os = openSearchWithWindow(10000)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(400);
+    }
+
+    @Test void negativeFrom_returns400() throws Exception {
+        when(request.getParameter("from")).thenReturn("-5");
+        when(request.getParameter("size")).thenReturn("10");
+        User user = mockUser("u1");
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user);
+            MockedConstruction<OpenSearch> os = openSearchWithWindow(10000)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(400);
+    }
+
+    // valid pagination -> 200, and the live window limit is exposed as a response header
+    @Test void withinWindow_succeeds_andExposesWindowHeader() throws Exception {
+        when(request.getParameter("from")).thenReturn("9990");
+        when(request.getParameter("size")).thenReturn("10");
+        User user = mockUser("u1");
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user);
+            MockedConstruction<OpenSearch> os = openSearchWithWindow(10000)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+        verify(response).setHeader("X-Wildbook-Max-Result-Window", "10000");
+    }
+
+    // the check uses the PER-INDEX window (which Wildbook raises above 10k on big indexes)
+    @Test void perIndexWindowIsRespected() throws Exception {
+        when(request.getParameter("from")).thenReturn("12000");
+        when(request.getParameter("size")).thenReturn("4");
+        User user = mockUser("u1");
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user);
+            MockedConstruction<OpenSearch> os = openSearchWithWindow(12004)) {
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(200);
+    }
+}


### PR DESCRIPTION
Fixes #1680

## What

- **`SearchApi`**: `from`/`size` are validated up front against the index's live `max_result_window` (read via `getSettings`, 60s cache, default 10000). Requests beyond the window get a clean **400** with the limit in the payload instead of a 500, before the query is stored or executed. The ceiling is exposed as **`X-Wildbook-Max-Result-Window`** so the frontend can cap its paginator (frontend PR for #1681 consumes it). Overflow-safe (`long` addition); `size=0` aggregation-style queries remain valid, including exactly at the boundary.
- **`OpenSearch.queryPit`**: rewritten as an iterative loop with a **local per-call retry budget**, replacing the racy `pitRetry` instance field (which was also never reset on the give-up path). Retries happen **only** for typed stale-PIT causes (`search_context_missing` / `No search context found`); every other `ResponseException` — including the result-window rejection — propagates after a single attempt instead of executing the same failing query six times with a fresh PIT each attempt.
- **PIT hygiene**: on any failed search the cached PIT id this request used is discarded (best-effort server-side delete) so a bad cached PIT cannot poison subsequent searches — but only if the cache still holds *this request's* PIT, so cleanup never destroys a fresh PIT installed by a concurrent request.

## Why

Production incident 2026-07-10: a user paginated deep into a ~147k-hit encounter search; OpenSearch rejected `from+size=147080` (> the index's 12,004 window) with a 400; `queryPit` retried the deterministic failure 6x per click, creating a PIT per attempt; the client saw a 500 and the UI showed an empty page, prompting repeated retries.

Note the ceiling is **per-index config, not always 10k** — Wildbook itself raises `index.max_result_window` on indexes past 10k docs, so validation reads the live setting.

## Tests

- `OpenSearchQueryPitRetryTest` (new): runs the real `queryPit` loop against constructed `ResponseException`s — deterministic 400 → single attempt + own-PIT discard; stale PIT → retry with fresh PIT; persistent stale → bounded at 6 attempts; bare 404 → no retry; retry budget is per-call, not per-instance.
- `OpenSearchPaginationTest` (new): window parsing (string/int/missing/garbage/non-positive) and retry classification.
- `SearchApiPaginationWindowTest` (new): 400 beyond window (with limit in body, query never executed), overflow guard, negative `from`, header exposure, per-index window respected, `size=0` boundary, non-positive-window fallback.
- Existing `SearchApiChildIndexTest` + token-scope/auth/media suites: all green (73 tests).

Reviewed by Codex (gpt-5.6, high reasoning), two rounds: all four round-1 findings addressed; round 2 returned no Major findings and one Medium (concurrent-PIT discard race), fixed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)