### PR TITLE
Apply Search ID: durable DB-backed stored queries + frontend fixes (#1500)

### DIFF
--- a/docs/superpowers/plans/2026-07-13-issue-1500-apply-search-id.md
+++ b/docs/superpowers/plans/2026-07-13-issue-1500-apply-search-id.md
@@ -1,0 +1,445 @@
+# Issue #1500 — Apply Search ID Fix Implementation Plan (rev 2, post-Codex)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make shared search-query IDs durable (DB-backed instead of `/tmp` files) and fix the frontend defects that make the Apply Search ID feature fail or mislead.
+
+**Architecture:** Replace the `/tmp/OpenSearch-query-<uuid>.json` file storage behind `OpenSearch.queryStore`/`queryLoad` with a minimal JDO entity `org.ecocean.OpenSearchQuery` (id PK, JSON value, indexed created). `queryStore` uses the **caller's** Shepherd on the **same connection**: persist → commit directly on the JDO transaction (so failures propagate — `Shepherd.commitDBTransaction()` swallows them) → re-begin, returning the ID only after a confirmed commit. No second connection per request (avoids pool self-starvation under `maxWait=-1`). Store failure = HTTP 503, not a silent 200. Opportunistic TTL pruning (default 90 days, at most hourly) bounds growth. Frontend: unify the two Apply navigation paths, remove every `"defaultSearchQueryId"` sentinel, gate the stray default POST on the apply-ID page, and route the *applied* query ID to export/map integrations.
+
+**Tech Stack:** Java 11 servlet + DataNucleus JDO (Postgres), JUnit 5 + Mockito + Testcontainers, React 18 + react-query v3 + jest.
+
+## Global Constraints
+
+- Worktree: `/mnt/c/Wildbook-searchid`, branch `fix/issue-1500-stored-query-durability` off `origin/main`.
+- After EVERY Edit/Write of a tracked file: `perl -i -pe 's/\r\n/\n/g' <file>` then `grep -cP '\r$' <file>` must print 0.
+- No new user-visible UI copy (avoids the 5-language i18n requirement). Do not add new locale keys.
+- JUnit 5 assertion message parameter goes LAST.
+- The stored-query JSON returned by `queryLoad` must keep the exact merged shape the file version had: top-level query body plus `id`, `indexName`, `created`, `creator` keys (downstream `queryScrubStored`, creator ownership check, and `indexName` read all depend on it).
+- `queryStore`'s contract: caller holds an open transaction with **no uncommitted writes** (SearchApi's is read-only); queryStore commits it and re-begins. Document this at the method and the call site.
+- `mvn clean install` must pass (gates CI). `npx jest` on touched frontend test files must pass locally (CI hides jest failures).
+
+---
+
+### Task 1: `OpenSearchQuery` JDO entity + storage swap in `OpenSearch`
+
+**Files:**
+- Create: `src/main/java/org/ecocean/OpenSearchQuery.java`
+- Modify: `src/main/resources/org/ecocean/package.jdo` (after the `SystemValue` class block, ~line 1000)
+- Modify: `src/main/java/org/ecocean/OpenSearch.java:96-98` (remove `QUERY_STORAGE_DIR`), `:1537-1568` (`queryStoragePath`/`queryStore`/`queryLoad`)
+- Modify: `src/main/java/org/ecocean/api/SearchApi.java:69,164-166` (+ 503 branch)
+- Modify: `src/main/java/org/ecocean/EncounterQueryProcessor.java:63,1582`
+
+**Interfaces:**
+- Produces: `OpenSearch.queryStore(JSONObject query, String indexName, User user, Shepherd myShepherd)` → String id (null ⇔ not durably stored); `OpenSearch.queryLoad(String id, Shepherd myShepherd)` → merged JSONObject or null; `OpenSearch.queryPrune(Shepherd myShepherd, long cutoffMs)` → long deleted-count; entity helper `OpenSearchQuery.load(Shepherd, String id)`.
+
+- [ ] **Step 1: Write the entity** — `src/main/java/org/ecocean/OpenSearchQuery.java`:
+
+```java
+package org.ecocean;
+
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+
+/**
+ * Durable storage for a stored OpenSearch query (see SearchApi "searchQueryId").
+ * The value column holds the merged JSON previously written to a /tmp file:
+ * the original query body plus id, indexName, created, creator.
+ */
+public class OpenSearchQuery implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+    private String id;
+    private String value;
+    private long created;
+
+    public OpenSearchQuery() {}
+
+    public OpenSearchQuery(String id, JSONObject value, long created) {
+        this.id = id;
+        if (value != null) this.value = value.toString();
+        this.created = created;
+    }
+
+    public String getId() { return id; }
+    public long getCreated() { return created; }
+
+    public JSONObject getValue() {
+        return Util.stringToJSONObject(value);
+    }
+
+    public static OpenSearchQuery load(Shepherd myShepherd, String id) {
+        if (id == null) return null;
+        try {
+            return ((OpenSearchQuery)(myShepherd.getPM().getObjectById(
+                myShepherd.getPM().newObjectIdInstance(OpenSearchQuery.class, id), true)));
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: JDO mapping** — in `src/main/resources/org/ecocean/package.jdo`, immediately after the `SystemValue` `</class>` block (check the file's existing `<index>` syntax — e.g. grep `<index` — and match it; intended shape):
+
+```xml
+	<class name="OpenSearchQuery">
+		<field name="id" primary-key="true" />
+		<field name="created">
+			<column allows-null="true" />
+			<index name="OPENSEARCHQUERY_CREATED_IDX" />
+		</field>
+		<field name="value">
+			<column jdbc-type="LONGVARCHAR" />
+		</field>
+	</class>
+```
+
+- [ ] **Step 3: Swap storage in `OpenSearch.java`.** Remove `public static String QUERY_STORAGE_DIR = "/tmp"; // FIXME` and `queryStoragePath`. Replace `queryStore`/`queryLoad`, add `queryPrune` + prune clock:
+
+```java
+    // stored search queries: pruned opportunistically at most every PRUNE_INTERVAL
+    static final long QUERY_PRUNE_INTERVAL_MILLIS = 3600000L;  // 1 hour
+    static final int QUERY_TTL_DAYS_DEFAULT = 90;
+    private static volatile long queryLastPruneMillis = 0L;
+
+    /**
+     * Persist a stored query durably. Uses the CALLER's Shepherd/connection: commits the
+     * caller's open transaction (which must hold no other uncommitted writes — SearchApi's is
+     * read-only) via commitDBTransactionWithStatus() so commit failure is detectable (plain
+     * commitDBTransaction() swallows it), then re-begins a transaction for the remainder of
+     * the request. Returns the new id ONLY after a CONFIRMED commit; null ⇔ durability not
+     * confirmed. A confirmed commit followed by a failed re-begin still returns the id —
+     * callers needing further DB reads must check myShepherd.isDBTransactionActive().
+     */
+    public static String queryStore(final JSONObject query, final String indexName,
+        final User user, final Shepherd myShepherd) {
+        if ((query == null) || (user == null) || (myShepherd == null)) return null;
+        JSONObject stored = new JSONObject(query.toString());
+        String id = Util.generateUUID();
+        long now = System.currentTimeMillis();
+        stored.put("id", id);
+        stored.put("indexName", indexName);
+        stored.put("created", now);
+        stored.put("creator", user.getUUID());
+        boolean committed = false;
+        try {
+            myShepherd.getPM().makePersistent(new OpenSearchQuery(id, stored, now));
+            if ((now - queryLastPruneMillis) > QUERY_PRUNE_INTERVAL_MILLIS) {
+                queryLastPruneMillis = now;
+                int ttlDays = (Integer)getConfigurationValue("searchQueryTtlDays",
+                    QUERY_TTL_DAYS_DEFAULT);
+                queryPrune(myShepherd, now - ttlDays * 86400000L);
+            }
+            committed = myShepherd.commitDBTransactionWithStatus();
+        } catch (Exception ex) {
+            System.out.println("OpenSearch.queryStore() failed to store " + id + ": " + ex);
+            ex.printStackTrace();
+        }
+        if (!committed) {
+            myShepherd.rollbackDBTransaction();
+            myShepherd.beginDBTransaction();
+            return null;
+        }
+        myShepherd.beginDBTransaction(); // recover a transaction for the rest of the request
+        return id;
+    }
+
+    // deletes stored queries with created < cutoffMillis; runs in the caller's transaction
+    public static long queryPrune(final Shepherd myShepherd, final long cutoffMillis) {
+        try {
+            javax.jdo.Query q = myShepherd.getPM().newQuery(OpenSearchQuery.class,
+                "created < " + cutoffMillis);
+            long ct = q.deletePersistentAll();
+            if (ct > 0)
+                System.out.println("OpenSearch.queryPrune() deleted " + ct
+                    + " stored queries older than " + new java.util.Date(cutoffMillis));
+            return ct;
+        } catch (Exception ex) {
+            System.out.println("OpenSearch.queryPrune() failed: " + ex);
+            return 0;
+        }
+    }
+
+    public static JSONObject queryLoad(String id, Shepherd myShepherd) {
+        OpenSearchQuery osq = OpenSearchQuery.load(myShepherd, id);
+
+        if (osq == null) return null;
+        return osq.getValue();
+    }
+```
+
+Note: `Shepherd` import already present in `OpenSearch.java` (line 21). Prune failure is swallowed on purpose (logged) — it must never break the store; a prune *exception mid-transaction* is covered by the outer catch (rollback + re-begin + null) which is acceptable-rare.
+
+- [ ] **Step 4: Update call sites.**
+  - `SearchApi.java:69`: `query = OpenSearch.queryLoad(searchQueryId, myShepherd);`
+  - `SearchApi.java` store block (~line 164): replace
+    ```java
+    if (newQueryToStore) {
+        searchQueryId = OpenSearch.queryStore(query, indexName, currentUser);
+    }
+    ```
+    with a fail-closed version — a search whose response promises a share ID must not 200 without one:
+    ```java
+    boolean storeFailed = false;
+    boolean sessionRecoveryFailed = false;
+    if (newQueryToStore) {
+        // commits + re-begins myShepherd's (read-only so far) transaction; see queryStore javadoc
+        searchQueryId = OpenSearch.queryStore(query, indexName, currentUser, myShepherd);
+        storeFailed = (searchQueryId == null);
+        // commit confirmed but the request's transaction could not be re-established:
+        // the id IS durable, but sanitizeDoc etc. need live DB reads — fail the request
+        // WITHOUT claiming the store failed, and hand back the (valid) id.
+        sessionRecoveryFailed = !storeFailed && !myShepherd.isDBTransactionActive();
+    }
+    if (storeFailed) {
+        response.setStatus(503);
+        res.put("success", false);
+        res.put("error", "failed to store search query");
+    } else if (sessionRecoveryFailed) {
+        response.setStatus(503);
+        res.put("success", false);
+        res.put("error", "search query stored but request could not continue; retry");
+        res.put("searchQueryId", searchQueryId);
+        response.setHeader("X-Wildbook-Search-Query-Id", searchQueryId);
+    } else {
+        ... existing applyAclFilter + execution block, unchanged ...
+    }
+    ```
+    (`boolean storeFailed` declared where `newQueryToStore` is; the existing execution block from `if (tokenAuth && !isAdmin)` through the `catch (IOException ex)` moves inside the `else`. Keep indentation minimal per the repo's leak-fix diff convention — do NOT reindent the moved block; add the wrapper braces at the surrounding indent level.)
+  - `EncounterQueryProcessor.java:63` and `:1582`: `OpenSearch.queryLoad(searchQueryId, myShepherd);` (both have `myShepherd` in scope — verify variable name at each site).
+
+- [ ] **Step 5: Compile** — `cd /mnt/c/Wildbook-searchid && mvn compile -q 2>&1 | tail -20`. Expected: BUILD SUCCESS.
+
+- [ ] **Step 6: Normalize CRLF on all touched files, then commit**
+
+```bash
+git add src/main/java/org/ecocean/OpenSearchQuery.java src/main/resources/org/ecocean/package.jdo \
+  src/main/java/org/ecocean/OpenSearch.java src/main/java/org/ecocean/api/SearchApi.java \
+  src/main/java/org/ecocean/EncounterQueryProcessor.java
+git commit -m "store search queries in the database instead of /tmp files"
+```
+
+### Task 2: Tests — real-queryStore roundtrip + mock updates + failure-contract tests
+
+**Files:**
+- Create: `src/test/java/org/ecocean/OpenSearchQueryStoreTest.java`
+- Modify: `src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java`
+- Modify: `src/test/java/org/ecocean/api/SearchApiChildIndexTest.java` (queryLoad stubs at lines ~276, 293)
+- Audit: every test in both classes that drives a direct POST **without** `mockStatic(OpenSearch.class)` — the real `queryStore(..., mockShepherd)` would NPE on the mocked PM; add an `osStatic` with a `queryStore` stub (or widen an existing one) to each. Find them by running the suite and fixing every new failure — do not guess.
+
+**Interfaces:**
+- Consumes: Task 1 signatures exactly: `queryStore(JSONObject, String, User, Shepherd)`, `queryLoad(String, Shepherd)`, `queryPrune(Shepherd, long)`.
+
+- [ ] **Step 1: Update existing stubs.** `queryLoad(anyString())` → `queryLoad(anyString(), any())` in both test classes. Where a test asserts the POST response carries `searchQueryId`, stub `osStatic.when(() -> OpenSearch.queryStore(any(), anyString(), any(), any())).thenReturn("<uuid literal>")`.
+
+- [ ] **Step 2: Add contract tests** in `SearchApiTokenAuthTest` (reuse `mockUser`, `shepherdReturning`, `su`, `EMPTY_HITS`):
+
+Test A — session path returns the stored id (must FORCE session mode: `when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR)).thenReturn(null);` and no Authorization header — the class `@BeforeEach` defaults the attr to TRUE):
+
+```java
+    @Test void sessionPost_storesQuery_andReturnsSearchQueryId() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null); // session path
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class)) {
+            osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(true);
+            osStatic.when(() -> OpenSearch.querySanitize(any(), any(), any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+            osStatic.when(() -> OpenSearch.queryStore(any(), anyString(), any(), any()))
+                .thenReturn("11111111-2222-3333-4444-555555555555");
+            try (MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(), any(),
+                    any())).thenReturn(EMPTY_HITS);
+            })) {
+                new SearchApi().doPost(request, response);
+            }
+        }
+        verify(response).setStatus(200);
+        verify(response).setHeader("X-Wildbook-Search-Query-Id",
+            "11111111-2222-3333-4444-555555555555");
+        assertTrue(out.toString().contains("11111111-2222-3333-4444-555555555555"),
+            "response body carries searchQueryId");
+    }
+```
+
+Test B — store failure is 503 and the search does NOT execute:
+
+```java
+    @Test void post_storeFailure_returns503_andDoesNotExecute() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null);
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class)) {
+            osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(true);
+            osStatic.when(() -> OpenSearch.querySanitize(any(), any(), any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+            osStatic.when(() -> OpenSearch.queryStore(any(), anyString(), any(), any()))
+                .thenReturn(null); // store failed
+            try (MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+            })) {
+                new SearchApi().doPost(request, response);
+                assertEquals(0, os.constructed().size() == 0 ? 0
+                    : mockingDetails(os.constructed().get(0)).getInvocations().size(),
+                    "no search executed after store failure");
+            }
+        }
+        verify(response).setStatus(503);
+        assertTrue(out.toString().contains("failed to store search query"),
+            "error surfaced in body");
+    }
+```
+
+(If the no-execution assertion is awkward, assert instead that `queryPit` was never invoked on any constructed mock — implementer's choice, but some no-execution assertion must exist.)
+
+- [ ] **Step 3: Testcontainers test through the REAL `queryStore`** — `src/test/java/org/ecocean/OpenSearchQueryStoreTest.java`. Postgres container only; copy the PMF boilerplate from `SearchTokenScopeTest`: `TestPMFUtil.closePMF("context0")` in `@BeforeAll` AND `@AfterAll`, `CommonConfiguration.initialize("context0", props)` minimal, `new Shepherd("context0", dnProperties())` primes the global PMF cache. Body:
+
+```java
+    @Test void queryStoreRoundtripAndPrune() {
+        // seed a real user (queryStore reads getUUID())
+        Shepherd seeder = new Shepherd("context0", dnProperties());
+        seeder.setAction("OpenSearchQueryStoreTest.seed");
+        User user;
+        seeder.beginDBTransaction();
+        try {
+            user = new User("osqtester",
+                ServletUtilities.hashAndSaltPassword("pw", ServletUtilities.getSalt().toHex()),
+                "salt");
+            seeder.getPM().makePersistent(user);
+            seeder.commitDBTransaction();
+        } finally {
+            seeder.rollbackAndClose();
+        }
+
+        // store through the REAL path: persist + direct-commit + re-begin
+        Shepherd writer = new Shepherd("context0", dnProperties());
+        writer.setAction("OpenSearchQueryStoreTest.write");
+        writer.beginDBTransaction();
+        String id;
+        try {
+            JSONObject query = new JSONObject().put("query",
+                new JSONObject().put("match_all", new JSONObject()));
+            id = OpenSearch.queryStore(query, "encounter", user, writer);
+            assertNotNull(id, "queryStore returns id after confirmed commit");
+            assertTrue(writer.getPM().currentTransaction().isActive(),
+                "queryStore re-begins the caller transaction");
+        } finally {
+            writer.rollbackAndClose();
+        }
+
+        // load from a SEPARATE Shepherd: durability + merged shape
+        Shepherd reader = new Shepherd("context0", dnProperties());
+        reader.setAction("OpenSearchQueryStoreTest.read");
+        reader.beginDBTransaction();
+        try {
+            JSONObject loaded = OpenSearch.queryLoad(id, reader);
+            assertNotNull(loaded, "stored query loads back");
+            assertEquals("encounter", loaded.optString("indexName"), "indexName survives");
+            assertEquals(user.getUUID(), loaded.optString("creator"), "creator survives");
+            assertEquals(id, loaded.optString("id"), "id embedded in stored doc");
+            assertNotNull(loaded.optJSONObject("query"), "query body survives");
+            assertNull(OpenSearch.queryLoad(Util.generateUUID(), reader), "unknown id is null");
+        } finally {
+            reader.rollbackAndClose();
+        }
+
+        // prune: older-than-cutoff rows deleted, newer kept
+        Shepherd pruner = new Shepherd("context0", dnProperties());
+        pruner.setAction("OpenSearchQueryStoreTest.prune");
+        pruner.beginDBTransaction();
+        try {
+            pruner.getPM().makePersistent(new OpenSearchQuery("old-one",
+                new JSONObject().put("query", new JSONObject()), 1000L));
+            pruner.commitDBTransaction();
+            pruner.beginDBTransaction();
+            OpenSearch.queryPrune(pruner, 2000L);
+            pruner.commitDBTransaction();
+            pruner.beginDBTransaction();
+            assertNull(OpenSearchQuery.load(pruner, "old-one"), "old row pruned");
+            assertNotNull(OpenSearchQuery.load(pruner, id), "fresh row kept");
+        } finally {
+            pruner.rollbackAndClose();
+        }
+    }
+```
+
+- [ ] **Step 4: Run backend tests** — `mvn test -q 2>&1 | tail -40`. Fix EVERY failure from the signature change per the audit note above. E2E `SearchTokenScopeTest`/`ChildIndex` exercise the real DB-backed store via the primed PMF cache — they must stay green with zero test-side changes (they are the regression guard for the implicit global-PMF wiring).
+
+- [ ] **Step 5: Normalize CRLF, commit** — `git commit -m "test: stored-query durable roundtrip, store-failure 503 contract, prune"`.
+
+### Task 3: Frontend — unify Apply navigation, kill the sentinel everywhere, gate the stray POST, route applied ID to exports
+
+**Files:**
+- Modify: `frontend/src/components/filterFields/ApplyQueryFilter.jsx`
+- Modify: `frontend/src/models/encounters/useFilterEncounters.js`
+- Modify: `frontend/src/models/encounters/useFilterEncountersAll.js` (sentinel only)
+- Modify: `frontend/src/models/encounters/useFilterEncountersWithMediaAssets.js` (sentinel only)
+- Modify: `frontend/src/pages/SearchPages/EncounterSearch.jsx`
+- Modify: `frontend/src/components/filterFields/SideBar.jsx`
+- Test: `frontend/src/__tests__/pages/EncounterSearchPageAndFilters/ApplyQueryFilter.test.js`
+- Test: `frontend/src/__tests__/pages/EncounterSearchPageAndFilters/EncounterSearch.test.js`
+
+- [ ] **Step 1: `ApplyQueryFilter.jsx`** — single `applyId` used by both Enter and click; trim + URL-encode; both use `PUBLIC_URL`:
+
+```jsx
+  const applyId = () => {
+    const trimmed = queryId.trim();
+    if (trimmed) {
+      window.location.href = `${process.env.PUBLIC_URL}/encounter-search?searchQueryId=${encodeURIComponent(trimmed)}`;
+    }
+  };
+```
+
+`onKeyDown`: `if (e.key === "Enter") { e.preventDefault(); applyId(); }` (preventDefault stops the form's default submit-reload). Button `onClick={applyId}`.
+
+- [ ] **Step 2: `useFilterEncounters.js`** — accept `enabled = true` param; replace `enable: false` with `enabled`; sentinel → `""`:
+
+```js
+export default function useFilterEncounters({ queries, params = {}, enabled = true }) {
+  ...
+    queryOptions: {
+      retry: 2,
+      enabled,
+    },
+```
+
+and `searchQueryId: get(result, ["data", "data", "searchQueryId"], "")`. Same sentinel replacement (only) in `useFilterEncountersAll.js` and `useFilterEncountersWithMediaAssets.js` — check no caller compares against the literal string first (`grep -rn defaultSearchQueryId frontend/src`).
+
+- [ ] **Step 3: `EncounterSearch.jsx`** — `useFilterEncounters({ queries: ..., params: ..., enabled: !queryID })`; `<DataTable searchQueryId={queryID || searchQueryId} ...>`; `<ExportModal searchQueryId={queryID || searchQueryId} ...>`.
+
+- [ ] **Step 4: `SideBar.jsx`** — first line of `handleCopy`: `const idToCopy = queryID || searchQueryId; if (!idToCopy) return;` (no new UI copy).
+
+- [ ] **Step 5: Update/extend jest tests.**
+  - `ApplyQueryFilter.test.js`: Enter/click expectations become the same URL (PUBLIC_URL is `""` under jest); add trim case (`"  12345  "` → `/encounter-search?searchQueryId=12345`) and whitespace-only no-redirect case.
+  - `EncounterSearch.test.js`: with `?searchQueryId=<uuid>` mounted (mock `useSearchParams`/router as the suite already does), assert (a) axios GET `/api/v3/search/<uuid>` is called, (b) the default POST (`useFetch`→axios POST `/api/v3/search/encounter`) is NOT (mock axios and inspect calls), (c) on GET rejection the component clears queryID (alert mocked) and the POST becomes enabled. Follow the suite's existing mocking idiom — read it first; if (c) is impractical in the current harness, cover (a)+(b) and note (c) as manual verification in the PR.
+
+- [ ] **Step 6: Run** — `cd frontend && npx jest src/__tests__/pages/EncounterSearchPageAndFilters/ --silent 2>&1 | tail -15`. Expected: PASS.
+
+- [ ] **Step 7: Normalize CRLF, commit** — `git commit -m "fix Apply Search ID frontend: unify navigation, gate default POST on apply page, no fake fallback id"`.
+
+### Task 4: Full verification + PR
+
+- [ ] **Step 1:** `mvn clean install -q 2>&1 | tail -15` — BUILD SUCCESS, 0 test failures.
+- [ ] **Step 2:** `cd frontend && npx jest --silent 2>&1 | tail -10` — no NEW failures vs main baseline (run baseline on a clean main checkout of the same files if unsure).
+- [ ] **Step 3:** `git diff origin/main --stat` and `git diff origin/main --ignore-cr-at-eol --stat` must match (no CRLF churn).
+- [ ] **Step 4:** Codex review of the full diff (codex-review skill), iterate to convergence.
+- [ ] **Step 5:** Push; PR against `main`, milestone 10.12 (`gh api -X PATCH repos/WildMeOrg/Wildbook/issues/<n> -F milestone=24`). PR body must include:
+  - diagnosis summary + fixes, references #1500;
+  - **deployment note:** table `"OPENSEARCHQUERY"` is auto-created only when the effective DataNucleus props allow DDL (bundled default `datanucleus.schema.autoCreateAll=true`, but deployment override props may disable it / DB role may lack CREATE). Manual DDL fallback:
+    ```sql
+    CREATE TABLE "OPENSEARCHQUERY" ("ID" varchar(255) NOT NULL PRIMARY KEY,
+        "CREATED" bigint, "VALUE" text);
+    CREATE INDEX "OPENSEARCHQUERY_CREATED_IDX" ON "OPENSEARCHQUERY" ("CREATED");
+    ```
+    (verify the exact generated names against the Testcontainers DB during Task 2 and correct this DDL if DataNucleus names differ);
+  - retention: stored queries pruned after `searchQueryTtlDays` (default 90) — shared IDs now survive redeploys but not forever;
+  - old `/tmp` IDs are not migrated (already ephemeral);
+  - does NOT close the #1500 redesign discussion (filter-chip hydration etc.).
+
+**Out of scope (note in PR):** filter-chip hydration from a replayed query; i18n for SideBar's preexisting hardcoded alert strings; the `regularQuery` legacy JSP flows beyond passing the correct id.

--- a/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/ApplyQueryFilter.test.js
+++ b/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/ApplyQueryFilter.test.js
@@ -51,4 +51,34 @@ describe("ApplyQueryFilter Component", () => {
     fireEvent.click(button);
     expect(window.location.href).not.toBe("/encounter-search?searchQueryId=");
   });
+
+  it("trims surrounding whitespace from a pasted id", () => {
+    renderComponent();
+    const input = screen.getByPlaceholderText("Search ID");
+    fireEvent.change(input, { target: { value: "  12345  " } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    expect(window.location.href).toBe("/encounter-search?searchQueryId=12345");
+  });
+
+  it("does not redirect for whitespace-only input", () => {
+    renderComponent();
+    const input = screen.getByPlaceholderText("Search ID");
+    const button = screen.getByText("APPLY");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.click(button);
+
+    expect(typeof window.location.href).not.toBe("string");
+  });
+
+  it("URL-encodes the pasted id", () => {
+    renderComponent();
+    const input = screen.getByPlaceholderText("Search ID");
+    fireEvent.change(input, { target: { value: "abc/1?x=2" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    expect(window.location.href).toBe(
+      "/encounter-search?searchQueryId=abc%2F1%3Fx%3D2",
+    );
+  });
 });

--- a/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/EncounterSearch.test.js
+++ b/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/EncounterSearch.test.js
@@ -43,6 +43,7 @@ jest.mock("../../../components/DataTable", () => {
       <div data-testid="datatable-total-items">{props.totalItems}</div>
       <div data-testid="datatable-page">{props.page}</div>
       <div data-testid="datatable-per-page">{props.perPage}</div>
+      <div data-testid="datatable-search-query-id">{props.searchQueryId}</div>
       <button onClick={() => props.onRowClicked({ id: "enc1" })}>
         RowClick
       </button>
@@ -96,8 +97,11 @@ jest.mock("../../../components/filterFields/SideBar", () => {
 });
 
 jest.mock("../../../pages/SearchPages/components/ExportModal", () => {
-  const MockExportModal = ({ open }) => (
-    <div data-testid="export-modal">{open ? "open" : "closed"}</div>
+  const MockExportModal = ({ open, searchQueryId }) => (
+    <div data-testid="export-modal">
+      {open ? "open" : "closed"}
+      <div data-testid="export-modal-search-query-id">{searchQueryId}</div>
+    </div>
   );
 
   MockExportModal.displayName = "MockExportModal";
@@ -708,6 +712,60 @@ describe("EncounterSearch", () => {
     expect(useFilterEncounters).toHaveBeenCalledWith({
       queries: mockFilter,
       params: params,
+      enabled: true,
+    });
+  });
+
+  it("disables the default filter search while a queryID is applied", async () => {
+    jest.spyOn(axios, "get").mockResolvedValue({
+      data: { hits: [{ id: "encX" }] },
+      headers: { "x-wildbook-total-hits": "1" },
+    });
+
+    renderWithProviders("/search?searchQueryId=abc123");
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v3/search/abc123"),
+      );
+    });
+    expect(useFilterEncounters).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(useFilterEncounters).not.toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+
+  it("routes the applied queryID to DataTable and ExportModal", async () => {
+    jest.spyOn(axios, "get").mockResolvedValue({
+      data: { hits: [{ id: "encX" }] },
+      headers: { "x-wildbook-total-hits": "1" },
+    });
+
+    renderWithProviders("/search?searchQueryId=abc123");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("datatable-search-query-id")).toHaveTextContent(
+        "abc123",
+      );
+    });
+    expect(
+      screen.getByTestId("export-modal-search-query-id"),
+    ).toHaveTextContent("abc123");
+  });
+
+  it("re-enables the default filter search after a failed queryID fetch", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(window, "alert").mockImplementation(() => {});
+    jest.spyOn(axios, "get").mockRejectedValue(new Error("fail"));
+
+    renderWithProviders("/search?searchQueryId=abc123");
+
+    await waitFor(() => {
+      expect(useFilterEncounters).toHaveBeenCalledWith(
+        expect.objectContaining({ enabled: true }),
+      );
     });
   });
 

--- a/frontend/src/components/filterFields/ApplyQueryFilter.jsx
+++ b/frontend/src/components/filterFields/ApplyQueryFilter.jsx
@@ -8,6 +8,12 @@ import { useContext } from "react";
 export default function ApplyQueryFilter() {
   const theme = useContext(ThemeColorContext);
   const [queryId, setQueryId] = React.useState("");
+  const applyId = () => {
+    const trimmed = queryId.trim();
+    if (trimmed) {
+      window.location.href = `${process.env.PUBLIC_URL}/encounter-search?searchQueryId=${encodeURIComponent(trimmed)}`;
+    }
+  };
   return (
     <div>
       <h4>
@@ -30,8 +36,9 @@ export default function ApplyQueryFilter() {
             borderRadius: " 5px 0 0 5px",
           }}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && queryId) {
-              window.location.href = `/encounter-search?searchQueryId=${queryId}`;
+            if (e.key === "Enter") {
+              e.preventDefault();
+              applyId();
             }
           }}
           onChange={(e) => {
@@ -45,11 +52,7 @@ export default function ApplyQueryFilter() {
             borderRadius: "0 5px 5px 0",
             backgroundColor: theme.primaryColors.primary700,
           }}
-          onClick={() => {
-            if (queryId) {
-              window.location.href = `${process.env.PUBLIC_URL}/encounter-search?searchQueryId=${queryId}`;
-            }
-          }}
+          onClick={applyId}
         >
           <FormattedMessage id="APPLY" />
         </Button>

--- a/frontend/src/components/filterFields/SideBar.jsx
+++ b/frontend/src/components/filterFields/SideBar.jsx
@@ -24,6 +24,7 @@ const Sidebar = observer(
       // When viewing a result loaded from a shared query ID, copy that ID;
       // otherwise copy the ID freshly generated for the current filter search.
       const idToCopy = queryID || searchQueryId;
+      if (!idToCopy) return;
       if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard
           .writeText(idToCopy)

--- a/frontend/src/models/encounters/useFilterEncounters.js
+++ b/frontend/src/models/encounters/useFilterEncounters.js
@@ -33,7 +33,11 @@ function buildQuery(queries) {
   };
 }
 
-export default function useFilterEncounters({ queries, params = {} }) {
+export default function useFilterEncounters({
+  queries,
+  params = {},
+  enabled = true,
+}) {
   const boolQuery = buildQuery(queries);
   const compositeQuery = { query: { bool: boolQuery } };
   const { sortOrder, sort, size, from } = params;
@@ -59,17 +63,13 @@ export default function useFilterEncounters({ queries, params = {} }) {
       return {
         resultCount,
         results: get(result, ["data", "data", "hits"], []),
-        searchQueryId: get(
-          result,
-          ["data", "data", "searchQueryId"],
-          "defaultSearchQueryId",
-        ),
+        searchQueryId: get(result, ["data", "data", "searchQueryId"], ""),
         success: get(result, ["data", "data", "success"], false),
       };
     },
     queryOptions: {
       retry: 2,
-      enable: false,
+      enabled,
     },
   });
 }

--- a/frontend/src/models/encounters/useFilterEncountersAll.js
+++ b/frontend/src/models/encounters/useFilterEncountersAll.js
@@ -58,11 +58,7 @@ export default function useFilterEncountersAll({ queries, params = {} }) {
       return {
         resultCount,
         results: get(result, ["data", "data", "hits"], []),
-        searchQueryId: get(
-          result,
-          ["data", "data", "searchQueryId"],
-          "defaultSearchQueryId",
-        ),
+        searchQueryId: get(result, ["data", "data", "searchQueryId"], ""),
         success: get(result, ["data", "data", "success"], false),
       };
     },

--- a/frontend/src/models/encounters/useFilterEncountersWithMediaAssets.js
+++ b/frontend/src/models/encounters/useFilterEncountersWithMediaAssets.js
@@ -81,11 +81,7 @@ export default function useFilterEncountersWithMediaAssets({
       return {
         resultCount,
         results: get(result, ["data", "data", "hits"], []),
-        searchQueryId: get(
-          result,
-          ["data", "data", "searchQueryId"],
-          "defaultSearchQueryId",
-        ),
+        searchQueryId: get(result, ["data", "data", "searchQueryId"], ""),
         success: get(result, ["data", "data", "success"], false),
       };
     },

--- a/frontend/src/pages/SearchPages/EncounterSearch.jsx
+++ b/frontend/src/pages/SearchPages/EncounterSearch.jsx
@@ -76,6 +76,7 @@ const EncounterSearch = observer(() => {
       size: perPage,
       from: page * perPage,
     },
+    enabled: !queryID,
   });
 
   const { fetchMediaAssets } = useFilterEncountersWithMediaAssets({
@@ -316,7 +317,7 @@ const EncounterSearch = observer(() => {
       />
       <DataTable
         store={store}
-        searchQueryId={searchQueryId}
+        searchQueryId={queryID || searchQueryId}
         refetchMediaAssets={fetchMediaAssets}
         pg={pg}
         isLoading={loading}
@@ -368,7 +369,7 @@ const EncounterSearch = observer(() => {
       <ExportModal
         open={exportModalOpen}
         setOpen={setExportModalOpen}
-        searchQueryId={searchQueryId}
+        searchQueryId={queryID || searchQueryId}
       />
     </div>
   );

--- a/src/main/java/org/ecocean/EncounterQueryProcessor.java
+++ b/src/main/java/org/ecocean/EncounterQueryProcessor.java
@@ -60,7 +60,7 @@ public class EncounterQueryProcessor extends QueryProcessor {
                 List<String> encIds = new ArrayList<String>();
                 User user = myShepherd.getUser(request);
                 if (user == null) return failed;
-                JSONObject searchQuery = OpenSearch.queryLoad(searchQueryId);
+                JSONObject searchQuery = OpenSearch.queryLoad(searchQueryId, myShepherd);
                 if (searchQuery == null) return failed;
                 String indexName = searchQuery.optString("indexName", null);
                 if (indexName == null) return failed;
@@ -1579,7 +1579,7 @@ public class EncounterQueryProcessor extends QueryProcessor {
             if (user == null)
                 return new EncounterQueryResult(rEncounters, "must be logged in",
                         "OpenSearch id " + searchQueryId);
-            JSONObject searchQuery = OpenSearch.queryLoad(searchQueryId);
+            JSONObject searchQuery = OpenSearch.queryLoad(searchQueryId, myShepherd);
             if (searchQuery == null)
                 return new EncounterQueryResult(rEncounters, "searchQuery not found",
                         "OpenSearch id " + searchQueryId);

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -101,7 +101,10 @@ public class OpenSearch {
     public static boolean isMatchWarmupReady() {
         return matchWarmupReady;
     }
-    public static String QUERY_STORAGE_DIR = "/tmp"; // FIXME
+    // stored search queries (see queryStore): pruned opportunistically at most this often
+    static final long QUERY_PRUNE_INTERVAL_MILLIS = 3600000L; // 1 hour
+    static final int QUERY_TTL_DAYS_DEFAULT = 90;
+    private static volatile long queryLastPruneMillis = 0L;
     static String ACTIVE_TYPE_FOREGROUND = "opensearch_indexing_foreground";
     static String ACTIVE_TYPE_BACKGROUND = "opensearch_indexing_background";
 
@@ -1565,37 +1568,69 @@ public class OpenSearch {
             "] completed indexing " + indexName);
     }
 
-    public static String queryStoragePath(String id) {
-        return QUERY_STORAGE_DIR + "/OpenSearch-query-" + id + ".json";
-    }
-
+    /**
+     * Persist a stored query durably (OPENSEARCHQUERY table). Uses the CALLER's
+     * Shepherd/connection: commits the caller's open transaction (which must hold no other
+     * uncommitted writes -- SearchApi's is read-only) via commitDBTransactionWithStatus() so a
+     * commit failure is detectable, then re-begins a transaction for the remainder of the
+     * request. Returns the new id ONLY after a confirmed commit; null means durability was not
+     * confirmed. A confirmed commit followed by a failed re-begin still returns the id --
+     * callers needing further DB reads must check myShepherd.isDBTransactionActive().
+     */
     public static String queryStore(final JSONObject query, final String indexName,
-        final User user) {
-        if (query == null) return null;
+        final User user, final Shepherd myShepherd) {
+        if ((query == null) || (user == null) || (myShepherd == null)) return null;
         JSONObject stored = new JSONObject(query.toString());
         String id = Util.generateUUID();
+        long now = System.currentTimeMillis();
         stored.put("id", id);
         stored.put("indexName", indexName);
-        stored.put("created", System.currentTimeMillis());
+        stored.put("created", now);
         stored.put("creator", user.getUUID());
+        boolean committed = false;
         try {
-            Util.writeToFile(stored.toString(), queryStoragePath(id));
+            myShepherd.getPM().makePersistent(new OpenSearchQuery(id, stored, now));
+            if ((now - queryLastPruneMillis) > QUERY_PRUNE_INTERVAL_MILLIS) {
+                queryLastPruneMillis = now;
+                int ttlDays = (Integer)getConfigurationValue("searchQueryTtlDays",
+                    QUERY_TTL_DAYS_DEFAULT);
+                queryPrune(myShepherd, now - ttlDays * 86400000L);
+            }
+            committed = myShepherd.commitDBTransactionWithStatus();
         } catch (Exception ex) {
+            System.out.println("OpenSearch.queryStore() failed to store " + id + ": " + ex);
             ex.printStackTrace();
+        }
+        if (!committed) {
+            myShepherd.rollbackDBTransaction();
+            myShepherd.beginDBTransaction();
             return null;
         }
+        myShepherd.beginDBTransaction(); // recover a transaction for the rest of the request
         return id;
     }
 
-    public static JSONObject queryLoad(String id) {
-        if (id == null) return null;
+    // deletes stored queries with created < cutoffMillis; runs in the caller's transaction
+    public static long queryPrune(final Shepherd myShepherd, final long cutoffMillis) {
         try {
-            String jsonData = Util.readFromFile(queryStoragePath(id));
-            return new JSONObject(jsonData);
+            javax.jdo.Query q = myShepherd.getPM().newQuery(OpenSearchQuery.class,
+                "created < " + cutoffMillis);
+            long ct = q.deletePersistentAll();
+            if (ct > 0)
+                System.out.println("OpenSearch.queryPrune() deleted " + ct +
+                    " stored queries older than " + new java.util.Date(cutoffMillis));
+            return ct;
         } catch (Exception ex) {
-            ex.printStackTrace();
+            System.out.println("OpenSearch.queryPrune() failed: " + ex);
+            return 0;
         }
-        return null;
+    }
+
+    public static JSONObject queryLoad(String id, Shepherd myShepherd) {
+        OpenSearchQuery osq = OpenSearchQuery.load(myShepherd, id);
+
+        if (osq == null) return null;
+        return osq.getValue();
     }
 
     public static JSONObject queryScrubStored(final JSONObject query) {

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -1590,40 +1590,74 @@ public class OpenSearch {
         boolean committed = false;
         try {
             myShepherd.getPM().makePersistent(new OpenSearchQuery(id, stored, now));
-            if ((now - queryLastPruneMillis) > QUERY_PRUNE_INTERVAL_MILLIS) {
-                queryLastPruneMillis = now;
-                int ttlDays = (Integer)getConfigurationValue("searchQueryTtlDays",
-                    QUERY_TTL_DAYS_DEFAULT);
-                queryPrune(myShepherd, now - ttlDays * 86400000L);
-            }
             committed = myShepherd.commitDBTransactionWithStatus();
         } catch (Exception ex) {
             System.out.println("OpenSearch.queryStore() failed to store " + id + ": " + ex);
             ex.printStackTrace();
         }
         if (!committed) {
-            myShepherd.rollbackDBTransaction();
-            myShepherd.beginDBTransaction();
+            try {
+                myShepherd.rollbackDBTransaction();
+                myShepherd.beginDBTransaction();
+            } catch (Exception ex) {
+                System.out.println("OpenSearch.queryStore() transaction recovery failed: " + ex);
+            }
             return null;
         }
-        myShepherd.beginDBTransaction(); // recover a transaction for the rest of the request
+        // the id is durable from here on: nothing below may throw past this method
+        try {
+            myShepherd.beginDBTransaction(); // recover a transaction for the rest of the request
+            queryPruneMaybe(myShepherd, now);
+        } catch (Exception ex) {
+            System.out.println("OpenSearch.queryStore() post-commit recovery failed (id " + id +
+                " IS stored): " + ex);
+        }
         return id;
     }
 
-    // deletes stored queries with created < cutoffMillis; runs in the caller's transaction
-    public static long queryPrune(final Shepherd myShepherd, final long cutoffMillis) {
+    /**
+     * Opportunistic TTL prune, run AFTER a stored query is durably committed, in its own
+     * best-effort commit cycle so a prune/database failure can never affect the stored id
+     * (only rolls back the prune itself). Non-positive searchQueryTtlDays disables pruning.
+     */
+    private static void queryPruneMaybe(final Shepherd myShepherd, final long now) {
+        if ((now - queryLastPruneMillis) <= QUERY_PRUNE_INTERVAL_MILLIS) return;
+        queryLastPruneMillis = now;
+        int ttlDays = QUERY_TTL_DAYS_DEFAULT;
         try {
-            javax.jdo.Query q = myShepherd.getPM().newQuery(OpenSearchQuery.class,
-                "created < " + cutoffMillis);
-            long ct = q.deletePersistentAll();
-            if (ct > 0)
-                System.out.println("OpenSearch.queryPrune() deleted " + ct +
-                    " stored queries older than " + new java.util.Date(cutoffMillis));
-            return ct;
+            ttlDays = (Integer)getConfigurationValue("searchQueryTtlDays",
+                QUERY_TTL_DAYS_DEFAULT);
+        } catch (Exception ex) {}
+        if (ttlDays <= 0) return;
+        try {
+            if (queryPrune(myShepherd, now - ttlDays * 86400000L) > 0) {
+                if (!myShepherd.commitDBTransactionWithStatus())
+                    myShepherd.rollbackDBTransaction();
+                myShepherd.beginDBTransaction();
+            }
         } catch (Exception ex) {
-            System.out.println("OpenSearch.queryPrune() failed: " + ex);
-            return 0;
+            System.out.println("OpenSearch.queryPruneMaybe() failed: " + ex);
+            try {
+                myShepherd.rollbackDBTransaction();
+                myShepherd.beginDBTransaction();
+            } catch (Exception ex2) {
+                System.out.println(
+                    "OpenSearch.queryPruneMaybe() transaction recovery failed: " + ex2);
+            }
         }
+    }
+
+    // deletes stored queries with created < cutoffMillis; runs in the caller's transaction,
+    // which the caller must commit -- propagates failures (callers own transaction recovery)
+    public static long queryPrune(final Shepherd myShepherd, final long cutoffMillis) {
+        javax.jdo.Query q = myShepherd.getPM().newQuery(OpenSearchQuery.class,
+            "created < " + cutoffMillis);
+        long ct = q.deletePersistentAll();
+
+        if (ct > 0)
+            System.out.println("OpenSearch.queryPrune() deleted " + ct +
+                " stored queries older than " + new java.util.Date(cutoffMillis));
+        return ct;
     }
 
     public static JSONObject queryLoad(String id, Shepherd myShepherd) {

--- a/src/main/java/org/ecocean/OpenSearchQuery.java
+++ b/src/main/java/org/ecocean/OpenSearchQuery.java
@@ -1,0 +1,42 @@
+package org.ecocean;
+
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+
+/**
+ * Durable storage for a stored OpenSearch query (see SearchApi "searchQueryId").
+ * The value column holds the merged JSON previously written to a /tmp file:
+ * the original query body plus id, indexName, created, creator.
+ */
+public class OpenSearchQuery implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+    private String id;
+    private String value;
+    private long created;
+
+    public OpenSearchQuery() {}
+
+    public OpenSearchQuery(String id, JSONObject value, long created) {
+        this.id = id;
+        if (value != null) this.value = value.toString();
+        this.created = created;
+    }
+
+    public String getId() { return id; }
+
+    public long getCreated() { return created; }
+
+    public JSONObject getValue() {
+        return Util.stringToJSONObject(value);
+    }
+
+    public static OpenSearchQuery load(Shepherd myShepherd, String id) {
+        if (id == null) return null;
+        try {
+            return ((OpenSearchQuery)(myShepherd.getPM().getObjectById(
+                       myShepherd.getPM().newObjectIdInstance(OpenSearchQuery.class, id), true)));
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/ecocean/api/SearchApi.java
+++ b/src/main/java/org/ecocean/api/SearchApi.java
@@ -66,7 +66,7 @@ public class SearchApi extends ApiBase {
                 JSONObject query = null;
                 if (Util.isUUID(indexName)) {
                     searchQueryId = indexName;
-                    query = OpenSearch.queryLoad(searchQueryId);
+                    query = OpenSearch.queryLoad(searchQueryId, myShepherd);
                 }
                 // effective index: a stored query's real index comes from the loaded doc, not the {uuid} URL.
                 // null-safe: null when a stored query failed to load (handled by the missing-stored-query branch).
@@ -161,9 +161,32 @@ public class SearchApi extends ApiBase {
                     } else {
                     // all token validation gates passed -> persist the clean new query now (before
                     // applyAclFilter embeds ACL fields into it); rejected bodies were never stored
+                    boolean storeFailed = false;
+                    boolean sessionRecoveryFailed = false;
                     if (newQueryToStore) {
-                        searchQueryId = OpenSearch.queryStore(query, indexName, currentUser);
+                        // commits + re-begins myShepherd's (read-only so far) transaction
+                        searchQueryId = OpenSearch.queryStore(query, indexName, currentUser,
+                            myShepherd);
+                        storeFailed = (searchQueryId == null);
+                        // commit confirmed but the request transaction could not be re-established:
+                        // the id IS durable, but sanitizeDoc needs live DB reads -- fail the request
+                        // without claiming the store failed, and hand back the (valid) id
+                        sessionRecoveryFailed = !storeFailed &&
+                            !myShepherd.isDBTransactionActive();
                     }
+                    if (storeFailed) {
+                        // a search whose response promises a share id must not 200 without one
+                        response.setStatus(503);
+                        res.put("success", false);
+                        res.put("error", "failed to store search query");
+                    } else if (sessionRecoveryFailed) {
+                        response.setStatus(503);
+                        res.put("success", false);
+                        res.put("error",
+                            "search query stored but request could not continue; retry");
+                        res.put("searchQueryId", searchQueryId);
+                        response.setHeader("X-Wildbook-Search-Query-Id", searchQueryId);
+                    } else {
                     if (tokenAuth && !isAdmin) {
                         // Java is the hard boundary: scope totals + pagination + hits before execution
                         query = OpenSearch.applyAclFilter(query, currentUser.getId(), indexName);
@@ -218,6 +241,7 @@ public class SearchApi extends ApiBase {
                         res.put("error", "query failed");
                         ex.printStackTrace();
                     }
+                    } // end storeFailed/sessionRecoveryFailed else
                     } // end individual-token field-gate else
                     } // end aggError else
                 }

--- a/src/main/resources/org/ecocean/package.jdo
+++ b/src/main/resources/org/ecocean/package.jdo
@@ -996,6 +996,17 @@
 		</field>
 	</class>
 
+	<class name="OpenSearchQuery">
+		<field name="id" primary-key="true" />
+		<field name="created">
+			<column allows-null="true" />
+			<index name="OPENSEARCHQUERY_CREATED_IDX" />
+		</field>
+		<field name="value">
+			<column jdbc-type="LONGVARCHAR" />
+		</field>
+	</class>
+
 
 	<class name="MultiValue" identity-type="application">
 		<field name="id" primary-key="true" value-strategy="identity" persistence-modifier="persistent" />

--- a/src/test/java/org/ecocean/OpenSearchQueryStoreContractTest.java
+++ b/src/test/java/org/ecocean/OpenSearchQueryStoreContractTest.java
@@ -1,0 +1,77 @@
+package org.ecocean;
+
+import javax.jdo.PersistenceManager;
+
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Failure-path contract for OpenSearch.queryStore: null ⇔ durability not confirmed;
+ * a confirmed commit always yields the id, even when post-commit recovery fails.
+ */
+class OpenSearchQueryStoreContractTest {
+
+    private final JSONObject query = new JSONObject().put("query",
+        new JSONObject().put("match_all", new JSONObject()));
+
+    private User mockUser() {
+        User u = mock(User.class);
+
+        when(u.getUUID()).thenReturn("user-uuid");
+        return u;
+    }
+
+    private Shepherd mockShepherd(boolean commitOk) {
+        Shepherd sh = mock(Shepherd.class);
+        PersistenceManager pm = mock(PersistenceManager.class);
+
+        when(sh.getPM()).thenReturn(pm);
+        when(sh.commitDBTransactionWithStatus()).thenReturn(commitOk);
+        return sh;
+    }
+
+    @Test void commitFailure_returnsNull_andRecoversTransaction() {
+        Shepherd sh = mockShepherd(false);
+        String id = OpenSearch.queryStore(query, "encounter", mockUser(), sh);
+
+        assertNull(id, "unconfirmed commit must not yield an id");
+        verify(sh).rollbackDBTransaction();
+        verify(sh).beginDBTransaction();
+    }
+
+    @Test void makePersistentThrows_returnsNull() {
+        Shepherd sh = mock(Shepherd.class);
+        PersistenceManager pm = mock(PersistenceManager.class);
+
+        when(sh.getPM()).thenReturn(pm);
+        when(sh.commitDBTransactionWithStatus()).thenReturn(true);
+        doThrow(new RuntimeException("boom")).when(pm).makePersistent(any());
+        assertNull(OpenSearch.queryStore(query, "encounter", mockUser(), sh),
+            "persist failure must not yield an id");
+    }
+
+    @Test void rebeginThrows_afterConfirmedCommit_stillReturnsId() {
+        Shepherd sh = mockShepherd(true);
+
+        doThrow(new RuntimeException("re-begin failed")).when(sh).beginDBTransaction();
+        assertNotNull(OpenSearch.queryStore(query, "encounter", mockUser(), sh),
+            "a durably committed id must be returned even when re-begin fails");
+    }
+
+    @Test void nullArguments_returnNull() {
+        Shepherd sh = mockShepherd(true);
+
+        assertNull(OpenSearch.queryStore(null, "encounter", mockUser(), sh));
+        assertNull(OpenSearch.queryStore(query, "encounter", null, sh));
+        assertNull(OpenSearch.queryStore(query, "encounter", mockUser(), null));
+    }
+}

--- a/src/test/java/org/ecocean/OpenSearchQueryStoreTest.java
+++ b/src/test/java/org/ecocean/OpenSearchQueryStoreTest.java
@@ -1,0 +1,129 @@
+package org.ecocean;
+
+import java.util.Properties;
+
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Durability contract for stored search queries (issue #1500): OpenSearch.queryStore must
+ * persist through the real DB path (confirmed commit + re-begun caller transaction) and
+ * OpenSearch.queryLoad must read the merged stored shape back from a separate Shepherd.
+ */
+@Testcontainers public class OpenSearchQueryStoreTest {
+
+    @Container static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
+        "postgres:15-alpine")
+            .withDatabaseName("wildbook_test")
+            .withUsername("wildbook")
+            .withPassword("wildbook");
+
+    @BeforeAll static void setUp() {
+        Properties commonConfiguration = new Properties();
+        commonConfiguration.setProperty("htmlTitle", "Unit Test");
+        CommonConfiguration.initialize("context0", commonConfiguration);
+        // evict any PMF a previous test class bound to ITS OWN (now stopped) container
+        org.ecocean.shepherd.core.TestPMFUtil.closePMF("context0");
+    }
+
+    @AfterAll static void tearDown() {
+        // our container stops with this class; don't leave a dead PMF for later classes
+        org.ecocean.shepherd.core.TestPMFUtil.closePMF("context0");
+    }
+
+    private static Properties dnProperties() {
+        Properties properties = new Properties();
+
+        properties.setProperty("datanucleus.ConnectionUserName", postgres.getUsername());
+        properties.setProperty("datanucleus.ConnectionPassword", postgres.getPassword());
+        properties.setProperty("datanucleus.ConnectionDriverName", postgres.getDriverClassName());
+        properties.setProperty("datanucleus.ConnectionURL", postgres.getJdbcUrl());
+        properties.setProperty("datanucleus.schema.autoCreateTables", "true");
+        return properties;
+    }
+
+    @Test void queryStoreRoundtripAndPrune() {
+        // seed a real user (queryStore reads getUUID())
+        Shepherd seeder = new Shepherd("context0", dnProperties());
+
+        seeder.setAction("OpenSearchQueryStoreTest.seed");
+        String creatorUuid;
+        seeder.beginDBTransaction();
+        try {
+            String salt = ServletUtilities.getSalt().toHex();
+            User user = new User("osqtester",
+                ServletUtilities.hashAndSaltPassword("password123", salt), salt);
+            seeder.getPM().makePersistent(user);
+            creatorUuid = user.getUUID(); // capture while attached
+            seeder.commitDBTransaction();
+        } finally {
+            seeder.rollbackAndClose();
+        }
+        assertNotNull(creatorUuid, "seeded user has a uuid");
+
+        // store through the REAL path: persist + confirmed commit + re-begin
+        Shepherd writer = new Shepherd("context0", dnProperties());
+        writer.setAction("OpenSearchQueryStoreTest.write");
+        writer.beginDBTransaction();
+        String id;
+        try {
+            JSONObject query = new JSONObject().put("query",
+                new JSONObject().put("match_all", new JSONObject()));
+            User writerUser = writer.getUser("osqtester");
+            id = OpenSearch.queryStore(query, "encounter", writerUser, writer);
+            assertNotNull(id, "queryStore returns id after confirmed commit");
+            assertTrue(writer.isDBTransactionActive(),
+                "queryStore re-begins the caller transaction");
+        } finally {
+            writer.rollbackAndClose();
+        }
+
+        // load from a SEPARATE Shepherd: durability + merged stored shape
+        Shepherd reader = new Shepherd("context0", dnProperties());
+        reader.setAction("OpenSearchQueryStoreTest.read");
+        reader.beginDBTransaction();
+        try {
+            JSONObject loaded = OpenSearch.queryLoad(id, reader);
+            assertNotNull(loaded, "stored query loads back from a different Shepherd");
+            assertEquals("encounter", loaded.optString("indexName"), "indexName survives");
+            assertEquals(creatorUuid, loaded.optString("creator"), "creator survives");
+            assertEquals(id, loaded.optString("id"), "id embedded in stored doc");
+            assertNotNull(loaded.optJSONObject("query"), "query body survives");
+            assertNull(OpenSearch.queryLoad(Util.generateUUID(), reader),
+                "unknown id loads null");
+        } finally {
+            reader.rollbackAndClose();
+        }
+
+        // prune: older-than-cutoff rows deleted, newer kept
+        Shepherd pruner = new Shepherd("context0", dnProperties());
+        pruner.setAction("OpenSearchQueryStoreTest.prune");
+        pruner.beginDBTransaction();
+        try {
+            pruner.getPM().makePersistent(new OpenSearchQuery("old-stored-query",
+                new JSONObject().put("query", new JSONObject()), 1000L));
+            pruner.commitDBTransaction();
+            pruner.beginDBTransaction();
+            long deleted = OpenSearch.queryPrune(pruner, 2000L);
+            pruner.commitDBTransaction();
+            pruner.beginDBTransaction();
+            assertEquals(1, deleted, "exactly the old row pruned");
+            assertNull(OpenSearchQuery.load(pruner, "old-stored-query"), "old row pruned");
+            assertNotNull(OpenSearchQuery.load(pruner, id), "fresh row kept");
+        } finally {
+            pruner.rollbackAndClose();
+        }
+    }
+}

--- a/src/test/java/org/ecocean/api/SearchApiChildIndexTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiChildIndexTest.java
@@ -63,6 +63,12 @@ class SearchApiChildIndexTest {
             doNothing().when(m).rollbackAndClose();
             when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
             when(user.isAdmin(m)).thenReturn(admin);
+            // let the REAL OpenSearch.queryStore run against this mock: makePersistent is a
+            // no-op on the mock PM, the commit reports success, and the re-begun transaction
+            // reads as active (queryPrune swallows the mock PM null-query internally)
+            when(m.getPM()).thenReturn(mock(javax.jdo.PersistenceManager.class));
+            when(m.commitDBTransactionWithStatus()).thenReturn(true);
+            when(m.isDBTransactionActive()).thenReturn(true);
         });
     }
 
@@ -273,7 +279,7 @@ class SearchApiChildIndexTest {
         User user = mockUser("u1", false);
         try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
             MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class)) {
-            osStatic.when(() -> OpenSearch.queryLoad(anyString())).thenReturn(null);
+            osStatic.when(() -> OpenSearch.queryLoad(anyString(), any())).thenReturn(null);
             osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(true);
             new SearchApi().doPost(request, response);
         }
@@ -290,7 +296,7 @@ class SearchApiChildIndexTest {
         User user = mockUser("u1", false);
         try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
             MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class)) {
-            osStatic.when(() -> OpenSearch.queryLoad(anyString())).thenReturn(
+            osStatic.when(() -> OpenSearch.queryLoad(anyString(), any())).thenReturn(
                 new JSONObject().put("creator", "someoneElse").put("indexName", "bogus")
                     .put("query", new JSONObject().put("match_all", new JSONObject())));
             osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(false);

--- a/src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java
+++ b/src/test/java/org/ecocean/api/SearchApiTokenAuthTest.java
@@ -64,6 +64,12 @@ class SearchApiTokenAuthTest {
             doNothing().when(m).rollbackAndClose();
             when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
             when(user.isAdmin(m)).thenReturn(admin);
+            // let the REAL OpenSearch.queryStore run against this mock: makePersistent is a
+            // no-op on the mock PM, the commit reports success, and the re-begun transaction
+            // reads as active (queryPrune swallows the mock PM null-query internally)
+            when(m.getPM()).thenReturn(mock(javax.jdo.PersistenceManager.class));
+            when(m.commitDBTransactionWithStatus()).thenReturn(true);
+            when(m.isDBTransactionActive()).thenReturn(true);
         });
     }
 
@@ -157,7 +163,7 @@ class SearchApiTokenAuthTest {
     /** Stub OpenSearch.queryLoad to return a stored-query doc (with indexName + creator). */
     private MockedStatic<OpenSearch> storedQuery(String indexName, String creator) {
         MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class);
-        osStatic.when(() -> OpenSearch.queryLoad(anyString())).thenReturn(
+        osStatic.when(() -> OpenSearch.queryLoad(anyString(), any())).thenReturn(
             new JSONObject().put("indexName", indexName).put("creator", creator)
                 .put("query", new JSONObject().put("match_all", new JSONObject())));
         osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(true);
@@ -245,6 +251,94 @@ class SearchApiTokenAuthTest {
             new SearchApi().doPost(request, response);
         }
         verify(response).setStatus(200); // session path unaffected by token gates
+    }
+
+    @Test void sessionPost_storesQuery_andReturnsSearchQueryId() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn(null);
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null); // session path
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class)) {
+            osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(true);
+            osStatic.when(() -> OpenSearch.querySanitize(any(), any(), any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+            osStatic.when(() -> OpenSearch.queryStore(any(), anyString(), any(), any()))
+                .thenReturn("11111111-2222-3333-4444-555555555555");
+            try (MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+                when(m.queryPit(anyString(), any(JSONObject.class), anyInt(), anyInt(),
+                    any(), any())).thenReturn(EMPTY_HITS);
+            })) {
+                new SearchApi().doPost(request, response);
+            }
+        }
+        verify(response).setStatus(200);
+        verify(response).setHeader("X-Wildbook-Search-Query-Id",
+            "11111111-2222-3333-4444-555555555555");
+        assertTrue(out.toString().contains("11111111-2222-3333-4444-555555555555"),
+            "response body carries searchQueryId");
+    }
+
+    @Test void post_storeFailure_returns503_andDoesNotExecute() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn(null);
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null);
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = shepherdReturning(user, false);
+            MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class)) {
+            osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(true);
+            osStatic.when(() -> OpenSearch.querySanitize(any(), any(), any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+            osStatic.when(() -> OpenSearch.queryStore(any(), anyString(), any(), any()))
+                .thenReturn(null); // store failed: durability not confirmed
+            try (MockedConstruction<OpenSearch> os = mockConstruction(OpenSearch.class, (m, c) -> {
+                doNothing().when(m).deletePit(anyString());
+            })) {
+                new SearchApi().doPost(request, response);
+                for (OpenSearch constructed : os.constructed()) {
+                    verify(constructed, never()).queryPit(anyString(), any(JSONObject.class),
+                        anyInt(), anyInt(), any(), any());
+                }
+            }
+        }
+        verify(response).setStatus(503);
+        assertTrue(out.toString().contains("failed to store search query"),
+            "error surfaced in body");
+    }
+
+    @Test void post_storedButSessionRecoveryFailed_returns503_withId() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/encounter");
+        when(request.getHeader("Authorization")).thenReturn(null);
+        when(request.getAttribute(WildbookTokenAuthenticationFilter.TOKEN_AUTH_ATTR))
+            .thenReturn(null);
+        User user = mockUser("u1", false);
+        try (MockedConstruction<Shepherd> sh = mockConstruction(Shepherd.class, (m, c) -> {
+            doNothing().when(m).beginDBTransaction();
+            doNothing().when(m).setAction(anyString());
+            doNothing().when(m).rollbackAndClose();
+            when(m.getUser(any(HttpServletRequest.class))).thenReturn(user);
+            when(user.isAdmin(m)).thenReturn(false);
+            when(m.isDBTransactionActive()).thenReturn(false); // re-begin failed post-commit
+        });
+            MockedStatic<OpenSearch> osStatic = mockStatic(OpenSearch.class)) {
+            osStatic.when(() -> OpenSearch.isValidIndexName(anyString())).thenReturn(true);
+            osStatic.when(() -> OpenSearch.querySanitize(any(), any(), any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+            osStatic.when(() -> OpenSearch.queryStore(any(), anyString(), any(), any()))
+                .thenReturn("22222222-3333-4444-5555-666666666666"); // durable
+            new SearchApi().doPost(request, response);
+        }
+        verify(response).setStatus(503);
+        verify(response).setHeader("X-Wildbook-Search-Query-Id",
+            "22222222-3333-4444-5555-666666666666");
+        assertTrue(out.toString().contains("22222222-3333-4444-5555-666666666666"),
+            "durable id still returned when the request session could not continue");
     }
 
     @Test void storedQuery_ownEncounter_succeeds() throws Exception {


### PR DESCRIPTION
Fixes the broken **Apply Search ID** feature (#1500): shared search-query IDs did not survive, and the frontend both hid the failure and made it worse.

## Root causes (diagnosed with a second-opinion Codex review)

1. **Stored queries lived in `/tmp`** (`OpenSearch.QUERY_STORAGE_DIR = "/tmp" // FIXME`) as loose JSON files, so every container redeploy/restart/tmp-cleanup silently invalidated all previously shared IDs — the exact use case (share an ID with a colleague, usually later) 404'd. `Util.writeToFile` also swallows write failures, so an ID could be handed out whose file was never written.
2. At the time the issue was filed, the frontend passed a hardcoded `queryID={false}` to the Applied Filters sidebar (always "0 filters") and swallowed GET failures silently — matching the report exactly. Partially fixed since (da9059f420); the remaining defects are fixed here.

## Backend changes

- New `OpenSearchQuery` JDO entity (`OPENSEARCHQUERY` table: id PK, JSON value, indexed created). `queryStore`/`queryLoad` now use the database instead of `/tmp` files. The stored JSON shape (query + `id`/`indexName`/`created`/`creator`) is unchanged, so stored-query replay, ownership checks, and `EncounterQueryProcessor` export flows work as before.
- `queryStore` uses the caller's Shepherd on the same connection (no second connection per request): persist → `commitDBTransactionWithStatus()` (a plain `commitDBTransaction()` swallows failures) → re-begin. It returns the new id **only after a confirmed commit**; `null` ⇔ durability not confirmed.
- SearchApi now fail-closes: if the store fails, the search returns **503** instead of a 200 whose response silently lacks the promised share id. A (rare) post-commit session-recovery failure also 503s but returns the durable id.
- Retention: stored queries older than `searchQueryTtlDays` (default **90 days**, non-positive disables) are pruned opportunistically (at most hourly), *after* the store commit in a separate best-effort commit cycle so pruning can never affect the stored id.

## Frontend changes

- The Enter key in Apply Search ID navigated to `/encounter-search` without the `/react` prefix (Tomcat 404 in production); both Enter and the Apply button now build the same `PUBLIC_URL` link, with the pasted id trimmed and URL-encoded.
- `useFilterEncounters` had `enable: false` — a react-query option typo (`enabled`) — so the default filter POST always ran, including on an applied-ID page (minting a stray stored query per visit). The hook now takes `enabled`, and the page passes `enabled: !queryID` (re-enabled automatically if the applied id fails to load).
- Removed the `"defaultSearchQueryId"` fallback from all three `useFilterEncounters*` models — users could copy that literal string, which can never replay. The sidebar Copy button is a no-op until a real id exists.
- The DataTable map/analysis links and the Export modal now receive the **applied** query id when viewing a shared search (previously they got an unrelated or empty id).

## Tests

- `OpenSearchQueryStoreTest` (Testcontainers, real Postgres): full `queryStore` → separate-Shepherd `queryLoad` durability roundtrip + prune behavior.
- `OpenSearchQueryStoreContractTest`: failure paths — commit failure → null + transaction recovery; persist throw → null; re-begin throw after a confirmed commit → id still returned.
- SearchApi: session-path POST returns the stored id (header + body); store failure → 503 with **no search execution**; stored-but-recovery-failed → 503 **with** the id. Existing token-path suites (28 tests) updated for the new signatures and green; the token-scope E2E tests now exercise the real DB-backed store path unchanged.
- Frontend jest: applied-ID mode fires only the GET (no default POST), routes the applied id to DataTable/ExportModal, re-enables the default search on failure; Apply input trims/encodes. (`GalleryView`/`ImageGalleryModal` suites fail pre-existing — react-intl mock issue unrelated to this diff; jest is continue-on-error in CI.)

## Deployment notes

- `OPENSEARCHQUERY` is auto-created on startup when the effective DataNucleus config allows DDL (bundled default `datanucleus.schema.autoCreateAll=true`). If a deployment overrides that or the DB role lacks CREATE, apply manually (verify identifier casing against your DB's `SYSTEMVALUE` table):
  ```sql
  CREATE TABLE "OPENSEARCHQUERY" ("ID" varchar(255) NOT NULL PRIMARY KEY,
      "CREATED" bigint, "VALUE" text);
  CREATE INDEX "OPENSEARCHQUERY_CREATED_IDX" ON "OPENSEARCHQUERY" ("CREATED");
  ```
- IDs minted before this deploy are not migrated (they were already ephemeral `/tmp` files).
- Shared IDs now survive redeploys but expire after the TTL; set `searchQueryTtlDays` in OpenSearch properties to adjust, `0`/negative to disable pruning.

Out of scope (per the #1500 discussion): making the share flow more discoverable / hydrating filter chips from a replayed query — that redesign conversation stays open.

Diagnosis and implementation were adversarially reviewed by Codex (2 plan rounds + 2 implementation rounds, converged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
