### PR TITLE
Fix quicksearch ordering: rank by relevance, not id sort

### DIFF
--- a/frontend/src/__tests__/components/header/usePostHeaderQuickSearch.test.js
+++ b/frontend/src/__tests__/components/header/usePostHeaderQuickSearch.test.js
@@ -26,9 +26,16 @@ describe("usePostHeaderQuickSearch", () => {
       await new Promise((resolve) => setTimeout(resolve, 300));
     });
 
+    // No sort URL param: an explicit sort would replace relevance ranking
+    // and the boosted should-clauses would have no effect on ordering.
     expect(axios.post).toHaveBeenCalledWith(
-      "/api/v3/search/individual?size=10&sort=id&sortOrder=asc",
-      expect.any(Object),
+      "/api/v3/search/individual?size=10",
+      expect.objectContaining({
+        sort: [
+          { _score: { order: "desc" } },
+          { names: { order: "asc", unmapped_type: "keyword" } },
+        ],
+      }),
     );
     expect(result.current.searchResults).toEqual(mockData.data.hits);
     expect(result.current.loading).toBe(false);

--- a/frontend/src/models/usePostHeaderQuickSearch.js
+++ b/frontend/src/models/usePostHeaderQuickSearch.js
@@ -17,7 +17,18 @@ export default function usePostHeaderQuickSearch(value) {
       const searchValue = value.trim();
       const searchValueLower = searchValue.toLowerCase();
       axios
-        .post("/api/v3/search/individual?size=10&sort=id&sortOrder=asc", {
+        .post("/api/v3/search/individual?size=10", {
+          // Rank by relevance (the boosted should-clauses below), then by name
+          // for deterministic order within a tier. A `sort` URL param would
+          // replace relevance ranking entirely, and `id` is a UUID for newer
+          // individuals, so sorting on it returns an arbitrary subset of the
+          // matches (issue #1541).
+          // (multi-valued names sort by their lowest value; unmapped_type keeps
+          // the query working on an index without the names mapping)
+          sort: [
+            { _score: { order: "desc" } },
+            { names: { order: "asc", unmapped_type: "keyword" } },
+          ],
           query: {
             bool: {
               minimum_should_match: 1,


### PR DESCRIPTION
## Summary
Follow-up to #1543, which did not fully fix #1541 (see the [recent report](https://github.com/WildMeOrg/Wildbook/pull/1543#issuecomment-5051645545) of "GNS-28" skipping from GNS-2800 to GNS-2807).

## Root cause
#1543 added boosted `should` clauses **and** `sort=id&sortOrder=asc` on the request URL. An explicit sort makes OpenSearch replace relevance ranking entirely, so the boost tiers never affected ordering. `id` (individualID) is a UUID for React-era individuals while the dropdown displays `names`, so the `size=10` window returned an arbitrary subset of the matches — e.g. GNS-2800 then GNS-2807 with GNS-2801..2806 missing — and an exact match could still fall outside the window (the original #1541 symptom).

## Changes
- Remove the `sort`/`sortOrder` URL params from the quicksearch request
- Add a body-level `sort: [{_score: desc}, {names: asc}]`: relevance tiers first (exact → prefix → partial), then displayed-name order within a tier for deterministic results
- `unmapped_type: "keyword"` on the `names` sort so the query still works on an index without the `names` mapping
- Updated the hook test to pin the new URL and body sort

The backend needs no change: `queryPit()` only injects a sort when the URL param is present, so the body sort reaches OpenSearch intact on the session path.

Notes: multi-valued `names` sort by their lowest value, so an individual with an alias sorting before its ID-style name orders by the alias (both are displayed). A backend integration test pinning end-to-end ordering would be a good follow-up.

## Test plan
- [x] Hook jest tests updated, all 60 header tests green (jest is not CI-gating; run locally)
- [ ] Search "GNS-28" on Sharkbook: expect GNS-28 first, then GNS-2800, GNS-2801, ... in order

Fixes #1541

Reviewed by Codex (2 rounds, converged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)