### PR TITLE
fix(match): link to existing individual by primary key, not just UUID (#1305)

### DIFF
--- a/src/main/webapp/iaResultsSetID.jsp
+++ b/src/main/webapp/iaResultsSetID.jsp
@@ -199,9 +199,13 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
                                 }
 				if (Util.stringExists(individualID)) {
 					System.out.println("CASE 1: both indy null");
-					if (Util.isUUID(individualID)) {
-						indiv = myShepherd.getMarkedIndividual(individualID);
-					}
+					// Always attempt an existing-individual lookup by primary key before
+					// creating. individualID here is a MarkedIndividual primary key
+					// (getId()); legacy individuals have human-readable string keys
+					// (e.g. "TZ-173"), not UUIDs, so a UUID-only guard would skip the
+					// lookup and mint a duplicate. getMarkedIndividualQuiet is an exact
+					// PK lookup that returns null on a miss (see issue #1305).
+					indiv = myShepherd.getMarkedIndividualQuiet(individualID);
 					if (indiv==null) {
 						indiv = new MarkedIndividual(individualID, enc);
                                                 isNewIndiv = true;


### PR DESCRIPTION
## Problem

Fixes #1305. Confirming a positive match to an **existing** individual from the
match-results page could create a **duplicate** `MarkedIndividual` (a fresh
system UUID with the target's name copied over) instead of attaching the
encounter to the existing individual. Seen on Sharkbook for individuals whose
ID is a human-readable string such as `TZ-173`; modern UUID-keyed individuals
were unaffected.

## Root cause

Both the legacy `iaResults.jsp` UI and the new (10.10+) React match UI
(`MatchResultsPage` → `handleMatch()`) confirm an assign-to-existing by calling
the same backend:

```
GET /iaResultsSetID.jsp?number=<queryEnc>&taskId=<t>&individualID=<targetPK>&encOther=...
```

`individualID` is the target individual's primary key (`MarkedIndividual.getId()`).
In this flow the query encounter and any `encOther` are unnamed, so
`allEncIndivs` is empty and control always reaches **CASE 1**. There the
existing-individual lookup was gated on `Util.isUUID(individualID)`:

```jsp
if (Util.isUUID(individualID)) {
    indiv = myShepherd.getMarkedIndividual(individualID);
}
if (indiv == null) {
    indiv = new MarkedIndividual(individualID, enc);   // mints a duplicate
}
```

Legacy individuals have non-UUID string primary keys, so `isUUID("TZ-173")` is
false, the lookup was skipped, and a duplicate was created — the
`MarkedIndividual(String, Encounter)` constructor generates a new UUID and keeps
the string only as a name, which matches the reported fingerprint (original id =
`TZ-173`, duplicate = a system UUID).

The 10.10 interface replacement rebuilt only the UI; the assign-to-existing
backend is unchanged and shared, so this was **not** fixed by that work.

## Fix

Always attempt an exact primary-key lookup before constructing:

```jsp
indiv = myShepherd.getMarkedIndividualQuiet(individualID);
if (indiv == null) {
    indiv = new MarkedIndividual(individualID, enc);
    isNewIndiv = true;
}
```

`getMarkedIndividualQuiet` is an exact JDO primary-key lookup that returns `null`
on a miss (works for both UUID and legacy string keys). This corrects both UI
callers at the right altitude — a React-only change could not fix the legacy
caller.

### Intentional behavior change

A manually typed name or project incremental name that **exactly equals an
existing individual's primary key** now links to that individual rather than
creating a second same-named individual. Existing PKs take precedence, which is
the correct identity rule. Normal new names (PK miss) and the `useLocation`
next-name path are unchanged.

## Testing

- Change is a one-line, type-correct backend swap in a JSP scriptlet; reviewed by
  Codex (design + implementation) — converged, no findings.
- Recommended live verification: on a dataset with legacy string-PK individuals
  (`TZ-*`), confirm a match against one and verify the encounter attaches to the
  existing individual with **no** new `MarkedIndividual` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
