### PR TITLE
fix(report): preserve civil encounter date-times

### DIFF
--- a/frontend/src/__tests__/pages/ReportAnEncounterPage/DateTimeSection.test.js
+++ b/frontend/src/__tests__/pages/ReportAnEncounterPage/DateTimeSection.test.js
@@ -82,8 +82,12 @@ describe("DateTimeSection Component", () => {
 
     await waitFor(() =>
       expect(mockStore.setDateTimeSectionValue).toHaveBeenCalledWith(
-        new Date("2024-03-12 15:30"),
+        expect.objectContaining({
+          format: expect.any(Function),
+        }),
       ),
     );
+    const selectedValue = mockStore.setDateTimeSectionValue.mock.calls.at(-1)[0];
+    expect(selectedValue.format("YYYY-MM-DDTHH:mm")).toBe("2024-03-12T15:30");
   });
 });

--- a/frontend/src/__tests__/pages/ReportAnEncounterPage/ReportEncounterStore.test.js
+++ b/frontend/src/__tests__/pages/ReportAnEncounterPage/ReportEncounterStore.test.js
@@ -1,5 +1,6 @@
 import { ReportEncounterStore } from "../../../pages/ReportsAndManagamentPages/ReportEncounterStore";
 import axios from "axios";
+import moment from "moment";
 
 jest.mock("axios");
 
@@ -66,6 +67,26 @@ describe("ReportEncounterStore", () => {
     expect(store.success).toBe(true);
     expect(store.finished).toBe(true);
     expect(store.imageSectionFileNames).toEqual([]);
+    expect(axios.post).toHaveBeenCalledWith(
+      "/api/v3/encounters",
+      expect.objectContaining({ dateTime: "2024-03-18T12:00" }),
+    );
+  });
+
+  test("submits the selected civil time without a timezone conversion", async () => {
+    axios.post.mockResolvedValue({ status: 200, data: { message: "Success" } });
+
+    store.setImageSectionFileNames("image1.jpg", "add");
+    store.setSpeciesSectionValue("Tiger");
+    store.setDateTimeSectionValue(moment.parseZone("2020-07-17T08:45:00-07:00"));
+    store.setLocationId("123-location");
+
+    await store.submitReport();
+
+    expect(axios.post).toHaveBeenCalledWith(
+      "/api/v3/encounters",
+      expect.objectContaining({ dateTime: "2020-07-17T08:45" }),
+    );
   });
 
   test("should handle submission failure", async () => {

--- a/frontend/src/pages/ReportsAndManagamentPages/DateTimeSection.jsx
+++ b/frontend/src/pages/ReportsAndManagamentPages/DateTimeSection.jsx
@@ -4,8 +4,8 @@ import { FormattedMessage } from "react-intl";
 import { observer } from "mobx-react-lite";
 import Datetime from "react-datetime";
 import "react-datetime/css/react-datetime.css";
-import moment from "moment";
 import ThemeContext from "../../ThemeColorProvider";
+import { parseReportDateTime } from "./reportDateTime";
 
 export const DateTimeSection = observer(({ store }) => {
   const theme = useContext(ThemeContext);
@@ -33,11 +33,7 @@ export const DateTimeSection = observer(({ store }) => {
                 store.setDateTimeSectionError(false);
                 return;
               }
-              const isValidFormat = moment(
-                new Date(inputDate),
-                moment.ISO_8601,
-                true,
-              ).isValid();
+              const isValidFormat = parseReportDateTime(inputDate).isValid();
               if (!isValidFormat) {
                 store.setDateTimeSectionError(true);
               }
@@ -79,7 +75,7 @@ export const DateTimeSection = observer(({ store }) => {
             id="exifDateTime"
             onChange={(e) => {
               const inputDate = e.target.value;
-              store.setDateTimeSectionValue(new Date(inputDate));
+              store.setDateTimeSectionValue(parseReportDateTime(inputDate));
             }}
           >
             <option value="">

--- a/frontend/src/pages/ReportsAndManagamentPages/ImageSection.jsx
+++ b/frontend/src/pages/ReportsAndManagamentPages/ImageSection.jsx
@@ -7,6 +7,7 @@ import {
 } from "react-bootstrap";
 import Flow from "@flowjs/flow.js";
 import { FormattedMessage } from "react-intl";
+import { formatReportDateTime } from "./reportDateTime";
 import ThemeContext from "../../ThemeColorProvider";
 import MainButton from "../../components/MainButton";
 import { v4 as uuidv4 } from "uuid";
@@ -372,7 +373,7 @@ export const ImageSection = observer(({ store }) => {
                 );
                 localStorage.setItem(
                   "datetime",
-                  store.dateTimeSection.value?.toISOString(),
+                  formatReportDateTime(store.dateTimeSection.value),
                 );
                 localStorage.setItem("exifDateTime", store.exifDateTime);
                 localStorage.setItem(

--- a/frontend/src/pages/ReportsAndManagamentPages/ReportEncounter.jsx
+++ b/frontend/src/pages/ReportsAndManagamentPages/ReportEncounter.jsx
@@ -14,6 +14,10 @@ import { ReportEncounterStore } from "./ReportEncounterStore";
 import { ReportEncounterSpeciesSection } from "./SpeciesSection";
 import { useNavigate } from "react-router-dom";
 import { useSiteSettings } from "../../SiteSettingsContext";
+import {
+  formatReportDateTime,
+  parseReportDateTime,
+} from "./reportDateTime";
 import "./recaptcha.css";
 
 const ReportEncounter = observer(() => {
@@ -71,7 +75,9 @@ const ReportEncounter = observer(() => {
         store.setImageSectionFileNames(fileName, "add");
       });
     localStorage.getItem("datetime") &&
-      store.setDateTimeSectionValue(new Date(localStorage.getItem("datetime")));
+      store.setDateTimeSectionValue(
+        parseReportDateTime(localStorage.getItem("datetime")),
+      );
     localStorage.getItem("exifDateTime") &&
       store.setExifDateTime(localStorage.getItem("exifDateTime"));
     localStorage.getItem("locationID") &&
@@ -369,7 +375,7 @@ const ReportEncounter = observer(() => {
                   store.dateTimeSection.value &&
                     localStorage.setItem(
                       "datetime",
-                      store.dateTimeSection.value?.toISOString(),
+                      formatReportDateTime(store.dateTimeSection.value),
                     );
                   store.exifDateTime &&
                     localStorage.setItem("exifDateTime", store.exifDateTime);

--- a/frontend/src/pages/ReportsAndManagamentPages/ReportEncounterStore.js
+++ b/frontend/src/pages/ReportsAndManagamentPages/ReportEncounterStore.js
@@ -1,5 +1,9 @@
 import { makeAutoObservable } from "mobx";
 import axios from "axios";
+import {
+  formatReportDateTime,
+  parseReportDateTime,
+} from "./reportDateTime";
 
 export class ReportEncounterStore {
   _isLoggedin;
@@ -332,16 +336,12 @@ export class ReportEncounterStore {
     }
 
     if (this._dateTimeSection.required) {
-      const dateValue = this._dateTimeSection.value
-        ? new Date(this._dateTimeSection.value)
-        : null;
+      const dateValue = parseReportDateTime(this._dateTimeSection.value);
 
       const isFutureDate =
-        dateValue &&
-        !Number.isNaN(dateValue.getTime()) &&
-        dateValue > new Date();
+        dateValue.isValid() && dateValue.isAfter(parseReportDateTime(new Date()));
 
-      if (!dateValue || Number.isNaN(dateValue.getTime()) || isFutureDate) {
+      if (!dateValue.isValid() || isFutureDate) {
         this._dateTimeSection.error = true;
         isValid = false;
       }
@@ -363,7 +363,7 @@ export class ReportEncounterStore {
         const payload = {
           submissionId: this._imageSectionSubmissionId,
           assetFilenames: this._imageSectionFileNames,
-          dateTime: this._dateTimeSection.value,
+          dateTime: formatReportDateTime(this._dateTimeSection.value),
           taxonomy: this._speciesSection.value,
           locationId: this._placeSection.locationId,
           comments: this._additionalCommentsSection.value,

--- a/frontend/src/pages/ReportsAndManagamentPages/reportDateTime.js
+++ b/frontend/src/pages/ReportsAndManagamentPages/reportDateTime.js
@@ -1,0 +1,34 @@
+import moment from "moment";
+
+export const REPORT_DATE_TIME_FORMAT = "YYYY-MM-DDTHH:mm";
+
+const CIVIL_DATE_TIME_FORMATS = [
+  REPORT_DATE_TIME_FORMAT,
+  "YYYY-MM-DDTHH:mm:ss",
+  "YYYY-MM-DDTHH:mm:ss.SSS",
+  "YYYY-MM-DD HH:mm",
+  "YYYY-MM-DD HH:mm:ss",
+  "YYYY-MM-DD",
+];
+
+// Encounter dates are civil values.  They must not acquire a timezone merely
+// because they pass through a browser Date or JSON serialization.
+export function parseReportDateTime(value) {
+  if (!value) return moment("");
+
+  if (typeof value === "string") {
+    // Older login continuations stored an ISO instant.  Parsing that as an
+    // instant restores the local value the reporter had selected; all newly
+    // saved values use one of the civil formats above.
+    if (/(Z|[+-]\d\d:\d\d)$/.test(value)) return moment(value);
+    return moment(value, CIVIL_DATE_TIME_FORMATS, true);
+  }
+
+  return moment(value);
+}
+
+export function formatReportDateTime(value) {
+  const dateTime = parseReportDateTime(value);
+  if (!dateTime.isValid()) return null;
+  return dateTime.format(REPORT_DATE_TIME_FORMAT);
+}

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -43,7 +43,7 @@ import org.ecocean.Util.MeasurementDesc;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.LocalDateTime;
+import org.joda.time.format.ISODateTimeFormat;
 
 import org.datanucleus.api.rest.orgjson.JSONArray;
 import org.datanucleus.api.rest.orgjson.JSONException;
@@ -2351,6 +2351,7 @@ public class Encounter extends Base implements java.io.Serializable {
             try { myMinutes = Integer.parseInt(minutes); } catch (Exception e) {}
             TimeZone tz = TimeZone.getTimeZone("UTC");
             Calendar calendar = Calendar.getInstance(tz);
+            calendar.clear();
             calendar.set(year, localMonth, localDay, localHour, myMinutes);
             return new Long(calendar.getTimeInMillis());
         }
@@ -2372,7 +2373,7 @@ public class Encounter extends Base implements java.io.Serializable {
         this.year = cal.get(Calendar.YEAR);
         this.month = cal.get(Calendar.MONTH) + 1;
         this.day = cal.get(Calendar.DAY_OF_MONTH);
-        this.hour = cal.get(Calendar.HOUR);
+        this.hour = cal.get(Calendar.HOUR_OF_DAY);
         this.minutes = Integer.toString(cal.get(Calendar.MINUTE));
         if (this.minutes.length() == 1) this.minutes = "0" + this.minutes;
         this.dateInMilliseconds = ms;
@@ -2419,13 +2420,25 @@ public class Encounter extends Base implements java.io.Serializable {
         }
         try {
             String adjusted = Util.getISO8601Date(iso8601);
-            DateTime dt = new DateTime(adjusted);
+            // Parse with the supplied offset retained rather than normalizing
+            // into the JVM default zone, so the civil fields below reflect the
+            // wall-clock value the reporter selected regardless of server zone.
+            DateTime dt = ISODateTimeFormat.dateTimeParser().withOffsetParsed()
+                .parseDateTime(adjusted);
             if (Util.dateIsInFuture(dt.getYear(), dt.getMonthOfYear(), dt.getDayOfMonth())) {
                 error.put("fieldName", "day");
                 error.put("value", dt.getDayOfMonth());
                 throw new ApiException("date is in the future", error);
             }
-            this.setDateInMilliseconds(dt.getMillis());
+            // Encounter event dates are civil values, not instants.  Retain
+            // the fields supplied by the reporter (including an optional ISO
+            // offset) rather than converting them into UTC first.
+            this.year = dt.getYear();
+            this.month = dt.getMonthOfYear();
+            this.day = dt.getDayOfMonth();
+            this.hour = dt.getHourOfDay();
+            this.minutes = Integer.toString(dt.getMinuteOfHour());
+            if (this.minutes.length() == 1) this.minutes = "0" + this.minutes;
         // pass this flavor out...
         } catch (ApiException ex) {
             throw ex;

--- a/src/test/java/org/ecocean/api/EncounterApiTest.java
+++ b/src/test/java/org/ecocean/api/EncounterApiTest.java
@@ -144,6 +144,27 @@ class EncounterApiTest {
         assertEquals(dv.getInt("minutes"), 15);
     }
 
+    @Test void encounterDateTimeRetainsCivilFields() throws ApiException {
+        Encounter enc = new Encounter();
+
+        enc.setDateFromISO8601String("2020-07-17T08:45:00-07:00");
+
+        assertEquals(2020, enc.getYear());
+        assertEquals(7, enc.getMonth());
+        assertEquals(17, enc.getDay());
+        assertEquals(8, enc.getHour());
+        assertEquals("45", enc.getMinutes());
+    }
+
+    @Test void setDateInMillisecondsUses24HourClock() {
+        Encounter enc = new Encounter();
+
+        enc.setDateInMilliseconds(new org.joda.time.DateTime("2020-07-17T15:45:00Z").getMillis());
+
+        assertEquals(15, enc.getHour());
+        assertEquals("45", enc.getMinutes());
+    }
+
     @Test void futureDateTest()
     throws ApiException {
         Encounter enc = new Encounter();


### PR DESCRIPTION
## Summary
- submit React report date-times as timezone-free civil values
- preserve a reporter's entered date and 24-hour time in Encounter persistence
- retain explicit ISO offsets while extracting civil fields, independent of the JVM timezone
- retain compatibility for legacy report drafts containing instant-form timestamps

## Verification
- targeted React report date-time/store tests
- targeted EncounterApiTest
- EncounterApiTest verified with both UTC and America/Los_Angeles JVM timezones