### PR TITLE
fix(individuals): inherit taxonomy from encounters so quicksearch shows a species (#1113)

### DIFF
--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -1098,25 +1098,249 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         return Util.taxonomyString(getGenus(), getSpecificEpithet());
     }
 
-    ///this is really only for when dont have a value set; i.e. it should not be run after set on the instance;
+    /// this is really only for when dont have a value set; i.e. it should not be run after set on the instance;
     /// therefore we dont allow that unless you pass boolean true to force it
-    ///   we only pick first from all encounters
+    // The "already has a value" test must not be a null test: genus defaults to the empty string, which
+    // getTaxonomyString() reports as no taxonomy at all, so a null test made this method a no-op for
+    // every individual built from an encounter (issue #1113).
     public String setTaxonomyFromEncounters(boolean force) {
-        if (!force && ((genus != null) || (specificEpithet != null))) return getTaxonomyString();
-        if ((encounters == null) || (encounters.size() < 1)) return getTaxonomyString();
-        for (Encounter enc : encounters) {
-            if ((enc.getGenus() != null) && (enc.getSpecificEpithet() != null)) {
-                genus = enc.getGenus();
-                specificEpithet = enc.getSpecificEpithet();
-                setVersion();
-                return getTaxonomyString();
-            }
-        }
+        if (!force && !hasNoTaxonomyOfItsOwn()) return getTaxonomyString();
+        String[] derived = unanimousTaxonomyFromEncounters(getEncounters());
+        // never trade a taxonomy we have for one we could not derive
+        if (derived == null) return getTaxonomyString();
+        if (Util.taxonomyString(derived[0], derived[1]).equals(getTaxonomyString()))
+            return getTaxonomyString();
+        // set the parts, not the assembled string: setTaxonomyString() reads a lone word as the
+        // specific epithet, which would turn a genus-only derivation into an epithet-only individual
+        setGenus(derived[0]);
+        setSpecificEpithet(derived[1]);
         return getTaxonomyString();
+    }
+
+    /**
+     * The taxonomy the encounters of an individual agree on, as { genus, specificEpithet } -- either
+     * part may be null -- or null when they state no taxonomy at all or disagree about one.
+     *
+     * Genus and specific epithet are judged separately, so a sighting identified only to genus does not
+     * contradict one identified to species (case and surrounding whitespace are ignored). Any real
+     * disagreement derives nothing, including a subspecies against the species it belongs to: that is a
+     * different identification, not a refinement of one.
+     *
+     * The pair returned is always the one a single encounter states. Pairing one sighting's genus with
+     * another sighting's epithet would assert a species nobody recorded.
+     */
+    public static String[] unanimousTaxonomyFromEncounters(Collection<Encounter> encs) {
+        Set<String> genera = new HashSet<String>();
+        Set<String> epithets = new HashSet<String>();
+        String[] best = null;
+
+        if (encs == null) return null;
+        for (Encounter enc : encs) {
+            String[] stated = statedTaxonomy(enc);
+            if (stated == null) continue;
+            if (stated[0] != null) genera.add(stated[0].toLowerCase(Locale.ROOT));
+            if (stated[1] != null) epithets.add(stated[1].toLowerCase(Locale.ROOT));
+            if ((genera.size() > 1) || (epithets.size() > 1)) return null;
+            if (isBetterTaxonomy(stated, best)) best = stated;
+        }
+        return best;
+    }
+
+    /**
+     * Whether this individual has no taxonomy of its own -- what the header quicksearch and the
+     * individual search results show as a blank species, and what the encounters are then asked for.
+     * Padded placeholders count as blank: getTaxonomyString() defers to Util.stringExists(), which
+     * compares against "unknown"/"none" before trimming and so reports " unknown " as a real value.
+     */
+    public boolean hasNoTaxonomyOfItsOwn() {
+        return (statedTaxonomyPart(getGenus()) == null) &&
+               (statedTaxonomyPart(getSpecificEpithet()) == null);
+    }
+
+    // what an encounter states about its animal, as { genus, specificEpithet } with anything unstated
+    // (empty, whitespace, "unknown", "none") left null, or null when it states neither
+    private static String[] statedTaxonomy(Encounter enc) {
+        if (enc == null) return null;
+        String genus = statedTaxonomyPart(enc.getGenus());
+        String epithet = statedTaxonomyPart(enc.getSpecificEpithet());
+        if ((genus == null) && (epithet == null)) return null;
+        return new String[] { genus, epithet };
+    }
+
+    // trim before asking stringExists(): it compares against "none"/"unknown" untrimmed, so it would
+    // otherwise accept " unknown " as an identification and let a placeholder be treated as data
+    private static String statedTaxonomyPart(String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        return Util.stringExists(trimmed) ? trimmed : null;
+    }
+
+    // Which of two encounters' identifications to carry: the more completely identified one, and
+    // failing that the lower-sorting values, so the answer never depends on the order the encounters
+    // come in. Any two candidates that reach here state the same taxonomy, differing only in how much
+    // of it they fill in and in capitalization.
+    private static boolean isBetterTaxonomy(String[] stated, String[] best) {
+        if (best == null) return true;
+        int rank = taxonomyRank(stated) - taxonomyRank(best);
+        if (rank != 0) return rank > 0;
+        int cmp = compareTaxonomyPart(stated[0], best[0]);
+        if (cmp != 0) return cmp < 0;
+        return compareTaxonomyPart(stated[1], best[1]) < 0;
+    }
+
+    // both parts beats a genus alone beats a stray epithet with no genus to attach it to
+    private static int taxonomyRank(String[] stated) {
+        if ((stated[0] != null) && (stated[1] != null)) return 2;
+        return (stated[0] != null) ? 1 : 0;
+    }
+
+    private static int compareTaxonomyPart(String a, String b) {
+        if (a == null) return (b == null) ? 0 : 1;
+        if (b == null) return -1;
+        return a.compareTo(b);
+    }
+
+    /**
+     * Every distinct taxonomy held by the encounters of an individual, for reporting what a set of
+     * encounters that could not agree actually says. More than one value here is not necessarily a
+     * disagreement -- unanimousTaxonomyFromEncounters() compares the parts, so "Delphinus" and
+     * "Delphinus delphis" agree -- so read this alongside it rather than on its own.
+     */
+    public static Set<String> distinctTaxonomiesFromEncounters(Collection<Encounter> encs) {
+        Set<String> found = new LinkedHashSet<String>();
+
+        if (encs == null) return found;
+        for (Encounter enc : encs) {
+            String tax = encounterTaxonomy(enc);
+            if (tax != null) found.add(tax);
+        }
+        return found;
+    }
+
+    // what an encounter contributes to its individual's taxonomy: the same value individuals.jsp
+    // already displays for it, so a genus-only sighting counts and "unknown" does not
+    private static String encounterTaxonomy(Encounter enc) {
+        if (enc == null) return null;
+        return Util.taxonomyString(enc.getGenus(), enc.getSpecificEpithet());
     }
 
     public String setTaxonomyFromEncounters() {
         return setTaxonomyFromEncounters(false);
+    }
+
+    public static final String TAXONOMY_BACKFILL_CURSOR = "INDIVIDUAL_TAXONOMY_BACKFILL_CURSOR";
+    private static final int TAXONOMY_BACKFILL_DEFAULT_BATCH_SIZE = 100;
+    // a run stays small enough to keep one short transaction and to not flood the indexing queue
+    private static final int TAXONOMY_BACKFILL_MAX_BATCH_SIZE = 1000;
+
+    static int backfillBatchSize(int requested) {
+        if (requested < 1) return TAXONOMY_BACKFILL_DEFAULT_BATCH_SIZE;
+        return Math.min(requested, TAXONOMY_BACKFILL_MAX_BATCH_SIZE);
+    }
+
+    // Selects what hasNoTaxonomyOfItsOwn() calls blank, and must keep agreeing with it: a row this
+    // misses is one the backfill can never reach, and one it selects that Java then considers
+    // non-blank is a wasted slot in the batch. Hence the regex rather than btrim(), which strips
+    // spaces but not the tabs and newlines String.trim() removes.
+    //
+    // Walks by ascending id from a cursor: the individuals we cannot fix (no source taxonomy, or
+    // encounters that disagree) stay in the candidate set, so a run without a cursor would keep
+    // re-examining them and never reach the rest of the table.
+    static String backfillTaxonomySql(int batchSize) {
+        return "SELECT \"INDIVIDUALID\" FROM \"MARKEDINDIVIDUAL\" WHERE \"INDIVIDUALID\" > ?"
+               + " AND " + blankTaxonomyPartSql("GENUS")
+               + " AND " + blankTaxonomyPartSql("SPECIFICEPITHET")
+               + " ORDER BY \"INDIVIDUALID\" LIMIT " + batchSize;
+    }
+
+    // Deliberately a superset of hasNoTaxonomyOfItsOwn(): the two only have to agree on which rows are
+    // worth loading, and the errors are not symmetric. A row this predicate misses is one the backfill
+    // can never reach, while one it offers that Java then judges non-blank costs a slot in the batch and
+    // nothing else. So it strips every space and control character instead of trying to reproduce
+    // exactly what String.trim() removes, and Java has the final say per row.
+    //
+    // [[:space:][:cntrl:]] rather than \s: a backslash in the pattern is consumed before the regex
+    // engine sees it on a connection with standard_conforming_strings off.
+    private static String blankTaxonomyPartSql(String column) {
+        return "COALESCE(lower(regexp_replace(\"" + column +
+               "\", '[[:space:][:cntrl:]]', '', 'g')), '') IN ('', 'none', 'unknown')";
+    }
+
+    /**
+     * Gives individuals with no taxonomy of their own the taxonomy their encounters agree on -- the
+     * inheritance that setTaxonomyFromEncounters() should have done when they were created but did
+     * not (issue #1113), which is why the header quicksearch shows a blank species for them.
+     *
+     * Reports rather than guesses: an individual whose encounters were identified as different
+     * animals is listed under "conflicts" and left alone, which doubles as a data-quality report.
+     *
+     * Reads (and, when committing, advances) a stored cursor so repeated runs walk the whole table;
+     * a run that finds no candidates clears the cursor, so the next one reports afresh. Writing a
+     * taxonomy bumps the individual's version, so the OpenSearch reconciler picks it up even if the
+     * postStore indexing queue is suppressed at the time.
+     *
+     * Dry by default: pass commit=true to write.
+     */
+    public static org.json.JSONObject backfillTaxonomyFromEncounters(Shepherd myShepherd,
+        String startId, int batchSize, boolean commit) {
+        batchSize = backfillBatchSize(batchSize);
+        if (startId == null) startId = SystemValue.getString(myShepherd, TAXONOMY_BACKFILL_CURSOR);
+        if (startId == null) startId = "";
+        Query query = myShepherd.getPM().newQuery("javax.jdo.query.SQL",
+            backfillTaxonomySql(batchSize));
+        query.setClass(MarkedIndividual.class);
+        List<MarkedIndividual> candidates = null;
+        try {
+            candidates = new ArrayList<MarkedIndividual>(
+                (Collection<MarkedIndividual>)query.execute(startId));
+        } finally {
+            query.closeAll();
+        }
+        org.json.JSONObject updates = new org.json.JSONObject();
+        org.json.JSONObject conflicts = new org.json.JSONObject();
+        int noSource = 0;
+        int hasStoredTaxonomy = 0;
+        String lastId = null;
+        for (MarkedIndividual indiv : candidates) {
+            lastId = indiv.getId();
+            // the sql filter should agree with this, but this is the authoritative test
+            if (!indiv.hasNoTaxonomyOfItsOwn()) {
+                hasStoredTaxonomy++;
+                continue;
+            }
+            String[] derived = unanimousTaxonomyFromEncounters(indiv.getEncounters());
+            if (derived == null) {
+                Set<String> disagreement = distinctTaxonomiesFromEncounters(indiv.getEncounters());
+                if (disagreement.isEmpty()) {
+                    noSource++;
+                } else {
+                    conflicts.put(indiv.getId(), new org.json.JSONArray(disagreement));
+                }
+                continue;
+            }
+            updates.put(indiv.getId(), Util.taxonomyString(derived[0], derived[1]));
+            if (commit) {
+                indiv.setGenus(derived[0]);
+                indiv.setSpecificEpithet(derived[1]);
+            }
+        }
+        boolean finished = candidates.isEmpty();
+        if (commit) SystemValue.set(myShepherd, TAXONOMY_BACKFILL_CURSOR, finished ? null : lastId);
+        org.json.JSONObject rtn = new org.json.JSONObject();
+        rtn.put("_batchSize", batchSize);
+        rtn.put("_commit", commit);
+        rtn.put("_startId", startId);
+        rtn.put("_lastId", lastId);
+        rtn.put("_finished", finished);
+        rtn.put("_examined", candidates.size());
+        rtn.put("_updated", updates.length());
+        rtn.put("_noTaxonomyOnEncounters", noSource);
+        rtn.put("_conflicted", conflicts.length());
+        rtn.put("_skippedHasStoredTaxonomy", hasStoredTaxonomy);
+        rtn.put("updates", updates);
+        rtn.put("conflicts", conflicts);
+        System.out.println("MarkedIndividual.backfillTaxonomyFromEncounters: " + rtn);
+        return rtn;
     }
 
     // similar to above

--- a/src/main/webapp/appadmin/individualTaxonomyBackfill.jsp
+++ b/src/main/webapp/appadmin/individualTaxonomyBackfill.jsp
@@ -1,0 +1,60 @@
+<%@ page contentType="text/plain; charset=utf-8" language="java" import="org.ecocean.servlet.ServletUtilities,
+org.ecocean.shepherd.core.Shepherd,
+org.json.JSONObject,
+org.ecocean.*" %>
+<%
+// Gives individuals with no taxonomy of their own the taxonomy their encounters agree on, so the
+// header quicksearch and the individual search results stop showing a blank species for them
+// (issue #1113). Dry run unless commit=true. Walks the table across runs via a stored cursor;
+// pass startId to override where this run begins.
+
+String context = ServletUtilities.getContext(request);
+
+int batchSize = 100;
+String batchParam = request.getParameter("batchSize");
+if (batchParam != null) {
+    try {
+        batchSize = Integer.parseInt(batchParam.trim());
+    } catch (NumberFormatException nfe) {
+        response.setStatus(400);
+        out.println(new JSONObject().put("error",
+            "invalid batchSize parameter: " + batchParam).toString(4));
+        return;
+    }
+    if (batchSize < 1) {
+        response.setStatus(400);
+        out.println(new JSONObject().put("error",
+            "batchSize must be a positive integer; got: " + batchParam).toString(4));
+        return;
+    }
+}
+boolean commit = "true".equals(request.getParameter("commit"));
+String startId = request.getParameter("startId");
+
+Shepherd myShepherd = new Shepherd(context);
+myShepherd.setAction("appadmin.individualTaxonomyBackfill");
+myShepherd.beginDBTransaction();
+try {
+    JSONObject res = MarkedIndividual.backfillTaxonomyFromEncounters(myShepherd, startId,
+        batchSize, commit);
+    if (commit) {
+        // commitDBTransaction() swallows commit failures; use the status variant
+        // so a failed commit reports an error instead of success json
+        if (!myShepherd.commitDBTransactionWithStatus()) {
+            throw new RuntimeException("commit failed; see logs");
+        }
+    } else {
+        res.put("_note",
+            "dry run: nothing was written and the cursor did not move; add commit=true to apply");
+        myShepherd.rollbackDBTransaction();
+    }
+    out.println(res.toString(4));
+} catch (Exception ex) {
+    if (myShepherd.isDBTransactionActive()) myShepherd.rollbackDBTransaction();
+    ex.printStackTrace();
+    response.setStatus(500);
+    out.println(new JSONObject().put("error", ex.toString()).toString(4));
+} finally {
+    myShepherd.closeDBTransaction();
+}
+%>

--- a/src/test/java/org/ecocean/MarkedIndividualTaxonomyBackfillTest.java
+++ b/src/test/java/org/ecocean/MarkedIndividualTaxonomyBackfillTest.java
@@ -1,0 +1,180 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+import javax.jdo.PersistenceManager;
+import javax.jdo.Query;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * The backfill that gives already-stored individuals the taxonomy their encounters agree on (issue
+ * #1113). Its cursor is what makes repeated runs progress: the individuals it cannot fix -- no source
+ * taxonomy, or encounters that disagree -- stay in the candidate set, so without a cursor every run
+ * would re-examine the same rows and never reach the rest of the table.
+ */
+class MarkedIndividualTaxonomyBackfillTest {
+    private Query query;
+    private Shepherd shepherd;
+
+    private Shepherd shepherdReturning(List<MarkedIndividual> candidates) {
+        PersistenceManager pm = mock(PersistenceManager.class);
+
+        query = mock(Query.class);
+        shepherd = mock(Shepherd.class);
+        when(shepherd.getPM()).thenReturn(pm);
+        when(pm.newQuery(anyString(), anyString())).thenReturn(query);
+        when(query.execute(any())).thenReturn(candidates);
+        return shepherd;
+    }
+
+    private MarkedIndividual individual(String id, Encounter... encs) {
+        MarkedIndividual mi = spy(new MarkedIndividual());
+
+        doReturn(id).when(mi).getId();
+        doReturn(new Vector<Encounter>(Arrays.asList(encs))).when(mi).getEncounters();
+        return mi;
+    }
+
+    private Encounter encounter(String genus, String specificEpithet) {
+        Encounter enc = new Encounter();
+
+        enc.setGenus(genus);
+        enc.setSpecificEpithet(specificEpithet);
+        return enc;
+    }
+
+    @Test void committingRunWritesFixablesAndAdvancesThePastEverythingExamined() {
+        MarkedIndividual fixable = individual("ind-1", encounter("Delphinus", "delphis"));
+        MarkedIndividual disagreeing = individual("ind-2", encounter("Delphinus", "delphis"),
+            encounter("Orcinus", "orca"));
+        MarkedIndividual noSource = individual("ind-3", encounter(null, null));
+        Shepherd sh = shepherdReturning(Arrays.asList(fixable, disagreeing, noSource));
+
+        try (MockedStatic<SystemValue> sv = mockStatic(SystemValue.class)) {
+            sv.when(() -> SystemValue.getString(any(), anyString())).thenReturn(null);
+            JSONObject res = MarkedIndividual.backfillTaxonomyFromEncounters(sh, null, 100, true);
+            assertEquals("Delphinus delphis", fixable.getTaxonomyString(),
+                "an individual whose encounters agree gets their taxonomy");
+            assertNull(disagreeing.getTaxonomyString(),
+                "an individual whose encounters disagree is left alone");
+            assertEquals(1, res.getInt("_updated"), "one individual was fixable");
+            assertEquals(1, res.getInt("_conflicted"), "one had encounters that disagree");
+            assertEquals(1, res.getInt("_noTaxonomyOnEncounters"),
+                "one had no taxonomy to inherit");
+            assertEquals(Arrays.asList("Delphinus delphis", "Orcinus orca"),
+                res.getJSONObject("conflicts").getJSONArray("ind-2").toList(),
+                "the conflict report says what the encounters actually claim");
+            sv.verify(() -> SystemValue.set(sh, MarkedIndividual.TAXONOMY_BACKFILL_CURSOR, "ind-3"));
+        }
+    }
+
+    @Test void writesOnlyWhatASightingActuallyStates() {
+        MarkedIndividual crossPaired = individual("ind-1", encounter("Balaenoptera", null),
+            encounter(null, "orca"));
+        Shepherd sh = shepherdReturning(Arrays.asList(crossPaired));
+
+        try (MockedStatic<SystemValue> sv = mockStatic(SystemValue.class)) {
+            sv.when(() -> SystemValue.getString(any(), anyString())).thenReturn(null);
+            JSONObject res = MarkedIndividual.backfillTaxonomyFromEncounters(sh, null, 100, true);
+            assertEquals("Balaenoptera", res.getJSONObject("updates").getString("ind-1"),
+                "the backfill must not pair one sighting's genus with another's epithet");
+            assertEquals("Balaenoptera", crossPaired.getGenus(), "the supported genus is written");
+            assertNull(crossPaired.getSpecificEpithet(), "the unattached epithet is not");
+        }
+    }
+
+    @Test void replacesAStoredPlaceholderRatherThanSkippingIt() {
+        // the candidate query selects a padded placeholder, so the Java side has to agree it is blank
+        // -- otherwise the row is skipped, the cursor moves past it, and it stays uncorrected
+        MarkedIndividual placeholder = individual("ind-1", encounter("Delphinus", "delphis"));
+
+        placeholder.setGenus(" unknown ");
+        Shepherd sh = shepherdReturning(Arrays.asList(placeholder));
+
+        try (MockedStatic<SystemValue> sv = mockStatic(SystemValue.class)) {
+            sv.when(() -> SystemValue.getString(any(), anyString())).thenReturn(null);
+            JSONObject res = MarkedIndividual.backfillTaxonomyFromEncounters(sh, null, 100, true);
+            assertEquals(0, res.getInt("_skippedHasStoredTaxonomy"),
+                "a placeholder is not a stored taxonomy");
+            assertEquals("Delphinus delphis", placeholder.getTaxonomyString(),
+                "the placeholder is replaced by what the encounters say");
+        }
+    }
+
+    @Test void dryRunReportsWithoutWritingOrMovingTheCursor() {
+        MarkedIndividual fixable = individual("ind-1", encounter("Delphinus", "delphis"));
+        Shepherd sh = shepherdReturning(Arrays.asList(fixable));
+
+        try (MockedStatic<SystemValue> sv = mockStatic(SystemValue.class)) {
+            sv.when(() -> SystemValue.getString(any(), anyString())).thenReturn(null);
+            JSONObject res = MarkedIndividual.backfillTaxonomyFromEncounters(sh, null, 100, false);
+            assertEquals(1, res.getInt("_updated"), "a dry run still reports what it would change");
+            assertEquals("Delphinus delphis", res.getJSONObject("updates").getString("ind-1"),
+                "and which taxonomy it would write");
+            assertNull(fixable.getTaxonomyString(), "but must not write it");
+            sv.verify(() -> SystemValue.set(any(Shepherd.class), anyString(), anyString()),
+                never());
+            sv.verify(() -> SystemValue.set(any(Shepherd.class), anyString(), (String)isNull()),
+                never());
+        }
+    }
+
+    @Test void resumesFromTheStoredCursor() {
+        Shepherd sh = shepherdReturning(new ArrayList<MarkedIndividual>());
+
+        try (MockedStatic<SystemValue> sv = mockStatic(SystemValue.class)) {
+            sv.when(() -> SystemValue.getString(any(), anyString())).thenReturn("ind-500");
+            JSONObject res = MarkedIndividual.backfillTaxonomyFromEncounters(sh, null, 100, false);
+            assertEquals("ind-500", res.getString("_startId"),
+                "a run with no explicit startId picks up where the last committing run stopped");
+            verify(query).execute("ind-500");
+        }
+    }
+
+    @Test void explicitStartIdOverridesTheStoredCursor() {
+        Shepherd sh = shepherdReturning(new ArrayList<MarkedIndividual>());
+
+        try (MockedStatic<SystemValue> sv = mockStatic(SystemValue.class)) {
+            sv.when(() -> SystemValue.getString(any(), anyString())).thenReturn("ind-500");
+            MarkedIndividual.backfillTaxonomyFromEncounters(sh, "ind-100", 100, false);
+            verify(query).execute("ind-100");
+        }
+    }
+
+    @Test void firstRunStartsAtTheBeginningOfTheTable() {
+        Shepherd sh = shepherdReturning(new ArrayList<MarkedIndividual>());
+
+        try (MockedStatic<SystemValue> sv = mockStatic(SystemValue.class)) {
+            sv.when(() -> SystemValue.getString(any(), anyString())).thenReturn(null);
+            JSONObject res = MarkedIndividual.backfillTaxonomyFromEncounters(sh, null, 100, false);
+            assertEquals("", res.getString("_startId"),
+                "with no stored cursor every id sorts after the starting point");
+            verify(query).execute("");
+        }
+    }
+
+    @Test void emptyBatchClearsTheCursorSoALaterRunReportsAfresh() {
+        Shepherd sh = shepherdReturning(new ArrayList<MarkedIndividual>());
+
+        try (MockedStatic<SystemValue> sv = mockStatic(SystemValue.class)) {
+            sv.when(() -> SystemValue.getString(any(), anyString())).thenReturn("ind-900");
+            JSONObject res = MarkedIndividual.backfillTaxonomyFromEncounters(sh, null, 100, true);
+            assertTrue(res.getBoolean("_finished"),
+                "nothing left to examine means the sweep is done");
+            assertFalse(res.has("_lastId"), "and there is no row to report as last");
+            // reaching the end clears the cursor rather than parking at it
+            sv.verify(() -> SystemValue.set(eq(sh),
+                eq(MarkedIndividual.TAXONOMY_BACKFILL_CURSOR), (String)isNull()));
+        }
+    }
+}

--- a/src/test/java/org/ecocean/MarkedIndividualTaxonomyTest.java
+++ b/src/test/java/org/ecocean/MarkedIndividualTaxonomyTest.java
@@ -1,0 +1,276 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Vector;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MarkedIndividual is meant to inherit its taxonomy from its encounters when it has none of its own
+ * -- both encounter-taking constructors and addEncounter() call setTaxonomyFromEncounters(). Issue
+ * #1113: that inheritance never happened for a newly built individual, because the guard tested
+ * genus for null while the field defaults to the empty string, so individuals created from
+ * encounters were left with no taxonomy and the header quicksearch had none to display.
+ */
+class MarkedIndividualTaxonomyTest {
+    private MarkedIndividual individualWithEncounters(Encounter... encs) {
+        MarkedIndividual mi = spy(new MarkedIndividual());
+
+        doReturn(new Vector<Encounter>(Arrays.asList(encs))).when(mi).getEncounters();
+        return mi;
+    }
+
+    private Encounter encounter(String genus, String specificEpithet) {
+        Encounter enc = new Encounter();
+
+        enc.setGenus(genus);
+        enc.setSpecificEpithet(specificEpithet);
+        return enc;
+    }
+
+    @Test void inheritsTaxonomyFromEncounters() {
+        MarkedIndividual mi = individualWithEncounters(encounter("Balaenoptera", "musculus"),
+            encounter("Balaenoptera", "musculus"));
+
+        assertEquals("Balaenoptera musculus", mi.setTaxonomyFromEncounters(),
+            "individual with no taxonomy of its own must take it from its encounters");
+        assertEquals("Balaenoptera musculus", mi.getTaxonomyString(),
+            "derived taxonomy must be stored on the individual, not just returned");
+    }
+
+    @Test void inheritsWhenStoredTaxonomyPartsAreNull() {
+        // a row persisted before the empty-string default loads with both parts null
+        MarkedIndividual mi = individualWithEncounters(encounter("Balaenoptera", "musculus"));
+
+        mi.setGenus(null);
+        mi.setSpecificEpithet(null);
+        assertEquals("Balaenoptera musculus", mi.setTaxonomyFromEncounters(),
+            "null-valued taxonomy parts count as unset, same as the empty-string default");
+    }
+
+    @Test void doesNotOverwriteTaxonomyAlreadySet() {
+        MarkedIndividual mi = individualWithEncounters(encounter("Balaenoptera", "musculus"));
+
+        mi.setTaxonomyString("Orcinus orca");
+        assertEquals("Orcinus orca", mi.setTaxonomyFromEncounters(),
+            "a taxonomy set on the individual wins over its encounters");
+    }
+
+    @Test void doesNotCompletePartialTaxonomyAlreadySet() {
+        MarkedIndividual mi = individualWithEncounters(encounter("Delphinus", "delphis"));
+
+        mi.setGenus("Delphinus");
+        assertEquals("Delphinus", mi.setTaxonomyFromEncounters(),
+            "a genus already on the individual is a value, so inheritance stays out of the way");
+    }
+
+    @Test void disagreeingEncountersDeriveNothing() {
+        MarkedIndividual mi = individualWithEncounters(encounter("Balaenoptera", "musculus"),
+            encounter("Orcinus", "orca"));
+
+        assertNull(mi.setTaxonomyFromEncounters(),
+            "encounters identified as different species must not stamp an arbitrary one on the individual");
+        assertNull(mi.getTaxonomyString(), "nothing derivable means nothing stored");
+    }
+
+    @Test void placeholderTaxonomyValuesAreNotIdentifications() {
+        MarkedIndividual mi = individualWithEncounters(encounter("unknown", "unknown"),
+            encounter("none", null));
+
+        assertNull(mi.setTaxonomyFromEncounters(),
+            "placeholder values are not a species identification");
+    }
+
+    @Test void placeholdersStayPlaceholdersWithSpaceAroundThem() {
+        // Util.stringExists() compares against "unknown"/"none" without trimming, so a padded
+        // placeholder must be recognized before it can conflict with, or be written instead of, a
+        // real identification
+        MarkedIndividual padded = individualWithEncounters(encounter(" unknown ", " none "));
+
+        assertNull(padded.setTaxonomyFromEncounters(),
+            "a padded placeholder is still a placeholder");
+        MarkedIndividual mixed = individualWithEncounters(encounter(" unknown ", null),
+            encounter("Balaenoptera", "musculus"));
+        assertEquals("Balaenoptera musculus", mixed.setTaxonomyFromEncounters(),
+            "and it must not read as a genus that disagrees with the real identification");
+    }
+
+    @Test void partlyFilledEncounterDoesNotBlockAFullIdentification() {
+        // the genus of the first sighting was never filled in; it must not read as a different animal
+        MarkedIndividual mi = individualWithEncounters(encounter("", "musculus"),
+            encounter("Balaenoptera", "musculus"));
+
+        assertEquals("Balaenoptera musculus", mi.setTaxonomyFromEncounters(),
+            "an encounter missing its genus agrees with the one that has it");
+    }
+
+    @Test void genusOnlySightingsYieldGenusOnly() {
+        MarkedIndividual mi = individualWithEncounters(encounter("Delphinus", null),
+            encounter("Delphinus", null));
+
+        assertEquals("Delphinus", mi.setTaxonomyFromEncounters(),
+            "sightings identified only to genus still give the individual its genus");
+        assertEquals("Delphinus", mi.getGenus(), "the genus must be stored as the genus");
+        assertNull(mi.getSpecificEpithet(),
+            "a lone genus must not be stored as the specific epithet");
+    }
+
+    @Test void partialSightingsDoNotContradictAFullIdentification() {
+        // genus-only, epithet-only and full-binomial sightings of the same animal, in every order:
+        // the parts are judged separately, so none of the six may report a disagreement
+        Encounter[] encs = {
+            encounter("Delphinus", null), encounter("", "delphis"),
+            encounter("Delphinus", "delphis")
+        };
+
+        for (int[] order : new int[][] {
+                 { 0, 1, 2 }, { 0, 2, 1 }, { 1, 0, 2 }, { 1, 2, 0 }, { 2, 0, 1 }, { 2, 1, 0 }
+             }) {
+            MarkedIndividual mi = individualWithEncounters(encs[order[0]], encs[order[1]],
+                encs[order[2]]);
+            assertEquals("Delphinus delphis", mi.setTaxonomyFromEncounters(),
+                "encounter order must not change the derived taxonomy, but did for order "
+                + Arrays.toString(order));
+        }
+    }
+
+    @Test void partialSightingsAreNotPairedIntoASpeciesNobodyRecorded() {
+        // one sighting states only a genus, the other only an epithet: taking a part from each would
+        // assert "Balaenoptera orca", which is not a species and which no encounter claims
+        for (boolean genusFirst : new boolean[] { true, false }) {
+            MarkedIndividual mi = genusFirst
+                ? individualWithEncounters(encounter("Balaenoptera", null), encounter(null, "orca"))
+                : individualWithEncounters(encounter(null, "orca"), encounter("Balaenoptera", null));
+            assertEquals("Balaenoptera", mi.setTaxonomyFromEncounters(),
+                "only the genus is actually supported by a sighting (genusFirst=" + genusFirst + ")");
+            assertNull(mi.getSpecificEpithet(),
+                "the unattached epithet must not be adopted (genusFirst=" + genusFirst + ")");
+        }
+    }
+
+    @Test void anEpithetFromASightingWithNoGenusStillCounts() {
+        // the middle sighting says capensis; the individual must not end up as delphis regardless.
+        // This is the case a candidate-only derivation gets wrong: the genus-only sighting is chosen
+        // first, the epithet-only one supersedes nothing, and then the binomial replaces the candidate
+        // outright -- so capensis would never be compared against delphis at all.
+        Encounter[] encs = {
+            encounter("Delphinus", null), encounter(null, "capensis"),
+            encounter("Delphinus", "delphis")
+        };
+
+        for (int[] order : new int[][] { { 0, 1, 2 }, { 2, 1, 0 }, { 1, 2, 0 } }) {
+            MarkedIndividual mi = individualWithEncounters(encs[order[0]], encs[order[1]],
+                encs[order[2]]);
+            assertNull(mi.setTaxonomyFromEncounters(),
+                "a partly-identified sighting can still disagree, order " + Arrays.toString(order));
+        }
+    }
+
+    @Test void capitalizationAndWhitespaceAreNotDisagreements() {
+        for (boolean capitalizedFirst : new boolean[] { true, false }) {
+            MarkedIndividual mi = capitalizedFirst
+                ? individualWithEncounters(encounter("Delphinus", "delphis"),
+                encounter(" delphinus ", "delphis"))
+                : individualWithEncounters(encounter(" delphinus ", "delphis"),
+                encounter("Delphinus", "delphis"));
+            assertEquals("Delphinus delphis", mi.setTaxonomyFromEncounters(),
+                "the same taxonomy written differently is one taxonomy, and the stored form must not"
+                + " depend on encounter order (capitalizedFirst=" + capitalizedFirst + ")");
+        }
+    }
+
+    @Test void differentSpeciesWithinAGenusStillDisagree() {
+        MarkedIndividual mi = individualWithEncounters(encounter("Delphinus", "delphis"),
+            encounter("Delphinus", "capensis"));
+
+        assertNull(mi.setTaxonomyFromEncounters(),
+            "same genus, different species is a real disagreement");
+    }
+
+    @Test void subspeciesIsNotTheSameIdentificationAsTheSpecies() {
+        MarkedIndividual mi = individualWithEncounters(encounter("Canis", "lupus"),
+            encounter("Canis", "lupus familiaris"));
+
+        assertNull(mi.setTaxonomyFromEncounters(),
+            "a subspecies is a different identification from the species, not a refinement of it");
+    }
+
+    @Test void forceDoesNotClearAnExistingTaxonomy() {
+        MarkedIndividual mi = individualWithEncounters(encounter(null, null));
+
+        mi.setTaxonomyString("Orcinus orca");
+        assertEquals("Orcinus orca", mi.setTaxonomyFromEncounters(true),
+            "recomputing with nothing derivable must leave the existing taxonomy alone");
+    }
+
+    @Test void forceRederivesFromEncounters() {
+        MarkedIndividual mi = individualWithEncounters(encounter("Balaenoptera", "musculus"));
+
+        mi.setTaxonomyString("Orcinus orca");
+        assertEquals("Balaenoptera musculus", mi.setTaxonomyFromEncounters(true),
+            "force is how importers re-derive taxonomy after adding encounters");
+    }
+
+    @Test void distinctTaxonomiesReportsEveryValueForConflictReporting() {
+        Vector<Encounter> encs = new Vector<Encounter>(Arrays.asList(
+            encounter("Balaenoptera", "musculus"), encounter("Orcinus", "orca"),
+            encounter("Balaenoptera", "musculus"), encounter("", "")));
+
+        assertEquals(Arrays.asList("Balaenoptera musculus", "Orcinus orca"),
+            new ArrayList<String>(MarkedIndividual.distinctTaxonomiesFromEncounters(encs)),
+            "the backfill reports which taxonomies an individual's encounters disagree on");
+    }
+
+    @Test void encounterCollectionsAreToleratedEmptyOrNull() {
+        assertTrue(MarkedIndividual.distinctTaxonomiesFromEncounters(null).isEmpty(),
+            "null encounter collection must not throw");
+        assertNull(MarkedIndividual.unanimousTaxonomyFromEncounters(new Vector<Encounter>()),
+            "an individual with no encounters has nothing to inherit");
+    }
+
+    @Test void storedPlaceholdersCountAsHavingNoTaxonomy() {
+        MarkedIndividual mi = individualWithEncounters();
+
+        assertTrue(mi.hasNoTaxonomyOfItsOwn(), "the empty-string field default is not a taxonomy");
+        mi.setGenus(" unknown ");
+        assertTrue(mi.hasNoTaxonomyOfItsOwn(),
+            "nor is a padded placeholder, which Util.stringExists() accepts because it compares"
+            + " 'unknown' before trimming");
+        mi.setGenus("\t");
+        assertTrue(mi.hasNoTaxonomyOfItsOwn(), "nor is whitespace");
+        mi.setGenus("Delphinus");
+        assertFalse(mi.hasNoTaxonomyOfItsOwn(), "a genus on its own is a taxonomy");
+    }
+
+    @Test void backfillWalksTheTableByCursor() {
+        String sql = MarkedIndividual.backfillTaxonomySql(37);
+
+        assertTrue(sql.contains("\"INDIVIDUALID\" > ?"),
+            "the candidate query must resume from a cursor, or individuals it cannot fix would pin"
+            + " every run to the same rows: " + sql);
+        assertTrue(sql.contains("ORDER BY \"INDIVIDUALID\""),
+            "cursor paging needs the matching order: " + sql);
+        assertTrue(sql.endsWith("LIMIT 37"), "the batch size must bound the run: " + sql);
+        for (String placeholder : new String[] { "''", "'none'", "'unknown'" }) {
+            assertTrue(sql.contains(placeholder),
+                "individuals holding " + placeholder +
+                " display as blank, so they are candidates too: " + sql);
+        }
+        // A row this query misses can never be fixed, so it must not be narrower than
+        // hasNoTaxonomyOfItsOwn(): btrim() would leave the tabs String.trim() removes, and a backslash
+        // pattern would be eaten on a connection with standard_conforming_strings off.
+        assertTrue(sql.contains("regexp_replace") && sql.contains("[[:space:][:cntrl:]]"),
+            "the query must treat as blank everything hasNoTaxonomyOfItsOwn() does: " + sql);
+        assertFalse(sql.contains("\\"), "and must not depend on backslash escaping to do it: " + sql);
+    }
+
+    @Test void backfillBatchSizeIsBounded() {
+        assertEquals(100, MarkedIndividual.backfillBatchSize(0), "a bad batch size falls back");
+        assertEquals(37, MarkedIndividual.backfillBatchSize(37), "a sane batch size is honored");
+        assertEquals(1000, MarkedIndividual.backfillBatchSize(100000),
+            "one run must not open an unbounded transaction or flood the indexing queue");
+    }
+}


### PR DESCRIPTION
Closes #1113.

## What users see

The header quicksearch lists an individual with a blank species line, while that individual's own page
shows a species. The individual search results table has the same blank in its SPECIES column.

## Why

Both search surfaces render the `taxonomy` field of the OpenSearch individual document, which comes
from the genus and specific epithet stored **on the individual**. `individuals.jsp` instead calls
`getGenusSpeciesDeep()`, which falls back to the individual's encounters. As @naknomum diagnosed on the
issue, the individuals in question genuinely have no taxonomy of their own.

They were supposed to. Both encounter-taking `MarkedIndividual` constructors and `addEncounter()` call
`setTaxonomyFromEncounters()`, documented as "will only set if has no value". That method could not set
anything on a new individual:

```java
private String genus = "";        // the field default

public String setTaxonomyFromEncounters(boolean force) {
    if (!force && ((genus != null) || (specificEpithet != null))) return getTaxonomyString();
```

`""` is not null, so the guard returned immediately — while `getTaxonomyString()` asks
`Util.stringExists()`, which reports `""` as no taxonomy at all. So every individual built from an
encounter was created untaxonomied and stayed that way. `BulkImporter` sets genus/epithet from the CSV
itself and so was unaffected, which is why some rows in the issue's screenshot have a species and
others do not; the React/API paths (encounter PATCH, match confirm, `AnnotationEdit`) all relied on the
broken inheritance.

The same `!= null` test appears in the per-encounter loop, and `Encounter.genus` defaults to `""` too,
so an encounter with a blank genus and a real epithet could be copied onto the individual as an
epithet-only taxonomy ahead of an encounter that had the full binomial.

## What this changes

**`MarkedIndividual.setTaxonomyFromEncounters()` works again.** The guard now asks
`Util.stringExists()`, matching what `getTaxonomyString()` counts as a value, so a blank individual
inherits from its encounters and one that already has a taxonomy (including a genus-only one) is left
alone. Derivation moved into `unanimousTaxonomyFromEncounters()`, which returns the genus and specific
epithet the encounters agree on:

- genus and specific epithet are judged separately, each accepted only when every encounter that
  states it states the same thing, ignoring case and surrounding whitespace. A sighting identified
  only to genus therefore does not contradict one identified to species, and the answer does not
  depend on what order the encounters happen to come in;
- a part counts as stated only if it is a real value, so `unknown`/`none`/whitespace — including
  `" unknown "`, which `Util.stringExists()` accepts because it compares those words untrimmed — are
  not identifications;
- the pair returned is always what a *single* encounter states. Taking one sighting's genus and
  another's epithet would assert a species nobody recorded: `Balaenoptera` plus a stray `orca` must
  yield `Balaenoptera`, not `Balaenoptera orca`;
- any real disagreement derives nothing — including a subspecies against its species (`Canis lupus`
  vs `Canis lupus familiaris`), which is a different identification rather than a refinement of one.
  Encounter order carries no meaning, so choosing a winner would stamp an arbitrary identification
  onto the animal as fact.

The parts are written separately, because `setTaxonomyString("Delphinus")` reads a lone word as the
*specific epithet*. Nothing is written when nothing was derived, so the `force=true` callers
(`BulkImporter`, `StandardImport`) cannot clear a value they could not replace.

**Individuals already in the database need a backfill**, since the setter only fires on new work.
`appadmin/individualTaxonomyBackfill.jsp` runs it:

```
/appadmin/individualTaxonomyBackfill.jsp?batchSize=500              # dry run — reports only
/appadmin/individualTaxonomyBackfill.jsp?batchSize=500&commit=true  # apply
```

It walks `MARKEDINDIVIDUAL` by ascending id from a cursor stored in `SystemValue`, advanced only on a
committing run, and reports what it changed plus the individuals whose encounters disagree — that list
is a data-quality report worth a look. Batch size is clamped to 1000 so a run is one short transaction
and a bounded number of indexing queue entries. Writes bump the individual's `version`, so the
OpenSearch reconciler reindexes them even if the indexing queue is suppressed at the time.

"Blank" means one thing, `hasNoTaxonomyOfItsOwn()`, and the candidate SQL is written to select exactly
that — including stored placeholders like `unknown`, `none` and whitespace, which display as blank and
so get replaced by what the encounters say. A row the query misses is one the backfill can never reach,
which is why it trims with `regexp_replace(..., '^[[:space:]]+|[[:space:]]+$', ...)`: `btrim()` strips
spaces but not the tabs `String.trim()` removes, and a `\s` in the pattern would be swallowed before the
regex engine saw it on a connection with `standard_conforming_strings` off.

Repeat until the run reports `"_finished": true`. The cursor clears itself at that point, so a later
run reports afresh rather than sitting at the end of the table.

Deliberately **not** an index-time fallback to `getGenusSpeciesDeep()` in the serializer: that bumps no
version and fires no `postStore`, so existing documents would keep their blank value until something
else reindexed them. Both routes need an operator action, and this one touches only the individuals that
need fixing — and it fixes the JSPs, exports and API responses too, not just the search index. It also
keeps @naknomum's point intact: no encounter-derived value is smuggled into the index as a synthetic
field; the individual's own field is what gets populated.

Populating the field also means individuals that were invisible to a taxonomy filter on the individual
search page start appearing in it.

## Testing

Two new test classes, both plain JUnit 5 with no container (Mockito spies over `getEncounters()`, the
pattern `MarkedIndividualAclSerializerTest` uses).

`MarkedIndividualTaxonomyTest` covers the derivation: inheritance from the empty-string default and
from null-loaded parts, existing full and partial values left alone, placeholders ignored whether or
not they are padded with spaces, genus-only stored as a genus rather than an epithet, cross-paired
partial sightings yielding only the part a sighting supports, all six orderings of a genus-only +
epithet-only + full-binomial mix reaching the same answer, capitalization and whitespace variants
treated as one taxonomy with an order-independent stored form, same-genus-different-species and
species-vs-subspecies both treated as disagreements, an epithet-only sighting still able to conflict
with a later binomial, `force` neither clearing a value nor failing to re-derive one, the conflict
report contents, and the candidate SQL's cursor/order/limit/placeholder handling plus the batch-size
clamp.

`MarkedIndividualTaxonomyBackfillTest` covers the cursor and write behavior against a mocked
persistence layer: a committing run writes only the fixable individual and advances the cursor past
every row it examined (not just the ones it changed), it writes only what a sighting actually states
rather than a cross-paired binomial, a dry run reports the same thing while writing nothing and
leaving the cursor alone, a run resumes from the stored cursor unless given an explicit `startId`, a
first run starts at the beginning of the table, and the terminal empty batch clears the cursor instead
of parking at it.

Verified red against the old guard: restoring the `!= null` test fails the inheritance cases with
`expected: <Balaenoptera musculus> but was: <null>`. Full `mvn clean install` is green.

The one part no automated test covers is the admin JSP itself — nothing in the build compiles JSPs — so
it is deliberately a thin wrapper (parameter parsing and transaction handling only, modelled line for
line on `appadmin/catchUpEmbeddings.jsp`) with all the logic in the tested Java method. Worth a click on
a dev instance before anyone runs it against real data.

## Not in this PR

- Propagating a *later* edit of an encounter's taxonomy onto its individual. Nothing records whether an
  individual's taxonomy was inherited or set deliberately, so overwriting risks clobbering a curator's
  decision; re-running the backfill covers those individuals.
- The `private String genus = ""` initializer that caused this. Flipping it to null would fix the guard
  without touching it, but `getGenus()` has enough consumers that the null-safety audit deserves its own
  change.
- Quicksearch relevance/ranking (#1541, PR #1697) and the UUID display split out as #1245.
