### PR TITLE
Add verbatimLocality field to React report encounter page

### DIFF
--- a/frontend/src/__tests__/pages/ReportAnEncounterPage/PlaceSection.test.js
+++ b/frontend/src/__tests__/pages/ReportAnEncounterPage/PlaceSection.test.js
@@ -22,9 +22,11 @@ jest.mock(
       lon: 7,
       setLat: jest.fn(),
       setLon: jest.fn(),
+      setVerbatimLocality: jest.fn(),
       placeSection: {
         required: true,
         locationId: "test-id",
+        verbatimLocality: "existing locality",
       },
     })),
   }),
@@ -110,5 +112,23 @@ describe("PlaceSection Component", () => {
     expect(screen.getByText(/INVALID_LONG/i)).toBeInTheDocument();
     fireEvent.change(lonInput, { target: { value: "90" } });
     await waitFor(() => expect(screen.queryByText(/INVALID_LONG/i)).toBeNull());
+  });
+
+  test("renders verbatim locality input field with store value", () => {
+    renderComponent(<PlaceSection store={mockStore} />);
+    const localityInput = screen.getByLabelText("LOCATION");
+    expect(localityInput).toBeInTheDocument();
+    expect(localityInput).toHaveValue("existing locality");
+  });
+
+  test("updates store on verbatim locality input change", () => {
+    renderComponent(<PlaceSection store={mockStore} />);
+    const localityInput = screen.getByLabelText("LOCATION");
+    fireEvent.change(localityInput, {
+      target: { value: "reef off the north point" },
+    });
+    expect(mockStore.setVerbatimLocality).toHaveBeenCalledWith(
+      "reef off the north point",
+    );
   });
 });

--- a/frontend/src/__tests__/pages/ReportAnEncounterPage/ReportEncounterStore.test.js
+++ b/frontend/src/__tests__/pages/ReportAnEncounterPage/ReportEncounterStore.test.js
@@ -233,4 +233,57 @@ describe("ReportEncounterStore", () => {
     expect(store.validateFields()).toBe(false);
     expect(store.dateTimeSection.error).toBe(true);
   });
+
+  test("should set verbatimLocality in place section", () => {
+    store.setVerbatimLocality("reef off the north point");
+    expect(store.placeSection.verbatimLocality).toBe(
+      "reef off the north point",
+    );
+  });
+
+  test("should include verbatimLocality in payload when set", async () => {
+    axios.post.mockClear();
+    axios.post.mockResolvedValue({ status: 200, data: { message: "Success" } });
+
+    store.setImageRequired(false);
+    store.setDateTimeSectionValue("2024-03-18T12:00:00");
+    store.setLocationId("123-location");
+    store.setVerbatimLocality("reef off the north point");
+
+    await store.submitReport();
+
+    expect(axios.post).toHaveBeenCalledWith(
+      "/api/v3/encounters",
+      expect.objectContaining({
+        verbatimLocality: "reef off the north point",
+      }),
+    );
+  });
+
+  test("should omit verbatimLocality from payload when empty", async () => {
+    axios.post.mockClear();
+    axios.post.mockResolvedValue({ status: 200, data: { message: "Success" } });
+
+    store.setImageRequired(false);
+    store.setDateTimeSectionValue("2024-03-18T12:00:00");
+    store.setLocationId("123-location");
+
+    await store.submitReport();
+
+    expect(axios.post.mock.calls[0][1]).not.toHaveProperty("verbatimLocality");
+  });
+
+  test("should clear verbatimLocality after successful submission", async () => {
+    axios.post.mockClear();
+    axios.post.mockResolvedValue({ status: 200, data: { message: "Success" } });
+
+    store.setImageRequired(false);
+    store.setDateTimeSectionValue("2024-03-18T12:00:00");
+    store.setLocationId("123-location");
+    store.setVerbatimLocality("reef off the north point");
+
+    await store.submitReport();
+
+    expect(store.placeSection.verbatimLocality).toBe("");
+  });
 });

--- a/frontend/src/pages/ReportsAndManagamentPages/PlaceSection.jsx
+++ b/frontend/src/pages/ReportsAndManagamentPages/PlaceSection.jsx
@@ -95,6 +95,16 @@ export const PlaceSection = observer(({ store }) => {
         mapCenterLon={mapCenterLon}
         mapZoom={mapZoom}
       />
+      <Form.Group controlId="verbatimLocality" className="mb-3">
+        <Form.Label>
+          <FormattedMessage id="LOCATION" />
+        </Form.Label>
+        <Form.Control
+          type="text"
+          value={store.placeSection.verbatimLocality || ""}
+          onChange={(e) => store.setVerbatimLocality(e.target.value)}
+        />
+      </Form.Group>
       <Form.Group>
         <Form.Label>
           <FormattedMessage id="FILTER_GPS_COORDINATES" />

--- a/frontend/src/pages/ReportsAndManagamentPages/ReportEncounterStore.js
+++ b/frontend/src/pages/ReportsAndManagamentPages/ReportEncounterStore.js
@@ -45,6 +45,7 @@ export class ReportEncounterStore {
       value: "",
       error: false,
       required: true,
+      verbatimLocality: "",
     };
     this._additionalCommentsSection = {
       value: "",
@@ -218,6 +219,10 @@ export class ReportEncounterStore {
     this._placeSection.error = error;
   }
 
+  setVerbatimLocality(value) {
+    this._placeSection.verbatimLocality = value;
+  }
+
   setFollowUpSection(value) {
     this._followUpSection.value = value;
   }
@@ -366,6 +371,7 @@ export class ReportEncounterStore {
           dateTime: this._dateTimeSection.value,
           taxonomy: this._speciesSection.value,
           locationId: this._placeSection.locationId,
+          verbatimLocality: this._placeSection.verbatimLocality,
           comments: this._additionalCommentsSection.value,
           submitterName: this._followUpSection.submitter.name,
           submitterEmail: this._followUpSection.submitter.email,
@@ -400,6 +406,7 @@ export class ReportEncounterStore {
         if (response.status === 200) {
           this._speciesSection.value = "";
           this._placeSection.value = "";
+          this._placeSection.verbatimLocality = "";
           this._followUpSection.value = "";
           this._dateTimeSection.value = "";
           this._imageSectionFileNames = [];

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -5164,6 +5164,7 @@ public class Encounter extends Base implements java.io.Serializable {
         Encounter enc = new Encounter(false);
         if (Util.isUUID(payload.optString("_id"))) enc.setId(payload.getString("_id"));
         enc.setLocationID(locationID);
+        enc.setVerbatimLocality(payload.optString("verbatimLocality", null));
         enc.setDecimalLatitude(decimalLatitude);
         enc.setDecimalLongitude(decimalLongitude);
         enc.setDateFromISO8601String(dateTime);

--- a/src/test/java/org/ecocean/EncounterCreateFromApiTest.java
+++ b/src/test/java/org/ecocean/EncounterCreateFromApiTest.java
@@ -1,0 +1,67 @@
+package org.ecocean;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.jdo.PersistenceManager;
+
+import org.ecocean.api.ApiException;
+import org.ecocean.shepherd.core.Shepherd;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.mockito.MockedStatic;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class EncounterCreateFromApiTest {
+    private Encounter createViaApi(JSONObject payload)
+    throws ApiException {
+        Shepherd mockShepherd = mock(Shepherd.class);
+        PersistenceManager mockPM = mock(PersistenceManager.class);
+        Occurrence mockOcc = mock(Occurrence.class);
+        List<File> files = new ArrayList<File>();
+
+        when(mockShepherd.getContext()).thenReturn("context0");
+        when(mockShepherd.getPM()).thenReturn(mockPM);
+        when(mockShepherd.getOrCreateOccurrence(null)).thenReturn(mockOcc);
+        try (MockedStatic<LocationID> mockLoc = mockStatic(LocationID.class)) {
+            mockLoc.when(() -> LocationID.isValidLocationID(any(String.class))).thenReturn(true);
+            try (MockedStatic<CommonConfiguration> mockConf = mockStatic(
+                    CommonConfiguration.class)) {
+                return (Encounter)Encounter.createFromApi(payload, files, mockShepherd);
+            }
+        }
+    }
+
+    @Test void createFromApiSetsVerbatimLocality()
+    throws ApiException {
+        JSONObject payload = new JSONObject();
+
+        payload.put("locationId", "test-location");
+        payload.put("dateTime", "2024-03-18T12:00:00");
+        payload.put("verbatimLocality", "reef off the north point");
+
+        Encounter enc = createViaApi(payload);
+        assertEquals("reef off the north point", enc.getVerbatimLocality());
+        assertEquals("test-location", enc.getLocationID());
+    }
+
+    @Test void createFromApiLeavesVerbatimLocalityNullWhenAbsent()
+    throws ApiException {
+        JSONObject payload = new JSONObject();
+
+        payload.put("locationId", "test-location");
+        payload.put("dateTime", "2024-03-18T12:00:00");
+
+        Encounter enc = createViaApi(payload);
+        assertNull(enc.getVerbatimLocality());
+    }
+}


### PR DESCRIPTION
## What this does

Adds a free-text locality field (`Encounter.verbatimLocality`) to the **Place** section of the React report page (`/react/report`), directly below the locationID selector — restoring parity with the legacy `submit.jsp` page, whose `location` text input feeds the same Encounter field.

## Changes

- **`PlaceSection.jsx`** — new text input below `<LocationID/>`. Label reuses the existing `LOCATION` i18n key (present in all 5 locales; same key the Encounter edit page uses for this field), so no locale changes are needed. `controlId` associates the label with the input for assistive technology.
- **`ReportEncounterStore.js`** — `verbatimLocality` in the place-section state, setter, payload entry in `submitReport()` (existing filter omits it when empty), and reset after successful submission.
- **`Encounter.createFromApi()`** — one line: `enc.setVerbatimLocality(payload.optString("verbatimLocality", null))`. The PATCH path already supported the field. Free text, same trust level as `comments`; anonymous GET sanitization already strips `verbatimLocality`.

## Tests

- New `EncounterCreateFromApiTest` (mocked Shepherd/LocationID/CommonConfiguration): asserts the field maps on create and stays null when absent. Verified red before the backend change, green after.
- 4 new `ReportEncounterStore` tests (setter, payload inclusion, omission when empty, reset on success) and 2 new `PlaceSection` tests (controlled value binding, change handler).
- Full `mvn clean install` green (0 surefire failures). Frontend suites 42/42 under `npx jest --config jest.config.js`.

Note: under `npm test` (CRA harness) the pre-existing PlaceSection suite fails identically on untouched `main` (CRA's default `resetMocks: true` clears the suite's `@googlemaps/js-api-loader` module-factory mock); the suite passes under the repo's `jest.config.js` harness. Not introduced or changed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)