### PR TITLE
Fix silent no-op deep reindex for newly created individuals in assignFromIAAPI

### DIFF
--- a/src/main/java/org/ecocean/identity/IBEISIA.java
+++ b/src/main/java/org/ecocean/identity/IBEISIA.java
@@ -2613,10 +2613,16 @@ public class IBEISIA {
             res = assignFromIA(indivId, al, myShepherd);
         }
         rtn.put("success", true);
+        // GH-1514: id to queue for post-commit deep reindex below. When a new
+        // individual was created, indivId is a *name*, not the generated
+        // individualID, and would silently fail to resolve in
+        // queueIndividualsByIdForDeepReindex.
+        String reindexIndividualId = indivId;
         if (res.get("newMarkedIndividual") != null) {
             MarkedIndividual ind = (MarkedIndividual)res.get("newMarkedIndividual");
             myShepherd.getPM().makePersistent(ind);
             rtn.put("newMarkedIndividual", ind.getIndividualID());
+            reindexIndividualId = ind.getIndividualID();
         }
         if (res.get("encounters") != null) {
             JSONArray je = new JSONArray();
@@ -2639,7 +2645,7 @@ public class IBEISIA {
         // GH-1514: post-commit, queue deep reindex of the target individual so
         // sibling encounters pick up refreshed individualNumberEncounters etc.
         org.ecocean.IndexingManager.queueIndividualsByIdForDeepReindex(myShepherd,
-            java.util.Collections.singleton(indivId));
+            java.util.Collections.singleton(reindexIndividualId));
         return rtn;
     }
 


### PR DESCRIPTION
Follow-up to #1547 (issue #1514). Fixes the one site where the post-commit deep-reindex added by that PR can still silently no-op.

## Summary

`IBEISIA.assignFromIAAPI` (the IA-driven individual-assignment API used by `IAGateway`) queues its post-commit deep reindex with the raw `name` request parameter. When the assign call creates a **new** MarkedIndividual, that queue entry never resolves, so the new individual and its member encounters keep stale denormalized fields (`individualNumberEncounters`, first/last encounter dates, etc.) in OpenSearch until something else touches the individual.

## Root cause

- `new MarkedIndividual(name, enc)` generates a UUID `individualID` and only registers `name` via `addName()` — the name is not the datastore id.
- `IndexingManager.queueIndividualsByIdForDeepReindex` resolves ids with `Shepherd.getMarkedIndividualQuiet`, a strict primary-key lookup that returns null (quietly) for anything that isn't an `individualID`.
- So for the new-individual path, the queue call looked up the *name*, got null, and skipped the reindex — with no log or error.

The existing-individual path was unaffected: there, `indivId` had already resolved via the same PK lookup inside `assignFromIA`/`assignFromIANoCreation`, proving it is a real `individualID`.

This is the same name-vs-UUID bug class #1547 fixed in `EncounterVMData`, `ImportIA`, and `AnnotationEdit`; this fourth site was missed.

## Fix

Both `assignFromIA` and `assignFromIANoCreation` already return the newly created individual under the `newMarkedIndividual` key. Capture its real `getIndividualID()` there and queue that instead of the raw `name` parameter. When no new individual was created, the behavior is unchanged (`indivId` is queued, as before).

One file, +7/−1.

## Test plan

- [x] `mvn compile` clean
- [x] Codex adversarial review
- [ ] Manual: assign annotations to a brand-new individual name via IA API; confirm the individual's encounter docs refresh `individualNumberEncounters` in OpenSearch without waiting for the background reconciler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
