### PR TITLE
fix: resolve existing individuals by name when assigning IDs to encounters (#1318)

### DIFF
--- a/frontend/src/__tests__/pages/MatchResults/matchResultsStore.test.js
+++ b/frontend/src/__tests__/pages/MatchResults/matchResultsStore.test.js
@@ -838,6 +838,43 @@ describe("MatchResultsStore — handleCreateNewIndividual", () => {
     });
     expect(axios.patch).toHaveBeenCalledTimes(1);
   });
+
+  test("does not re-send the name when the response lacks the created uuid", async () => {
+    store.setNewIndividualName("Nemo");
+    store.setSelectedMatch(true, "k1", "enc-a", null, null);
+    store.setSelectedMatch(true, "k2", "enc-b", null, null);
+    axios.patch.mockResolvedValue({ data: {} }); // no patchResults[].individualId
+    const result = await store.handleCreateNewIndividual(null);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("CREATE_NEW_INDIVIDUAL_PARTIAL");
+    // only the first encounter may be patched with the raw name
+    expect(axios.patch).toHaveBeenCalledTimes(1);
+    expect(result.failures).toHaveLength(1);
+  });
+
+  test("next-name (locationId) ops are also rewritten to the returned uuid", async () => {
+    store.setNewIndividualName("placeholder", true);
+    store._encounterLocationId = "loc-1";
+    store.setSelectedMatch(true, "k1", "enc-a", null, null);
+    store.setSelectedMatch(true, "k2", "enc-b", null, null);
+    axios.patch
+      .mockResolvedValueOnce({
+        data: { patchResults: [{ individualId: "uuid-777" }] },
+      })
+      .mockResolvedValue({ data: {} });
+    const result = await store.handleCreateNewIndividual(null);
+    expect(result.ok).toBe(true);
+    const firstOps = axios.patch.mock.calls[0][1];
+    expect(firstOps.find((op) => op.path === "individualId").value).toEqual({
+      type: "locationId",
+      value: "loc-1",
+    });
+    const secondOps = axios.patch.mock.calls[1][1];
+    // second encounter must NOT allocate another next-name
+    expect(secondOps.find((op) => op.path === "individualId").value).toBe(
+      "uuid-777",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/__tests__/pages/MatchResults/matchResultsStore.test.js
+++ b/frontend/src/__tests__/pages/MatchResults/matchResultsStore.test.js
@@ -801,6 +801,43 @@ describe("MatchResultsStore — handleCreateNewIndividual", () => {
     await store.handleCreateNewIndividual(null);
     expect(store.matchRequestLoading).toBe(false);
   });
+
+  test("creates via first encounter, attaches the rest by returned uuid", async () => {
+    store.setNewIndividualName("Nemo");
+    store.setSelectedMatch(true, "k1", "enc-a", null, null);
+    store.setSelectedMatch(true, "k2", "enc-b", null, null);
+    axios.patch
+      .mockResolvedValueOnce({
+        data: { patchResults: [{ individualId: "uuid-123" }] },
+      })
+      .mockResolvedValue({ data: {} });
+    const result = await store.handleCreateNewIndividual(null);
+    expect(result.ok).toBe(true);
+    expect(axios.patch).toHaveBeenCalledTimes(2);
+    const firstOps = axios.patch.mock.calls[0][1];
+    const secondOps = axios.patch.mock.calls[1][1];
+    expect(firstOps.find((op) => op.path === "individualId").value).toBe(
+      "Nemo",
+    );
+    // the second encounter must reference the individual by uuid, not name,
+    // so parallel creates cannot mint duplicates (issue 1318)
+    expect(secondOps.find((op) => op.path === "individualId").value).toBe(
+      "uuid-123",
+    );
+  });
+
+  test("does not patch remaining encounters when the first patch fails", async () => {
+    store.setNewIndividualName("Nemo");
+    store.setSelectedMatch(true, "k1", "enc-a", null, null);
+    store.setSelectedMatch(true, "k2", "enc-b", null, null);
+    axios.patch.mockRejectedValueOnce(new Error("server error"));
+    const result = await store.handleCreateNewIndividual(null);
+    expect(result).toEqual({
+      ok: false,
+      error: "CREATE_NEW_INDIVIDUAL_FAILED",
+    });
+    expect(axios.patch).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
+++ b/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
@@ -618,21 +618,30 @@ export default class MatchResultsStore {
           firstResult.response?.data?.patchResults?.find(
             (r) => r?.individualId,
           )?.individualId;
-        const restOps = resolvedIndividualId
-          ? patchOps.map((op) =>
-              op.path === "individualId"
-                ? { ...op, value: resolvedIndividualId }
-                : op,
-            )
-          : patchOps;
-        const restResults = await Promise.all(
-          restIds.map((id) => doPatch(id, restOps)),
-        );
-        for (const r of restResults) {
-          if (r.status === "fulfilled") {
-            successes.push(r.encounterId);
-          } else {
-            failures.push({ encounterId: r.encounterId, error: r.error });
+        if (!resolvedIndividualId) {
+          // never re-send the name per-encounter: parallel creates by name
+          // are exactly what minted duplicates (issue 1318)
+          for (const id of restIds) {
+            failures.push({
+              encounterId: id,
+              error: new Error("could not resolve created individual id"),
+            });
+          }
+        } else {
+          const restOps = patchOps.map((op) =>
+            op.path === "individualId"
+              ? { ...op, value: resolvedIndividualId }
+              : op,
+          );
+          const restResults = await Promise.all(
+            restIds.map((id) => doPatch(id, restOps)),
+          );
+          for (const r of restResults) {
+            if (r.status === "fulfilled") {
+              successes.push(r.encounterId);
+            } else {
+              failures.push({ encounterId: r.encounterId, error: r.error });
+            }
           }
         }
       }

--- a/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
+++ b/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
@@ -583,10 +583,9 @@ export default class MatchResultsStore {
         });
       }
 
-      // Run all PATCHes in parallel and track results
-      const patchPromises = encounterIds.map((id) =>
+      const doPatch = (id, ops) =>
         axios
-          .patch(`/api/v3/encounters/${encodeURIComponent(id)}`, patchOps, {
+          .patch(`/api/v3/encounters/${encodeURIComponent(id)}`, ops, {
             headers: {
               "Content-Type": "application/json-patch+json",
               Accept: "application/json",
@@ -595,22 +594,45 @@ export default class MatchResultsStore {
           .then(
             (response) => ({ status: "fulfilled", encounterId: id, response }),
             (error) => ({ status: "rejected", encounterId: id, error }),
-          ),
-      );
+          );
 
-      const results = await Promise.allSettled(patchPromises);
+      // Create (or resolve) the individual via the FIRST encounter only, then
+      // attach the remaining encounters by the returned uuid. Sending all
+      // PATCHes in parallel with the same name let each transaction miss the
+      // others' uncommitted individual and mint duplicates (issue 1318).
+      const [firstId, ...restIds] = encounterIds;
+      const firstResult = await doPatch(firstId, patchOps);
 
-      // Separate successes and failures
-      const successes = [];
+      if (firstResult.status !== "fulfilled") {
+        // no individual was created; don't retry the same ops per-encounter
+        this._matchRequestError = "CREATE_NEW_INDIVIDUAL_FAILED";
+        toast.error("Failed to create new individual");
+        return { ok: false, error: "CREATE_NEW_INDIVIDUAL_FAILED" };
+      }
+
+      const successes = [firstResult.encounterId];
       const failures = [];
 
-      for (const result of results) {
-        if (result.status === "fulfilled") {
-          const { status, encounterId, error } = result.value;
-          if (status === "fulfilled") {
-            successes.push(encounterId);
+      if (restIds.length > 0) {
+        const resolvedIndividualId =
+          firstResult.response?.data?.patchResults?.find(
+            (r) => r?.individualId,
+          )?.individualId;
+        const restOps = resolvedIndividualId
+          ? patchOps.map((op) =>
+              op.path === "individualId"
+                ? { ...op, value: resolvedIndividualId }
+                : op,
+            )
+          : patchOps;
+        const restResults = await Promise.all(
+          restIds.map((id) => doPatch(id, restOps)),
+        );
+        for (const r of restResults) {
+          if (r.status === "fulfilled") {
+            successes.push(r.encounterId);
           } else {
-            failures.push({ encounterId, error });
+            failures.push({ encounterId: r.encounterId, error: r.error });
           }
         }
       }

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -5219,6 +5219,10 @@ public class Encounter extends Base implements java.io.Serializable {
     // user should already have been validated -- via obj.canUserEdit() -- in api/BaseObject, so this
     // does not need to be tested here. however, more detailed checks may require user (e.g. can user
     // also alter another object, such as Occurrence)
+    // not persisted; carries individuals touched by processPatch() to afterPatch()
+    // within a single request so they get indexed post-commit
+    private transient Set<MarkedIndividual> patchIndividualsToIndex = null;
+
     public org.json.JSONObject processPatch(org.json.JSONArray patchArr, User user,
         Shepherd myShepherd)
     throws ApiException {
@@ -5254,9 +5258,24 @@ public class Encounter extends Base implements java.io.Serializable {
                 occ.setSkipAutoIndexing(false);
             }
         }
+        this.patchIndividualsToIndex = new HashSet<MarkedIndividual>();
         for (MarkedIndividual indiv : indivNeedPruning) {
             if (!indiv.pruneIfNeeded(myShepherd)) {
                 indiv.setSkipAutoIndexing(false);
+                // removeIndividual() suppressed auto-indexing on this (old)
+                // individual, so afterPatch() must index it explicitly
+                this.patchIndividualsToIndex.add(indiv);
+            }
+        }
+        // a patched-in individual may be brand new (created this transaction);
+        // index it post-commit so it is searchable without waiting for the
+        // background reconciler -- see issue 1318
+        for (int i = 0; i < patchArr.length(); i++) {
+            org.json.JSONObject p = patchArr.optJSONObject(i);
+            if ((p != null) && "individualId".equals(p.optString("path", null)) &&
+                (this.getIndividual() != null)) {
+                this.patchIndividualsToIndex.add(this.getIndividual());
+                break;
             }
         }
         // no exceptions means success
@@ -5549,6 +5568,19 @@ public class Encounter extends Base implements java.io.Serializable {
             }
         }
         if (newAssetsArr.length() > 0) res.put("newMediaAssets", newAssetsArr);
+        // individuals touched by this patch (newly created, or detached old ones
+        // whose auto-indexing was suppressed) are indexed here, post-commit, so
+        // their documents are searchable promptly (best-effort; the background
+        // reconciler remains the backstop) -- see issue 1318
+        if (this.patchIndividualsToIndex != null) {
+            for (MarkedIndividual indiv : this.patchIndividualsToIndex) {
+                // the names cache key (MultiValue id) is db-assigned; refresh again
+                // now that commit definitely happened, in case it was unset earlier
+                indiv.refreshNamesCache();
+                needsIndexing.add(indiv);
+            }
+            this.patchIndividualsToIndex = null;
+        }
         BulkImportUtil.bulkOpensearchIndex(needsIndexing);
         return res;
     }

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -2498,7 +2498,9 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
 
         if (nameIds.size() < 1) return rtn;
         String taxonomyStringFilter = "";
-        if ((genus != null) && (specificEpithet != null)) {
+        // blank ("") genus/specificEpithet must mean *no* taxonomy scope, not a
+        // filter for empty-string taxonomy fields
+        if (Util.stringExists(genus) && Util.stringExists(specificEpithet)) {
             genus = genus.trim();
             specificEpithet = specificEpithet.trim();
             taxonomyStringFilter = " && enc.genus == '" + genus + "' && enc.specificEpithet == '" +
@@ -2657,6 +2659,11 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
     public void refreshNamesCache() {
         if (names == null) return;
         if (NAMES_CACHE == null) return; // snh
+        // an unpersisted MultiValue still has the default id (0); caching under
+        // that shared key would pollute the cache (and a rollback would leave a
+        // phantom name). callers must refresh again after persisting -- as
+        // BulkImporter and EncounterPatchValidator do.
+        if (names.getId() == 0) return;
         NAMES_CACHE.put(names.getId(),
             this.getId() + ";" + String.join(";", names.getAllValues()).toLowerCase());
     }

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -2485,8 +2485,18 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
             return rtn;
         }
         // System.out.println("findByNames nameIds: "+nameIds.toString());
+        return findByNameIds(myShepherd, nameIds, genus, specificEpithet);
+    }
+
+    public static List<MarkedIndividual> findByNames(Shepherd myShepherd, String regex) {
+        return findByNames(myShepherd, regex, null, null);
+    }
+
+    private static List<MarkedIndividual> findByNameIds(Shepherd myShepherd, List<String> nameIds,
+        String genus, String specificEpithet) {
+        List<MarkedIndividual> rtn = new ArrayList<MarkedIndividual>();
+
         if (nameIds.size() < 1) return rtn;
-        // System.out.println("findByNames: "+genus+" "+specificEpithet);
         String taxonomyStringFilter = "";
         if ((genus != null) && (specificEpithet != null)) {
             genus = genus.trim();
@@ -2497,7 +2507,7 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         String jdoql =
             "SELECT FROM org.ecocean.MarkedIndividual WHERE encounters.contains(enc) && (names.id == "
             + String.join(" || names.id == ", nameIds) + ")" + taxonomyStringFilter;
-        System.out.println("findByNames jdoql: " + jdoql);
+        System.out.println("findByNameIds jdoql: " + jdoql);
         Query query = myShepherd.getPM().newQuery(jdoql);
         if (query == null) return rtn; // this is really only to save us while testing snh irl
         Collection c = (Collection)(query.execute());
@@ -2509,8 +2519,31 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         return rtn;
     }
 
-    public static List<MarkedIndividual> findByNames(Shepherd myShepherd, String regex) {
-        return findByNames(myShepherd, regex, null, null);
+    // exact (whole-name), case-insensitive lookup backed by NAMES_CACHE. unlike
+    // findByNames() the name is never treated as a regex, so names containing
+    // regex metacharacters are safe. genus+specificEpithet (both required to
+    // apply) scope matches to individuals with at least one encounter of that
+    // taxonomy, same as findByNames().
+    public static List<MarkedIndividual> findByExactName(Shepherd myShepherd, String name,
+        String genus, String specificEpithet) {
+        List<MarkedIndividual> rtn = new ArrayList<MarkedIndividual>();
+
+        if ((name == null) || (NAMES_CACHE == null)) return rtn;
+        String trimmed = name.trim();
+        List<String> nameIds = new ArrayList<String>();
+        for (Integer nid : NAMES_CACHE.keySet()) {
+            String cached = NAMES_CACHE.get(nid);
+            if (cached == null) continue;
+            // cache value format: "<individualId>;<name1>;<name2>..."
+            String[] parts = cached.split(";");
+            for (int i = 1; i < parts.length; i++) {
+                if (parts[i].equalsIgnoreCase(trimmed)) {
+                    nameIds.add(Integer.toString(nid));
+                    break;
+                }
+            }
+        }
+        return findByNameIds(myShepherd, nameIds, genus, specificEpithet);
     }
 
     public static MarkedIndividual withName(Shepherd myShepherd, String name) {

--- a/src/main/java/org/ecocean/api/patch/EncounterPatchValidator.java
+++ b/src/main/java/org/ecocean/api/patch/EncounterPatchValidator.java
@@ -381,6 +381,12 @@ public class EncounterPatchValidator {
             idOrName = value.toString();
             indiv = myShepherd.getMarkedIndividual(idOrName);
             if (indiv != null) return indiv;
+            // the names cache is ';'-delimited, so a name containing ';' could
+            // never be reliably found again; reject rather than create an
+            // unfindable individual
+            if (idOrName.contains(";"))
+                throw new ApiException("individualId may not contain ';'",
+                        ApiException.ERROR_RETURN_CODE_INVALID);
             // no pk match; the value may be a human-readable id living in names
             // (e.g. an individual created via the match results page), so fall back
             // to an exact name lookup before minting a duplicate -- see issue 1318.

--- a/src/main/java/org/ecocean/api/patch/EncounterPatchValidator.java
+++ b/src/main/java/org/ecocean/api/patch/EncounterPatchValidator.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.time.YearMonth;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.json.JSONArray;
@@ -79,7 +80,10 @@ public class EncounterPatchValidator {
             if (path.equals("individualId") && (value != null)) {
                 MarkedIndividual currentIndiv = enc.getIndividual();
                 if (currentIndiv != null) mayNeedPruning.put(currentIndiv);
-                value = getOrCreateMarkedIndividual(value, myShepherd);
+                value = getOrCreateMarkedIndividual(value, enc, myShepherd);
+                // expose the resolved uuid so clients can reference this individual
+                // (e.g. to patch further encounters) without another name lookup
+                rtn.put("individualId", ((MarkedIndividual)value).getId());
                 System.out.println("applyPatch() path=individualId using " + value);
             }
             if (path.equals("occurrenceId") && (value != null)) {
@@ -343,7 +347,8 @@ public class EncounterPatchValidator {
     }
 
     // should never get called here with null value
-    private static MarkedIndividual getOrCreateMarkedIndividual(Object value, Shepherd myShepherd)
+    private static MarkedIndividual getOrCreateMarkedIndividual(Object value, Encounter enc,
+        Shepherd myShepherd)
     throws ApiException {
         String idOrName = null;
         MarkedIndividual indiv = null;
@@ -376,11 +381,26 @@ public class EncounterPatchValidator {
             idOrName = value.toString();
             indiv = myShepherd.getMarkedIndividual(idOrName);
             if (indiv != null) return indiv;
+            // no pk match; the value may be a human-readable id living in names
+            // (e.g. an individual created via the match results page), so fall back
+            // to an exact name lookup before minting a duplicate -- see issue 1318.
+            // scoped to the encounter taxonomy when set, like bulk import does.
+            List<MarkedIndividual> byName = MarkedIndividual.findByExactName(myShepherd, idOrName,
+                enc.getGenus(), enc.getSpecificEpithet());
+            if (byName.size() > 1)
+                throw new ApiException("multiple existing individuals are named '" + idOrName +
+                        "'; use the individual uuid instead",
+                        ApiException.ERROR_RETURN_CODE_INVALID);
+            if (byName.size() == 1) return byName.get(0);
         }
         indiv = new MarkedIndividual(); // will get assigned id
         indiv.addName(idOrName);
         // other properties like taxonomy set during actual patchOp
         myShepherd.getPM().makePersistent(indiv);
+        // names cache is keyed by the db-assigned MultiValue id, which only exists
+        // now that we persisted; without this the new individual cannot be found
+        // by name until a full cache rebuild (restart)
+        indiv.refreshNamesCache();
         return indiv;
     }
 

--- a/src/test/java/org/ecocean/MarkedIndividualExactNameTest.java
+++ b/src/test/java/org/ecocean/MarkedIndividualExactNameTest.java
@@ -1,0 +1,112 @@
+package org.ecocean;
+
+import javax.jdo.PersistenceManager;
+import javax.jdo.Query;
+
+import org.ecocean.shepherd.core.Shepherd;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.mockito.ArgumentCaptor;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class MarkedIndividualExactNameTest {
+    Shepherd mockShepherd;
+    PersistenceManager mockPM;
+    Query mockQuery;
+    HashMap<Integer, String> savedCache;
+
+    @SuppressWarnings("unchecked")
+    private HashMap<Integer, String> namesCache()
+    throws Exception {
+        Field f = MarkedIndividual.class.getDeclaredField("NAMES_CACHE");
+
+        f.setAccessible(true);
+        return (HashMap<Integer, String>)f.get(null);
+    }
+
+    @BeforeEach void setUp()
+    throws Exception {
+        mockShepherd = mock(Shepherd.class);
+        mockPM = mock(PersistenceManager.class);
+        mockQuery = mock(Query.class);
+        when(mockShepherd.getPM()).thenReturn(mockPM);
+        when(mockPM.newQuery(anyString())).thenReturn(mockQuery);
+        savedCache = new HashMap<Integer, String>(namesCache());
+        namesCache().clear();
+    }
+
+    @AfterEach void tearDown()
+    throws Exception {
+        namesCache().clear();
+        namesCache().putAll(savedCache);
+    }
+
+    @Test void exactNameMatchesAndScopesByTaxonomy()
+    throws Exception {
+        // cache format: "<individualId>;<name1>;<name2>" with names lowercased
+        namesCache().put(7, "11111111-aaaa-bbbb-cccc-dddddddddddd;gns-2620");
+        MarkedIndividual indiv = mock(MarkedIndividual.class);
+        when(mockQuery.execute()).thenReturn(Arrays.asList(indiv));
+
+        List<MarkedIndividual> found = MarkedIndividual.findByExactName(mockShepherd, "GNS-2620",
+            "Carcharodon", "carcharias");
+        assertEquals(1, found.size());
+        assertEquals(indiv, found.get(0));
+
+        ArgumentCaptor<String> jdoql = ArgumentCaptor.forClass(String.class);
+        verify(mockPM).newQuery(jdoql.capture());
+        assertTrue(jdoql.getValue().contains("names.id == 7"));
+        assertTrue(jdoql.getValue().contains("Carcharodon"));
+        assertTrue(jdoql.getValue().contains("carcharias"));
+    }
+
+    @Test void substringOrOtherNamesDoNotMatch()
+    throws Exception {
+        namesCache().put(3, "22222222-aaaa-bbbb-cccc-dddddddddddd;gns-26201;other-name");
+
+        List<MarkedIndividual> found = MarkedIndividual.findByExactName(mockShepherd, "GNS-2620",
+            null, null);
+        assertEquals(0, found.size());
+        verify(mockPM, never()).newQuery(anyString());
+    }
+
+    @Test void caseInsensitiveExactMatchWithoutTaxonomy()
+    throws Exception {
+        namesCache().put(5, "33333333-aaaa-bbbb-cccc-dddddddddddd;r1714");
+        MarkedIndividual indiv = mock(MarkedIndividual.class);
+        when(mockQuery.execute()).thenReturn(Arrays.asList(indiv));
+
+        List<MarkedIndividual> found = MarkedIndividual.findByExactName(mockShepherd, "r1714",
+            null, null);
+        assertEquals(1, found.size());
+        ArgumentCaptor<String> jdoql = ArgumentCaptor.forClass(String.class);
+        verify(mockPM).newQuery(jdoql.capture());
+        // no taxonomy scope when genus/specificEpithet not both given
+        assertTrue(!jdoql.getValue().contains("genus"));
+    }
+
+    @Test void regexMetacharactersInNameAreSafe()
+    throws Exception {
+        namesCache().put(9, "44444444-aaaa-bbbb-cccc-dddddddddddd;r(19+a]");
+        MarkedIndividual indiv = mock(MarkedIndividual.class);
+        when(mockQuery.execute()).thenReturn(Arrays.asList(indiv));
+
+        // must neither throw nor mis-match
+        List<MarkedIndividual> found = MarkedIndividual.findByExactName(mockShepherd, "R(19+a]",
+            null, null);
+        assertEquals(1, found.size());
+        assertEquals(0,
+            MarkedIndividual.findByExactName(mockShepherd, "R.19.a.", null, null).size());
+    }
+}

--- a/src/test/java/org/ecocean/MarkedIndividualExactNameTest.java
+++ b/src/test/java/org/ecocean/MarkedIndividualExactNameTest.java
@@ -96,6 +96,42 @@ class MarkedIndividualExactNameTest {
         assertTrue(!jdoql.getValue().contains("genus"));
     }
 
+    @Test void firstCacheSegmentIsIndividualIdNotAName()
+    throws Exception {
+        namesCache().put(11, "55555555-aaaa-bbbb-cccc-dddddddddddd;gns-1");
+
+        // the leading segment is the individual id and must not match as a name
+        List<MarkedIndividual> found = MarkedIndividual.findByExactName(mockShepherd,
+            "55555555-aaaa-bbbb-cccc-dddddddddddd", null, null);
+        assertEquals(0, found.size());
+        verify(mockPM, never()).newQuery(anyString());
+    }
+
+    @Test void blankTaxonomyMeansNoScope()
+    throws Exception {
+        namesCache().put(13, "66666666-aaaa-bbbb-cccc-dddddddddddd;gns-5");
+        MarkedIndividual indiv = mock(MarkedIndividual.class);
+        when(mockQuery.execute()).thenReturn(Arrays.asList(indiv));
+
+        List<MarkedIndividual> found = MarkedIndividual.findByExactName(mockShepherd, "GNS-5",
+            "", "  ");
+        assertEquals(1, found.size());
+        ArgumentCaptor<String> jdoql = ArgumentCaptor.forClass(String.class);
+        verify(mockPM).newQuery(jdoql.capture());
+        // blank genus/specificEpithet must not become an ''=='' taxonomy filter
+        assertTrue(!jdoql.getValue().contains("enc.genus"));
+    }
+
+    @Test void inputIsTrimmed()
+    throws Exception {
+        namesCache().put(15, "77777777-aaaa-bbbb-cccc-dddddddddddd;gns-7");
+        MarkedIndividual indiv = mock(MarkedIndividual.class);
+        when(mockQuery.execute()).thenReturn(Arrays.asList(indiv));
+
+        assertEquals(1,
+            MarkedIndividual.findByExactName(mockShepherd, "  GNS-7  ", null, null).size());
+    }
+
     @Test void regexMetacharactersInNameAreSafe()
     throws Exception {
         namesCache().put(9, "44444444-aaaa-bbbb-cccc-dddddddddddd;r(19+a]");

--- a/src/test/java/org/ecocean/api/patch/EncounterPatchValidatorTest.java
+++ b/src/test/java/org/ecocean/api/patch/EncounterPatchValidatorTest.java
@@ -1,0 +1,128 @@
+package org.ecocean.api.patch;
+
+import javax.jdo.PersistenceManager;
+
+import org.ecocean.api.ApiException;
+import org.ecocean.Encounter;
+import org.ecocean.MarkedIndividual;
+import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.User;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class EncounterPatchValidatorTest {
+    Shepherd mockShepherd;
+    PersistenceManager mockPM;
+    Encounter mockEnc;
+    User mockUser;
+
+    @BeforeEach void setUp() {
+        mockShepherd = mock(Shepherd.class);
+        mockPM = mock(PersistenceManager.class);
+        mockEnc = mock(Encounter.class);
+        mockUser = mock(User.class);
+        when(mockShepherd.getPM()).thenReturn(mockPM);
+        when(mockEnc.getGenus()).thenReturn("Carcharodon");
+        when(mockEnc.getSpecificEpithet()).thenReturn("carcharias");
+    }
+
+    private JSONObject individualIdPatch(String value) {
+        JSONObject patch = new JSONObject();
+
+        patch.put("op", "replace");
+        patch.put("path", "individualId");
+        patch.put("value", value);
+        return patch;
+    }
+
+    @Test void typedNameAttachesExistingIndividual()
+    throws ApiException {
+        MarkedIndividual existing = mock(MarkedIndividual.class);
+
+        when(existing.getId()).thenReturn("11111111-2222-3333-4444-555555555555");
+        // no PK match for the human-readable name
+        when(mockShepherd.getMarkedIndividual("GNS-2620")).thenReturn(null);
+        try (MockedStatic<MarkedIndividual> mockedIndiv = mockStatic(MarkedIndividual.class, CALLS_REAL_METHODS)) {
+            mockedIndiv.when(() -> MarkedIndividual.findByExactName(mockShepherd, "GNS-2620",
+                "Carcharodon", "carcharias")).thenReturn(
+                new ArrayList<>(Arrays.asList(existing)));
+            JSONObject res = EncounterPatchValidator.applyPatch(mockEnc,
+                individualIdPatch("GNS-2620"), mockUser, mockShepherd);
+            // the *existing* individual must be attached...
+            verify(mockEnc).applyPatchOp(eq("individualId"), same(existing), eq("replace"));
+            // ...no new individual persisted...
+            verify(mockPM, never()).makePersistent(any(MarkedIndividual.class));
+            // ...and the resolved id is reported so clients can chain by uuid
+            assertEquals("11111111-2222-3333-4444-555555555555", res.optString("individualId"));
+        }
+    }
+
+    @Test void ambiguousNameThrowsConflict() {
+        MarkedIndividual one = mock(MarkedIndividual.class);
+        MarkedIndividual two = mock(MarkedIndividual.class);
+
+        when(mockShepherd.getMarkedIndividual("GNS-2620")).thenReturn(null);
+        try (MockedStatic<MarkedIndividual> mockedIndiv = mockStatic(MarkedIndividual.class, CALLS_REAL_METHODS)) {
+            mockedIndiv.when(() -> MarkedIndividual.findByExactName(any(Shepherd.class),
+                anyString(), any(), any())).thenReturn(
+                new ArrayList<>(Arrays.asList(one, two)));
+            assertThrows(ApiException.class, () -> {
+                EncounterPatchValidator.applyPatch(mockEnc, individualIdPatch("GNS-2620"),
+                    mockUser, mockShepherd);
+            });
+            verify(mockPM, never()).makePersistent(any(MarkedIndividual.class));
+        }
+    }
+
+    @Test void unknownNameCreatesNewIndividual()
+    throws ApiException {
+        when(mockShepherd.getMarkedIndividual("GNS-9999")).thenReturn(null);
+        try (MockedStatic<MarkedIndividual> mockedIndiv = mockStatic(MarkedIndividual.class, CALLS_REAL_METHODS)) {
+            mockedIndiv.when(() -> MarkedIndividual.findByExactName(any(Shepherd.class),
+                anyString(), any(), any())).thenReturn(new ArrayList<MarkedIndividual>());
+            JSONObject res = EncounterPatchValidator.applyPatch(mockEnc,
+                individualIdPatch("GNS-9999"), mockUser, mockShepherd);
+            ArgumentCaptor<Object> persisted = ArgumentCaptor.forClass(Object.class);
+            verify(mockPM).makePersistent(persisted.capture());
+            assertTrue(persisted.getValue() instanceof MarkedIndividual);
+            MarkedIndividual created = (MarkedIndividual)persisted.getValue();
+            assertTrue(created.hasName("GNS-9999"));
+            assertNotNull(res.optString("individualId", null));
+        }
+    }
+
+    @Test void pkMatchSkipsNameLookup()
+    throws ApiException {
+        MarkedIndividual existing = mock(MarkedIndividual.class);
+
+        when(existing.getId()).thenReturn("aaaa1111-2222-3333-4444-555555555555");
+        when(mockShepherd.getMarkedIndividual("aaaa1111-2222-3333-4444-555555555555")).thenReturn(
+            existing);
+        try (MockedStatic<MarkedIndividual> mockedIndiv = mockStatic(MarkedIndividual.class, CALLS_REAL_METHODS)) {
+            EncounterPatchValidator.applyPatch(mockEnc,
+                individualIdPatch("aaaa1111-2222-3333-4444-555555555555"), mockUser, mockShepherd);
+            mockedIndiv.verify(() -> MarkedIndividual.findByExactName(any(Shepherd.class),
+                anyString(), any(), any()), never());
+            verify(mockEnc).applyPatchOp(eq("individualId"), same(existing), eq("replace"));
+            verify(mockPM, never()).makePersistent(any(MarkedIndividual.class));
+        }
+    }
+}

--- a/src/test/java/org/ecocean/api/patch/EncounterPatchValidatorTest.java
+++ b/src/test/java/org/ecocean/api/patch/EncounterPatchValidatorTest.java
@@ -33,8 +33,19 @@ class EncounterPatchValidatorTest {
     PersistenceManager mockPM;
     Encounter mockEnc;
     User mockUser;
+    java.util.HashMap<Integer, String> savedNamesCache;
 
-    @BeforeEach void setUp() {
+    @SuppressWarnings("unchecked")
+    private java.util.HashMap<Integer, String> namesCache()
+    throws Exception {
+        java.lang.reflect.Field f = MarkedIndividual.class.getDeclaredField("NAMES_CACHE");
+
+        f.setAccessible(true);
+        return (java.util.HashMap<Integer, String>)f.get(null);
+    }
+
+    @BeforeEach void setUp()
+    throws Exception {
         mockShepherd = mock(Shepherd.class);
         mockPM = mock(PersistenceManager.class);
         mockEnc = mock(Encounter.class);
@@ -42,6 +53,14 @@ class EncounterPatchValidatorTest {
         when(mockShepherd.getPM()).thenReturn(mockPM);
         when(mockEnc.getGenus()).thenReturn("Carcharodon");
         when(mockEnc.getSpecificEpithet()).thenReturn("carcharias");
+        // real addName() during the create path touches the global names cache
+        savedNamesCache = new java.util.HashMap<Integer, String>(namesCache());
+    }
+
+    @org.junit.jupiter.api.AfterEach void tearDown()
+    throws Exception {
+        namesCache().clear();
+        namesCache().putAll(savedNamesCache);
     }
 
     private JSONObject individualIdPatch(String value) {
@@ -106,6 +125,20 @@ class EncounterPatchValidatorTest {
             MarkedIndividual created = (MarkedIndividual)persisted.getValue();
             assertTrue(created.hasName("GNS-9999"));
             assertNotNull(res.optString("individualId", null));
+        }
+    }
+
+    @Test void semicolonNameRejected() {
+        when(mockShepherd.getMarkedIndividual("GNS;2620")).thenReturn(null);
+        try (MockedStatic<MarkedIndividual> mockedIndiv = mockStatic(MarkedIndividual.class,
+            CALLS_REAL_METHODS)) {
+            assertThrows(ApiException.class, () -> {
+                EncounterPatchValidator.applyPatch(mockEnc, individualIdPatch("GNS;2620"),
+                    mockUser, mockShepherd);
+            });
+            mockedIndiv.verify(() -> MarkedIndividual.findByExactName(any(Shepherd.class),
+                anyString(), any(), any()), never());
+            verify(mockPM, never()).makePersistent(any(MarkedIndividual.class));
         }
     }
 


### PR DESCRIPTION
## Problem

Fixes #1318. Users creating a new individual on the match results page later could not attach that ID to another encounter: the React encounter page's *Add to existing individual ID* field showed no suggestion, and typing the ID (e.g. `GNS-2620`) silently created a **second individual with the same name**.

## Root cause (three compounding defects, all in the `PATCH /api/v3/encounters/{id}` `individualId` path)

1. **PK-only lookup.** `EncounterPatchValidator.getOrCreateMarkedIndividual()` resolved the typed value with `Shepherd.getMarkedIndividual()` (a `getObjectById` PK lookup) and created a new individual on a miss. Modern individuals have UUID PKs with the human-readable ID stored in `names`, so a typed name **always** missed and minted a duplicate. Bulk import's equivalent path falls back to a name lookup; this path never did.
2. **Names cache never refreshed after persist.** `NAMES_CACHE` is keyed by the DB-assigned `MultiValue` id; `addName()` before `makePersistent()` caches under the default key `0`. `BulkImporter` re-refreshes after persisting — the patch path didn't, so match-page-created individuals were invisible to every name lookup until restart.
3. **Parallel PATCHes by name.** The match results page sent one PATCH per encounter *in parallel with the same name*; each transaction missed the others' uncommitted individual, creating one duplicate per encounter (see the paired GNS-1046 examples in the issue).

The old individual detached by `removeIndividual()` also had auto-indexing suppressed (`skipAutoIndexing=true`) with nothing ever re-indexing it.

## Fix

- **`MarkedIndividual.findByExactName()`** — exact, case-insensitive name lookup backed by the live names cache with **no regex interpretation** (names containing regex metacharacters are safe), sharing the query with `findByNames()` via an extracted `findByNameIds()` helper. Blank genus/specificEpithet now means *no* taxonomy scope instead of an `''==''` filter.
- **Patch validator**: after the PK miss, resolve by exact name scoped by the encounter's taxonomy (both genus+specificEpithet, like bulk import); ambiguous names return 400; names containing `;` (the cache delimiter) are rejected; the names cache is refreshed **after** persisting a new individual; each `individualId` patch result now reports the resolved individual uuid.
- **`Encounter.afterPatch()`**: patched-in and detached-surviving individuals are indexed post-commit (best-effort; the background reconciler remains the backstop), so the new ID shows up in encounter-page suggestions promptly.
- **`refreshNamesCache()`** skips unpersisted `MultiValue` (id 0) — no more shared-key pollution or phantom names from rolled-back transactions.
- **Match results page**: the individual is created via the *first* encounter only; remaining encounters are attached by the returned uuid. If the uuid cannot be resolved, the remaining encounters fail explicitly rather than falling back to the racy parallel-name path.

## Tests

- `EncounterPatchValidatorTest` (new): typed name attaches existing individual; ambiguity 400; unknown name creates; PK match skips name lookup; `;` rejection.
- `MarkedIndividualExactNameTest` (new): exact/substring/case/trim semantics, taxonomy scoping incl. blank-taxonomy, first-cache-segment (individual id) exclusion, regex-metacharacter safety.
- jest `matchResultsStore`: first-encounter create + uuid attach (name and next-name flows), no re-send on missing uuid, first-failure short-circuit. Also fixes a pre-existing jest failure (hidden by CI's continue-on-error) around total-failure semantics.
- Full `mvn clean install` green (101 surefire reports, 0 failures/errors); jest suite 86/86.

## Known residuals (out of scope, documented for follow-up)

- **Cross-request race**: two truly concurrent requests (separate sessions) creating the same name can still both miss and mint duplicates; a proper fix needs DB-level name reservation/uniqueness, complicated by legitimately duplicated names already in production. This PR strictly reduces duplicate creation and does not worsen the race.
- **Data cleanup**: installs already carrying duplicates from this bug (e.g. two `GNS-2620`s on Sharkbook) need a merge pass; until then the new ambiguity guard returns 400 for those names (use the uuid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)