### PR TITLE
fix(config): size the DBCP2 connection pool with maxActive

### DIFF
--- a/src/main/resources/bundles/jdoconfig.properties
+++ b/src/main/resources/bundles/jdoconfig.properties
@@ -47,11 +47,29 @@ datanucleus.cache.collections.lazy = false
 
 # Connection pooling
 datanucleus.connectionPoolingType = dbcp2
-datanucleus.connectionPool.maxIdle=10
+# maxIdle bounds how many idle connections the pool retains on return; returned
+# connections beyond it are closed immediately, so a value far below maxActive causes
+# reconnect churn under repeated traffic bursts. The evictor (running every
+# timeBetweenEvictionRunsMillis) evicts connections idle longer than
+# minEvictableIdleTimeMillis and then replenishes toward minIdle as needed.
+datanucleus.connectionPool.maxIdle=25
 datanucleus.connectionPool.minIdle=5
+datanucleus.connectionPool.minEvictableIdleTimeMillis=1800000
 datanucleus.connectionPool.timeBetweenEvictionRunsMillis=240000
-# Standard DataNucleus keys (that map internally to DBCP2)
-datanucleus.connectionPool.maxPoolSize = 300
+# Bounds the per-borrow testSQL validation query (seconds, passed through to JDBC
+# setQueryTimeout) so a stalled validation cannot hang a borrower indefinitely.
+datanucleus.connectionPool.validationTimeout = 5
+# IMPORTANT: both DBCP2 pool factories in DataNucleus 5.2.7 ("dbcp2" and
+# "dbcp2-builtin") size the pool from maxActive; NEITHER reads maxPoolSize (that key
+# belongs to other pool types such as HikariCP). With maxActive unset, the pool
+# silently falls back to the commons-pool default of 8 total connections.
+# SIZING REQUIREMENT: DataNucleus creates two pools (transactional and
+# non-transactional), so PostgreSQL max_connections must exceed 2 x maxActive plus
+# headroom for other clients. The stock devops postgresql.conf ships
+# max_connections = 300; 2 x 100 = 200 leaves 100 spare. If your database allows
+# fewer connections or is shared with other applications, lower maxActive
+# accordingly (e.g. 50).
+datanucleus.connectionPool.maxActive = 100
 # maxWait in milliseconds. -1 means wait forever, which on contention causes threads to silently
 # pile up at "begin" on dbconnections.jsp until Tomcat is restarted. 30s lets a request fail
 # fast with a clear error instead, so operators see the problem and pool slots free up.


### PR DESCRIPTION
## What

Fixes the stock `jdoconfig.properties` so the DBCP2 connection pool is actually sized by configuration:

- add `datanucleus.connectionPool.maxActive = 100` and remove `maxPoolSize`, which is not read by either DBCP2 factory in DataNucleus 5.2.7 (verified against `DBCP2ConnectionPoolFactory` and `DBCP2BuiltinConnectionPoolFactory` in datanucleus-rdbms-5.2.7.jar — both size the pool from `maxActive`; `maxPoolSize` belongs to other pool types such as HikariCP)
- raise `maxIdle` 10 → 25 and set `minEvictableIdleTimeMillis` explicitly, so bursts don't cause reconnect churn
- set `validationTimeout = 5` so the per-borrow `testSQL` validation is bounded
- document the sizing requirement: DataNucleus creates two pools (tx + nontx), so PostgreSQL `max_connections` must exceed 2×`maxActive` plus headroom (stock devops postgresql.conf ships 300; 2×100 = 200)

## Why

With only `maxPoolSize` set, the pool silently fell back to the commons-pool default of **8 total connections** — far below the intended 300 and easily saturated under concurrent load, with saturation showing up as requests piling up waiting for connections. Sizing the pool correctly (together with the finite `maxWait` already on main) makes contention degrade gracefully instead.

## Notes for deployments

Installs that use a data-dir override `jdoconfig.properties` are NOT affected by this change — `ShepherdPMF.loadOverrideProps` replaces the bundled file entirely, so those installs need the same `maxActive` line added to their override file.

Reviewed by Codex (3 rounds, converged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)