### PR TITLE
fix(ia): exclude subspecies from Manual Annotation IA-class dropdown (#1298)

### DIFF
--- a/devops/deploy/.dockerfiles/tomcat/IA-wbia.json
+++ b/devops/deploy/.dockerfiles/tomcat/IA-wbia.json
@@ -30,6 +30,7 @@
 		},
 
 		"camelopardalis": {
+			"_subspecies": ["camelopardalis", "antiquorum", "peralta"],
 			"camelopardalis": "@Giraffa.tippelskirchi",
 			"antiquorum": "@Giraffa.tippelskirchi",
 			"peralta": "@Giraffa.tippelskirchi",
@@ -43,6 +44,7 @@
 		},
 
 		"tippelskirchi": {
+			"_subspecies": ["thornicrofti"],
 			"thornicrofti": "@Giraffa.tippelskirchi",
 			"_detect_conf": [
 				{

--- a/devops/development/.dockerfiles/tomcat/IA-wbia.json
+++ b/devops/development/.dockerfiles/tomcat/IA-wbia.json
@@ -30,6 +30,7 @@
 		},
 
 		"camelopardalis": {
+			"_subspecies": ["camelopardalis", "antiquorum", "peralta"],
 			"camelopardalis": "@Giraffa.tippelskirchi",
 			"antiquorum": "@Giraffa.tippelskirchi",
 			"peralta": "@Giraffa.tippelskirchi",
@@ -43,6 +44,7 @@
 		},
 
 		"tippelskirchi": {
+			"_subspecies": ["thornicrofti"],
 			"thornicrofti": "@Giraffa.tippelskirchi",
 			"_detect_conf": [
 				{

--- a/src/main/java/org/ecocean/IAJsonProperties.java
+++ b/src/main/java/org/ecocean/IAJsonProperties.java
@@ -439,6 +439,12 @@ public class IAJsonProperties extends JsonProperties {
             return false;
         } else if (key.equals("match_trivial")) {
             return false;
+        } else if (isSubspeciesKey(key, underTaxy)) {
+            // issue #1298: subspecies are taxonomic children, not matchable IA
+            // classes, but they sit as sibling keys under the species node. A
+            // species node marks its subspecies via a "_subspecies" list of child
+            // key names so they are excluded from the Manual Annotation dropdown.
+            return false;
         } else if (underTaxy.get(key) instanceof String &&
             ((String)underTaxy.get(key)).startsWith("@")) {
             return ((String)underTaxy.get(key)).endsWith("." + key);
@@ -450,6 +456,19 @@ public class IAJsonProperties extends JsonProperties {
             }
         }
         return true;
+    }
+
+    // issue #1298: a species node lists its subspecies child keys in "_subspecies"
+    // so they can be distinguished from matchable IA classes (both are non-"_"
+    // sibling keys with no structural difference otherwise).
+    private boolean isSubspeciesKey(String key, JSONObject underTaxy) {
+        JSONArray subspecies = underTaxy.optJSONArray("_subspecies");
+
+        if (subspecies == null) return false;
+        for (int i = 0; i < subspecies.length(); i++) {
+            if (key.equals(subspecies.optString(i))) return true;
+        }
+        return false;
     }
 
     public List<String> getValidIAClassesIgnoreRedirects(Taxonomy taxy) {

--- a/src/test/java/org/ecocean/IAJsonPropertiesTest.java
+++ b/src/test/java/org/ecocean/IAJsonPropertiesTest.java
@@ -1,8 +1,12 @@
 package org.ecocean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -173,5 +177,59 @@ class IAJsonPropertiesTest {
                                 .put("pipeline_root", "vector"))))));
         IAJsonProperties iac = iaConfigWith(json);
         assertNull(iac.getActiveMlServiceConfigs(TAXY));
+    }
+
+    // --- issue #1298: subspecies must not appear as selectable IA classes ---
+
+    private static final Taxonomy PHOCA = new Taxonomy("Phoca vitulina");
+
+    // object-valued subspecies listed in the species node's "_subspecies" marker
+    // is excluded from the dropdown, while a sibling real IA class is kept.
+    @Test void getValidIAClassesIgnoreRedirects_excludesObjectSubspeciesInMarkerList() {
+        JSONObject json = new JSONObject()
+            .put("Phoca", new JSONObject()
+                .put("vitulina", new JSONObject()
+                    .put("_subspecies", new JSONArray().put("vitulina"))
+                    .put("vitulina", new JSONObject())   // subspecies, object-valued
+                    .put("seal", new JSONObject())        // real IA class
+                    .put("seal+head", new JSONObject()))); // real IA class
+        IAJsonProperties iac = iaConfigWith(json);
+        List<String> classes = iac.getValidIAClassesIgnoreRedirects(PHOCA);
+        assertTrue(classes.contains("seal"), "real IA class 'seal' should be selectable");
+        assertTrue(classes.contains("seal+head"),
+            "real IA class 'seal+head' should be selectable");
+        assertFalse(classes.contains("vitulina"),
+            "subspecies 'vitulina' must not be selectable");
+    }
+
+    // a self-referencing redirect subspecies ("@Phoca.vitulina.vitulina") would be
+    // INCLUDED by the endsWith(".vitulina") heuristic; the "_subspecies" marker must
+    // take precedence and exclude it.
+    @Test void getValidIAClassesIgnoreRedirects_markerOverridesSelfRedirectHeuristic() {
+        JSONObject json = new JSONObject()
+            .put("Phoca", new JSONObject()
+                .put("vitulina", new JSONObject()
+                    .put("_subspecies", new JSONArray().put("vitulina"))
+                    .put("vitulina", "@Phoca.vitulina.vitulina")  // self-redirect subspecies
+                    .put("seal", new JSONObject())));
+        IAJsonProperties iac = iaConfigWith(json);
+        List<String> classes = iac.getValidIAClassesIgnoreRedirects(PHOCA);
+        assertTrue(classes.contains("seal"), "real IA class 'seal' should be selectable");
+        assertFalse(classes.contains("vitulina"),
+            "marker must override the self-redirect suffix heuristic");
+    }
+
+    // control: with no "_subspecies" marker, behavior is unchanged (real classes kept).
+    @Test void getValidIAClassesIgnoreRedirects_noMarkerKeepsRealClasses() {
+        JSONObject json = new JSONObject()
+            .put("Phoca", new JSONObject()
+                .put("vitulina", new JSONObject()
+                    .put("seal", new JSONObject())
+                    .put("seal+head", new JSONObject())));
+        IAJsonProperties iac = iaConfigWith(json);
+        List<String> classes = iac.getValidIAClassesIgnoreRedirects(PHOCA);
+        assertTrue(classes.contains("seal"), "real IA class 'seal' should be selectable");
+        assertTrue(classes.contains("seal+head"),
+            "real IA class 'seal+head' should be selectable");
     }
 }


### PR DESCRIPTION
## Problem

Fixes #1298. The Manual Annotation tool listed **subspecies** as selectable IA
classes — e.g. species `Phoca vitulina` showed subspecies `vitulina` next to real
classes like `seal` / `seal+head`, and `Giraffa camelopardalis` showed
`camelopardalis`. Subspecies are not matchable classes; offering them causes WBIA
errors (no matching config) and misses matches by constraining comparisons to a
bogus same-class set.

## Root cause

IA.json nests `genus → species → { IA-class keys AND subspecies keys as siblings }`,
with **no structural difference** between the two. The dropdown source
(`SiteSettings.iaClassesForTaxonomy` → `getValidIAClassesIgnoreRedirects` →
`isUserSelectableIAClass`) had no subspecies detection and defaulted to *selectable*.
Subspecies were only filtered when written as an `@`-redirect pointing to a
**different** node — and only by accident of the `endsWith("." + key)` heuristic.
So subspecies defined as nested objects, or as self-referencing redirects
(`"vitulina": "@Phoca.vitulina.vitulina"`), leaked into the dropdown.

## Fix

Introduce an explicit marker: a species node lists its subspecies child keys in a
`"_subspecies"` array, and `isUserSelectableIAClass` excludes any key in that list.
The check runs **before** the redirect heuristic, so the marker is authoritative.
`"_subspecies"` is a `_`-prefixed key, so every existing consumer already skips it.

```json
"vitulina": {
  "_subspecies": ["vitulina"],
  "vitulina": { ... },     // subspecies — excluded
  "seal": { ... },         // real IA class — kept
  "seal+head": { ... }     // real IA class — kept
}
```

Only `getValidIAClassesIgnoreRedirects` is affected. `MetricsBot` also consumes it
and correctly stops counting subspecies as IA classes. Raw `getValidIAClasses`
(used for ident-config bundling), detection validation, and `_save_as` remapping
use direct lookups and are intentionally unchanged.

## Testing

First unit coverage of this method (`IAJsonPropertiesTest`, synthetic `setJson`
trees) — 14/14 green:
- **object-valued** subspecies in `_subspecies` → excluded, sibling classes kept;
- **self-referencing-redirect** subspecies → excluded, proving the marker overrides
  the `endsWith` heuristic (this case leaks without the fix);
- **no marker** → unchanged (control).

## Scope note (please read before merge)

This is an **opt-in** fix: the code teaches the dropdown to honor `_subspecies`
markers, but each install must add those markers to species in its own IA.json
whose subspecies are defined as **objects or self-referencing redirects**.

The sample `IA-wbia.json` edits (Giraffa nodes) **document the convention but do not
change that config's behavior** — its giraffe subspecies are cross-node redirects
already excluded by the old heuristic. The repo has no sample config that exhibits
the object-valued leak (e.g. the Seals config that prompted the report lives only
on that install), so the behavioral proof is the unit tests above rather than a
repo config diff. Ops action for affected installs: add `_subspecies` lists to the
relevant species nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
