### PR TITLE
feat(ia): WBIA annotation reconciliation sweep

### DIFF
--- a/docs/superpowers/specs/2026-08-03-wbia-annotation-reconciliation-sweep-design.md
+++ b/docs/superpowers/specs/2026-08-03-wbia-annotation-reconciliation-sweep-design.md
@@ -1,0 +1,241 @@
+# WBIA Annotation Reconciliation Sweep — Design
+
+**Date:** 2026-08-03 (rev 2, post-Codex review)
+**Status:** Approved
+**Branch:** `feature/wbia-annotation-reconciliation-sweep` (off `main`)
+
+## Problem
+
+`AcmIdBot.sweepMatchableAssets()` continuously reconciles **MediaAssets** against WBIA:
+it probes `/api/image/rowid/uuid/` for every asset backing a `matchAgainst` annotation
+and re-registers the ones WBIA does not know. There is **no annotation equivalent**.
+
+Annotation registration relies on `StartupWildbook.startWbiaRegistrationPollingThread`
+(30s), which is push-once-and-trust-a-flag:
+
+1. **No probe.** It only queries `wbiaRegistered == false && wbiaRegisterAttempts < 10`.
+   Nothing ever asks WBIA whether an annotation is actually present, so drift (WBIA DB
+   rebuilt/restored, annotations deleted WBIA-side, a POST that "succeeded" but didn't
+   persist) is invisible and permanent.
+2. **Optimistic mass backfill.** `archive/sql/ml_service_idempotency.sql:65` sets
+   `WBIAREGISTERED = TRUE WHERE "ACMID" IS NOT NULL AND "WBIAREGISTERED" IS NULL` — an
+   assumption, never verified against WBIA. Every annotation it touched is excluded
+   from the poller forever.
+3. **No un-park path.** Only `MlServiceProcessor` (at creation) ever sets the flag FALSE.
+   Annotations parked at `wbiaRegisterAttempts = 10` — including ones parked for a
+   transient WBIA outage — never retry. No admin JSP exists.
+
+Live symptoms, both observed on the affected install:
+
+- identify fails permanently with WBIA
+  `code 600 "Missing image and/or annotation UUIDs (0, 32)"`, requeued 30× to no effect;
+- a manual annotation POST fails with WBIA `code 500`
+  `ValueError: The input list image_uuid_list has invalid values (index, value): [(0, None)]`
+  — i.e. **WBIA does not have the backing image**, even though the MediaAsset carries a
+  well-formed `acmId`. This is the decisive evidence for §4 below: a non-null `acmId` is
+  not evidence of WBIA image presence.
+
+## Verified facts (code archaeology, against `main` @ 61122d6f5a)
+
+- **`Annotation.id` is a String PK**, `<column length="36"/>` (UUID). The sweep cursor is
+  therefore a **String** with lexicographic ordering, not the int cursor the asset sweep
+  uses. Lexicographic order over a fixed-width UUID column is a stable total order.
+- **`matchAgainst` is a field on `Annotation`** (`Annotation.java:85`), not on Encounter.
+- **What identify asks WBIA about is the annotation's `acmId`, not its `id`:**
+  `IBEISIA.sendIdentify` builds `query_annot_uuid_list` / `database_annot_uuid_list`
+  from `toFancyUUID(ann.getAcmId())` (`IBEISIA.java:289`, `:326`). **The probe and the
+  heal must both key on `acmId`.**
+- **`acmId != id` is real for legacy rows.** ml-service and manual paths set
+  `acmId = getId()` (`MlServiceProcessor.java:478`, `Annotation.java:1656`,
+  `SubmitSpotsAndImage.java:145`), but WBIA-era import paths set acmId from WBIA's own
+  UUID (`IBEISIA.java:1274`, `:2172`) and `AcmUtil.rectifyAnnotationIds` rewrites it to
+  whatever WBIA returned (`AcmUtil.java:56,61`). So a force-by-`id` heal would register
+  a UUID identify never asks about.
+- **`sendAnnotationsForceId` forces the wrong identifier** for this purpose:
+  `annot_uuid_list = toFancyUUID(ann.getId())` (`WildbookIAM.java:387-388`). A new
+  force-by-acmId send is required — verified necessary, not a preference.
+- **Non-forced `sendAnnotations` mutates `acmId`** via `AcmUtil.rectifyAnnotationIds`,
+  which is why it is rejected as the heal: a reconciler must not rewrite the identifier
+  it reconciles.
+- **WBIA's annotation probe endpoint exists and has the semantics we need.** Verified in
+  the wildbook-ia source, not assumed:
+  `@register_api('/api/annot/rowid/uuid/', methods=['GET'])` on
+  `get_annot_aids_from_uuid` (`wbia/control/manual_annot_funcs.py:1126`), decorated
+  `@accessor_decors.getter_1to1` so the response is a parallel list. Its companion
+  `get_annot_missing_uuid` defines missing as exactly `aid is None`, matching what
+  `parseRowidProbeResponse` already implements. (As on the image side, the tidier
+  `/api/annot/uuid/missing/` route is commented out and unusable over REST.)
+- **Existing plumbing reused verbatim:** `WildbookIAM.chunkList`,
+  `PROBE_CHUNK_SIZE = 50`, `parseRowidProbeResponse`, `validateForcedResponse`,
+  `AcmIdBot.sendConfirmedAcmId`, `shouldSkipPoisonedPage`, `PAGE_FAIL_LIMIT = 3`, and the
+  read/probe/heal phase separation with explicit `updateDBTransaction()` commits.
+- **`Shepherd.updateDBTransaction()` = commit + begin**, so confirmed writes survive the
+  trailing `rollbackAndClose()`.
+- **Featureless legacy annotations bypass the asset sweep entirely.**
+  `Annotation.getMediaAsset()` falls back to the deprecated direct `__getMediaAsset()`
+  association when the annotation has no Features (`Annotation.java:618-627`), while the
+  asset sweep's scope query traverses `Feature` rows (`AcmIdBot.java:308`). Those assets
+  are invisible to it. The annotation sweep therefore cannot delegate image healing.
+
+## Design
+
+### 1. Scope
+
+Annotations with `matchAgainst == true` that are attached to an Encounter. Orphans are
+excluded: identification cannot reach them, and an orphan's `findIndividualId()` yields
+no name anyway. Scope deliberately **ignores `wbiaRegistered`** — that flag is the thing
+this sweep exists to stop trusting.
+
+```java
+select id, acmId from org.ecocean.Annotation
+where matchAgainst == true && enc.annotations.contains(this) && id > cursor
+VARIABLES org.ecocean.Encounter enc
+PARAMETERS String cursor
+result:   distinct id, acmId
+ordering: id ascending
+```
+
+Three deliberate choices:
+
+- **Bound parameter, not concatenation** — a String cursor concatenated into JDOQL is
+  invalid as an unquoted literal and brittle if quoted.
+- **Projection (`id, acmId`), not entity materialization** — the read phase must not
+  materialize 10,000 managed `Annotation` graphs to extract two fields.
+- **`distinct`** — `enc.annotations.contains(this)` yields one row per parent encounter,
+  so an annotation attached to several appears several times. Dedup is pushed into SQL;
+  the in-memory distinct-id collection remains as a backstop.
+
+### 2. Paging & cursor
+
+- `ANNOT_SWEEP_PAGE_SIZE = 10_000` distinct annotations per 15-minute run.
+- `static String annotSweepCursor = ""` (empty string sorts below every UUID);
+  `static int annotSweepFailCount = 0`.
+- Wrap-around on **raw result exhaustion only**, never a post-dedup count. Reset to `""`.
+- `maxFixes` clamp: cap hit mid-page ⇒ cursor advances only to the last annotation
+  actually processed.
+- **Partial-read progress (fixes the livelock).** The page object is allocated *before*
+  iteration and populated in place, so if iteration throws partway the caller still holds
+  the last safely-read id. A read-phase failure can then do a **targeted** skip to that
+  id rather than the blind `cursor += PAGE_SIZE` the int cursor uses and a String cursor
+  cannot express. Only when a page yields no ids at all is there nothing to skip to; that
+  case wraps to `""` with a loud `ANNOT SWEEP STUCK` log rather than retrying the same
+  page forever or silently dropping a range.
+
+### 3. Probe
+
+`WildbookIAM.iaMissingAnnotationIds(List<String> acmIds, String context)`, delegating to
+a new shared private `iaMissingIds(acmIds, context, endpointPath)` that also backs
+`iaMissingImageIds` — the two endpoints are both `getter_1to1` rowid lookups with
+identical response semantics, so the body is shared rather than copied. Null / non-UUID
+acmIds are filtered out before sending (they would make WBIA reject the whole chunk);
+any chunk failure throws `IOException` so a failed probe is never read as "all present".
+
+### 4. Heal — image presence first
+
+**The annotation heal must confirm the backing image is present in WBIA, not merely that
+`MediaAsset.acmId != null`.** This is the correction the live 500 error forces, and it
+also covers the featureless-legacy-annotation hole where the asset sweep never sees the
+asset at all. Per candidate, in order:
+
+1. Load the annotation; skip if gone.
+2. Resolve the MediaAsset; skip (count `skippedNoAsset`) if absent. If its `acmId` is
+   null or malformed, adopt `acmId = ma.getUUID()` (the asset sweep's own convention).
+3. **Context-aware** eligibility: `IBEISIA.validForIdentification(ann, context)`. The
+   no-context overload skips the `validIAClassForIdentification` check, so using it would
+   let the sweep register annotations identify then rejects.
+4. **Image presence:** probe `iaMissingImageIds([ma.getAcmId()])`. If missing, register
+   via the existing `IBEISIA.sendMediaAssetsNew([ma], context, false)` and require
+   `AcmIdBot.sendConfirmedAcmId(rtn, ma.getAcmId())`. Unconfirmed ⇒ count
+   `blockedOnAsset`, revert any adopted asset acmId, continue — the annotation is
+   retried on a later pass, not parked.
+5. Adopt the annotation's `acmId = getId()` if null/malformed.
+6. `WildbookIAM.sendAnnotationForcedByAcmId(ann, shepherd)` — forces
+   `annot_uuid_list = acmId`, performs **no already-present check** (the probe already
+   established absence, and the full-list `iaAnnotationIds()` fetch would be ~1M UUIDs).
+   Critically it must never treat presence of `ann.id` at WBIA as evidence that
+   `ann.acmId` is registered — that is precisely the failure under repair.
+7. Confirmed (WBIA echoed our acmId) ⇒ set `wbiaRegistered = TRUE` and
+   `wbiaRegisterAttempts = 0`, **each only if its value actually changes**, since both
+   setters bump `Annotation.version` and would otherwise cause needless OpenSearch
+   reindex churn across a systemic WBIA loss. Then `updateDBTransaction()`.
+   Not confirmed ⇒ revert the adopted acmId. Reverting happens on **every**
+   non-confirmed outcome, not only a thrown send.
+
+Setting `wbiaRegistered = TRUE` also un-parks annotations the 30s poller abandoned at
+`attempts >= MAX`, which nothing else in the codebase does — closing problem #3.
+
+### 5. Transactions
+
+Phase separation identical to `sweepMatchableAssets`: read (short tx, primitives out) →
+probe (no tx open) → heal (fresh tx, commit per confirmed heal). Wired into
+`AcmIdBot.fixAcmIds()` after `sweepMatchableAssets`, under the existing `botRunning`
+guard. The heal phase does hold one DB connection across its HTTP calls — the same
+shape the asset sweep already has, one connection at a time.
+
+### 6. Constants & expected duration
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `ANNOT_SWEEP_PAGE_SIZE` | 10,000 | distinct annotations examined per 15-min run |
+| `PROBE_CHUNK_SIZE` | 50 (existing) | UUIDs per probe GET |
+| `PAGE_FAIL_LIMIT` | 3 (existing) | failed runs on one page before skipping |
+| `maxFixes` | 500 (existing) | max successful heals per run |
+
+**Duration, stated plainly** (the rev-1 spec understated this): at 1M matchable
+annotations, a *healthy* full pass is 100 runs ≈ **25 hours**. If every annotation needs
+repair, `maxFixes = 500` makes it 2,000 runs ≈ **21 days**, and each resumed run still
+probes up to 10,000 rows. That is acceptable for continuous background reconciliation and
+unacceptable as an incident response — a bulk repair for a known-bad install wants a
+dedicated admin JSP (deferred, see below). The summary log reports page counts, heals
+sent/confirmed, and both skip reasons so the rate is observable.
+
+## Explicitly out of scope
+
+Real defects found in the same investigation; each is separately PR-worthy and bundling
+them would make this diff unreviewable.
+
+- **`IBEISIA.iaCheckMissing` is broken.** Its image branch is a no-op
+  (`// TODO: actually send the mediaasset duh`, prints "FAKE ATTEMPT"); its annotation
+  branch calls `__sendAnnotations(...)` but never assigns the result to `srtn`, so
+  `tryAgain` is always false and identify is never retried; `catch (Exception ex) {}`
+  swallows failures; and `anns.add(annsTemp.get(0))` inside one shared try means a single
+  unresolvable acmId aborts collection of the rest of the missing list.
+- **send/identify eligibility mismatch.** `sendAnnotations` skips annotations whose
+  MediaAsset lacks an acmId while `sendIdentify` still asks about them. The sweep no
+  longer *depends* on this being fixed (it confirms image presence itself and uses the
+  context-aware eligibility check), but the live path still needs it.
+- **`sendAnnotationsAsNeeded` swallows send exceptions** into
+  `rtn.put("sendAnnotMAException", ...)`; identify proceeds regardless.
+- Durable cursor/quarantine persistence across restart; an admin JSP for bulk repair and
+  for forcing a re-sweep; configurable probe/heal limits with run-duration telemetry.
+
+## Testing
+
+Pure-logic unit tests (no scheduler, no network), mirroring `AcmIdBotSweepTest` and
+`WildbookIAMRowidProbeParseTest`:
+
+- Page collection over `(id, acmId)` projection rows: distinct-id dedup (multi-encounter
+  duplicates), `rawExhausted` only on input exhaustion, page-size boundary, empty page,
+  null-row and null-id tolerance, duplicate-acmId warning.
+- Cursor policy: advance past page, wrap to `""` on exhaustion, `maxFixes` clamp resumes
+  mid-page, empty page never writes a null cursor.
+- Candidate routing: null and malformed acmIds go to the heal-without-probe bucket;
+  well-formed ones go to the probe bucket, mapped back to their annotation id.
+- **Regression for Codex finding #1:** `id` present at WBIA but `acmId` absent must still
+  POST the `acmId`. Covered at the unit level by asserting the forced request map carries
+  the acmId (not the id) when the two differ.
+- Probe: `iaMissingAnnotationIds` null-input and non-UUID filtering; response parsing is
+  already covered by the shared `parseRowidProbeResponse` tests.
+
+## Codex review disposition (rev 1 → rev 2)
+
+| # | Severity | Finding | Disposition |
+|---|---|---|---|
+| 1 | Critical | A near-copy sender retaining the `iaAnnotIds.contains(ann.getId())` skip would refuse to send exactly the rows under repair | §4.6: new sender does **no** already-present check at all; unit test asserts acmId (not id) is forced |
+| 2 | Major | "asset sweep runs earlier in the same tick" does not establish the dependency; featureless legacy annotations are invisible to the asset sweep | §4.4: annotation heal probes and registers the image itself. Confirmed independently by the live 500 error |
+| 3 | Major | JDOQL not implementation-ready: String cursor needs a bound parameter | §1: `PARAMETERS String cursor`, plus projection and `distinct` |
+| 4 | Major | String-cursor failure policy can livelock at a poison row | §2: page allocated before iteration so partial progress survives; targeted skip, `ANNOT SWEEP STUCK` only when no ids at all |
+| 5 | Minor | Two "verified facts" wrong: prospects hold an `Annotation` relationship not an acmId; `findIndividualId` doesn't require an encounter | Both claims removed/corrected above |
+| 6 | Major | Deferred eligibility defect partly load-bearing; sweep used the context-free `validForIdentification` | §4.3: context-aware form; image presence in this same PR |
+| 7 | Major | Scale understated; entity materialization not proven heap-safe; pool claim wrong | §1 projects `id, acmId`; §6 states 25h healthy / 21d worst case plainly; unverified pool number dropped |
+| 8 | Minor | Revert on every non-confirmed outcome; setters always bump version → reindex churn | §4.7: revert on all non-confirmed paths; set each flag only when its value changes |

--- a/docs/superpowers/specs/2026-08-03-wbia-annotation-reconciliation-sweep-design.md
+++ b/docs/superpowers/specs/2026-08-03-wbia-annotation-reconciliation-sweep-design.md
@@ -1,6 +1,6 @@
 # WBIA Annotation Reconciliation Sweep — Design
 
-**Date:** 2026-08-03 (rev 2, post-Codex review)
+**Date:** 2026-08-03 (rev 3, post-Codex round 2 on the implementation)
 **Status:** Approved
 **Branch:** `feature/wbia-annotation-reconciliation-sweep` (off `main`)
 
@@ -95,7 +95,23 @@ result:   distinct id, acmId
 ordering: id ascending
 ```
 
-Three deliberate choices:
+plus an anti-race clause taking the exact complement of the 30s poller's queue:
+
+```java
+&& (wbiaRegistered == null || wbiaRegistered == true
+    || wbiaRegisterAttempts >= StartupWildbook.WBIA_REGISTER_MAX_ATTEMPTS)
+```
+
+The poller claims precisely `wbiaRegistered == false && attempts < MAX`. Without this
+clause both workers could POST the same annotation concurrently — and since the poller
+forces `id` while the sweep forces `acmId`, an `id != acmId` row would land in WBIA as
+**two annotations on one box**. Partitioning by the flag beats a lease here because the
+sweep's whole purpose is the rows the poller ignores: those whose flag is lying
+(`TRUE`, or `NULL` for rows the backfill never touched) and those it permanently parked.
+Note `wbiaRegistered` is a nullable `Boolean`, so the null case is spelled out rather
+than relying on `!= false` — SQL three-valued logic would drop null rows.
+
+Three further deliberate choices:
 
 - **Bound parameter, not concatenation** — a String cursor concatenated into JDOQL is
   invalid as an unquoted literal and brittle if quoted.
@@ -138,16 +154,26 @@ also covers the featureless-legacy-annotation hole where the asset sweep never s
 asset at all. Per candidate, in order:
 
 1. Load the annotation; skip if gone.
-2. Resolve the MediaAsset; skip (count `skippedNoAsset`) if absent. If its `acmId` is
-   null or malformed, adopt `acmId = ma.getUUID()` (the asset sweep's own convention).
+2. Resolve the MediaAsset; skip (count `skippedNoAsset`) if absent.
 3. **Context-aware** eligibility: `IBEISIA.validForIdentification(ann, context)`. The
    no-context overload skips the `validIAClassForIdentification` check, so using it would
    let the sweep register annotations identify then rejects.
-4. **Image presence:** probe `iaMissingImageIds([ma.getAcmId()])`. If missing, register
-   via the existing `IBEISIA.sendMediaAssetsNew([ma], context, false)` and require
-   `AcmIdBot.sendConfirmedAcmId(rtn, ma.getAcmId())`. Unconfirmed ⇒ count
-   `blockedOnAsset`, revert any adopted asset acmId, continue — the annotation is
-   retried on a later pass, not parked.
+4. **Image presence**, delegated wholly to `ensureImageRegistered`, which owns the asset's
+   `acmId` so the heal loop never has to reason about reverting it. **Step order inside it
+   is load-bearing**, because `updateDBTransaction()` is commit-plus-begin and so commits
+   *every* dirty object in the transaction, not just the field the caller had in mind:
+   1. resolve and commit image validity **first**, while nothing provisional is pending;
+   2. if the asset already carries a well-formed acmId, probe
+      `iaMissingImageIds([acmId])` — present ⇒ done, no writes at all;
+   3. only then adopt `acmId = ma.getUUID()` if needed, POST via
+      `IBEISIA.sendMediaAssetsNew([ma], context, false)`, require
+      `sendConfirmedAcmId(rtn, ma.getAcmId())`, and commit **only after** confirmation.
+
+   Adopting before the validity commit would let an unconfirmed identifier be committed by
+   that flush, after which the in-memory revert is silently discarded by the enclosing
+   `rollbackAndClose()` — leaving Wildbook holding an acmId WBIA never acknowledged.
+   Unconfirmed ⇒ count `blockedOnAsset` and continue; the annotation is retried on a later
+   pass, never parked.
 5. Adopt the annotation's `acmId = getId()` if null/malformed.
 6. `WildbookIAM.sendAnnotationForcedByAcmId(ann, shepherd)` — forces
    `annot_uuid_list = acmId`, performs **no already-present check** (the probe already
@@ -158,8 +184,11 @@ asset at all. Per candidate, in order:
    `wbiaRegisterAttempts = 0`, **each only if its value actually changes**, since both
    setters bump `Annotation.version` and would otherwise cause needless OpenSearch
    reindex churn across a systemic WBIA loss. Then `updateDBTransaction()`.
-   Not confirmed ⇒ revert the adopted acmId. Reverting happens on **every**
-   non-confirmed outcome, not only a thrown send.
+   Not confirmed ⇒ revert the annotation's acmId, on **every** non-confirmed outcome and
+   not only a thrown send — but only when an adoption actually happened, since a
+   no-op `setAcmId` still bumps `version`. The asset's acmId is deliberately **not**
+   reverted here: its registration was already confirmed in step 4, and undoing it would
+   make Wildbook forget an image WBIA really holds.
 
 Setting `wbiaRegistered = TRUE` also un-parks annotations the 30s poller abandoned at
 `attempts >= MAX`, which nothing else in the codebase does — closing problem #3.
@@ -239,3 +268,22 @@ Pure-logic unit tests (no scheduler, no network), mirroring `AcmIdBotSweepTest` 
 | 6 | Major | Deferred eligibility defect partly load-bearing; sweep used the context-free `validForIdentification` | §4.3: context-aware form; image presence in this same PR |
 | 7 | Major | Scale understated; entity materialization not proven heap-safe; pool claim wrong | §1 projects `id, acmId`; §6 states 25h healthy / 21d worst case plainly; unverified pool number dropped |
 | 8 | Minor | Revert on every non-confirmed outcome; setters always bump version → reindex churn | §4.7: revert on all non-confirmed paths; set each flag only when its value changes |
+
+## Codex round 2 disposition (implementation review; rev 2 → rev 3)
+
+Round 2 confirmed findings 1–7 FIXED in code and 8 partially fixed. Three items remained,
+all now closed:
+
+| # | Severity | Finding | Disposition |
+|---|---|---|---|
+| 8 | Minor | An unconfirmed POST called `setAcmId(prior)` even when no adoption had occurred, bumping `version` for nothing | Track `annAcmIdAdopted`; revert only when true, on both the else-branch and catch paths |
+| 9 | Major | A provisional asset acmId could be **committed** by the validity `updateDBTransaction()` before image confirmation; the later revert was then discarded by `rollbackAndClose()`, leaving an unconfirmed acmId persisted | `ensureImageRegistered` reordered to commit validity before adopting, and to commit the adopted acmId only after confirmation; it now owns the asset acmId end-to-end so the heal loop never touches it |
+| 10 | Major | The sweep raced the 30s poller; for an `id != acmId` row both could POST, creating two WBIA annotations for one box | §1 anti-race clause: sweep scope is the exact complement of the poller's queue |
+
+Also confirmed correct in round 2, having been fixed between rounds without being asked:
+page-exhaustion logic (size-limit return cannot mark exhaustion, including an exactly-full
+final page); fail-closed projection-shape handling (an unexpected row shape throws instead
+of mass-routing every row into the null-acmId bucket and re-POSTing the corpus);
+database-order candidate processing (so the heal-cap resume cursor cannot skip candidates
+when Postgres collation disagrees with Java String ordering); and that the `iaMissingIds`
+extraction preserved `iaMissingImageIds` behavior for its existing caller.

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -174,7 +174,7 @@ public class AcmIdBot {
     // WBIA? add_images_json returns the registered image UUIDs; require ours
     // among them before counting (and committing) a heal — otherwise a locally
     // pre-assigned acmId could be persisted although WBIA never registered it
-    static boolean sendConfirmedAcmId(org.json.JSONObject sendRtn, String expectedAcmId) {
+    public static boolean sendConfirmedAcmId(org.json.JSONObject sendRtn, String expectedAcmId) {
         if ((sendRtn == null) || (expectedAcmId == null)) return false;
         org.json.JSONArray batches = sendRtn.optJSONArray("batchResults");
         if (batches == null) return false;

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -22,6 +22,12 @@ import org.ecocean.shepherd.core.Shepherd;
  * page of a continuous reconciliation sweep: every MediaAsset backing a matchAgainst annotation is eventually probed against WBIA
  * (/api/image/rowid/uuid/) and re-registered if WBIA does not know its acmId.
  *
+ * Annotations get the same treatment in a second sweep (/api/annot/rowid/uuid/). They need their own because
+ * StartupWildbook's 30-second registration poller only pushes newly created annotations once and then trusts
+ * Annotation.wbiaRegistered forever -- so anything that flag lies about stays broken silently and permanently.
+ * See sweepMatchableAnnotations() and
+ * docs/superpowers/specs/2026-08-03-wbia-annotation-reconciliation-sweep-design.md.
+ *
  */
 public class AcmIdBot {
     private static void fixFeats(List<Feature> feats, Shepherd myShepherd, String summaryMessage,
@@ -279,6 +285,11 @@ public class AcmIdBot {
             // full reconciliation sweep of the matchable set (replaces the old
             // 24-hour Encounter query); manages its own transactions
             sweepMatchableAssets(context, maxFixes);
+            // annotation-side equivalent; also manages its own transactions. Runs after
+            // the asset sweep so a tick heals images before annotations, though the
+            // annotation sweep does NOT rely on that -- the two have independent cursors,
+            // so it confirms image presence itself (see sweepMatchableAnnotations).
+            sweepMatchableAnnotations(context, maxFixes);
         } finally {
             botRunning.set(false);
         }
@@ -481,5 +492,407 @@ public class AcmIdBot {
             healedCount + (maxFixesHit ? " (maxFixes cap hit)" : ""));
         System.out.println("......cursor now " + sweepCursor +
             (page.rawExhausted && !maxFixesHit ? " (sweep complete, wrapped)" : ""));
+    }
+
+    // ------- annotation reconciliation sweep -------
+    // (spec: docs/superpowers/specs/2026-08-03-wbia-annotation-reconciliation-sweep-design.md)
+
+    static final int ANNOT_SWEEP_PAGE_SIZE = 10000; // distinct annotations per 15-minute run
+    // Annotation.id is a String UUID primary key (package.jdo: <column length="36"/>), so
+    // unlike the asset cursor this one is lexicographic and its "from the beginning"
+    // sentinel is the empty string, which sorts below every UUID.
+    static String annotSweepCursor = "";
+    static int annotSweepFailCount = 0;
+
+    // one page of annotation sweep candidates, reduced to primitives so no JDO
+    // object outlives the read transaction
+    static class AnnotSweepPage {
+        // annotations to heal without probing: no acmId, or a non-UUID one
+        final List<String> nullAcmAnnotIds = new ArrayList<String>();
+        final java.util.LinkedHashMap<String, String> acmIdToAnnotId =
+            new java.util.LinkedHashMap<String, String>();
+        boolean rawExhausted = false;
+        String lastAnnotId = null; // null = nothing read yet
+    }
+
+    /**
+     * Convenience wrapper allocating the page for callers that don't need partial
+     * progress on failure (i.e. tests).
+     */
+    static AnnotSweepPage collectAnnotSweepPage(java.util.Iterator<String[]> rowsInIdOrder,
+        int pageSize) {
+        AnnotSweepPage page = new AnnotSweepPage();
+
+        collectAnnotSweepPageInto(page, rowsInIdOrder, pageSize);
+        return page;
+    }
+
+    /**
+     * Walk projected {@code (id, acmId)} rows in ascending id order, collecting up to
+     * {@code pageSize} distinct annotations into {@code page}.
+     *
+     * <p>Populates the caller's page <b>in place</b> on purpose: if iteration throws
+     * partway (a corrupt row, a dead cursor), the caller still sees the last safely-read
+     * id and can make a targeted skip. A String cursor has no {@code cursor += PAGE_SIZE}
+     * blind advance available to it, so without partial progress a single poison row
+     * would stall the sweep forever.</p>
+     *
+     * <p>The scope query joins through Encounter, so an annotation attached to more than
+     * one encounter can appear more than once even with SQL {@code distinct} applied;
+     * hence the in-memory dedup. {@code rawExhausted} is set true only when the input
+     * actually ran out — never inferred from a post-dedup count, or a page whose
+     * duplicates collapsed below {@code pageSize} would falsely end the sweep.</p>
+     */
+    static void collectAnnotSweepPageInto(AnnotSweepPage page,
+        java.util.Iterator<String[]> rowsInIdOrder, int pageSize) {
+        java.util.Set<String> seen = new java.util.HashSet<String>();
+
+        while (rowsInIdOrder.hasNext()) {
+            String[] row = rowsInIdOrder.next();
+            if ((row == null) || (row.length < 1)) continue;
+            String annId = row[0];
+            String acmId = (row.length > 1) ? row[1] : null;
+            // an id-less row could not be re-loaded in the heal phase, and must not
+            // become the cursor either
+            if (!Util.stringExists(annId)) continue;
+            if (seen.contains(annId)) continue;
+            if (seen.size() >= pageSize) return; // rawExhausted stays false: more remains
+            seen.add(annId);
+            page.lastAnnotId = annId;
+            // null or malformed acmId: route straight to the heal path rather than the
+            // probe, since a non-UUID value would make WBIA reject the whole probe chunk
+            // and could strand the rest of the page
+            if ((acmId == null) || !Util.isUUID(acmId)) {
+                page.nullAcmAnnotIds.add(annId);
+            } else {
+                String displaced = page.acmIdToAnnotId.put(acmId, annId);
+                if (displaced != null) {
+                    System.out.println("WARNING: AcmIdBot annotation sweep found duplicate acmId " +
+                        acmId + " on annotations " + displaced + " and " + annId +
+                        "; only the latter will be probed/healed this sweep");
+                }
+            }
+        }
+        page.rawExhausted = true; // input ran out: sweep has reached the end
+    }
+
+    // cursor policy, mirroring nextCursorAfterSuccess: maxFixes clamp wins (resume
+    // mid-page next run), else wrap on true exhaustion, else advance past the page
+    static String nextAnnotCursorAfterSuccess(AnnotSweepPage page, boolean maxFixesHit,
+        String resumeAnnotId) {
+        if (maxFixesHit && Util.stringExists(resumeAnnotId)) return resumeAnnotId;
+        if (page.rawExhausted) return "";
+        // lastAnnotId is null only when nothing was read, which the exhaustion branch
+        // above already covers. Guard anyway so a null never reaches the cursor.
+        return (page.lastAnnotId == null) ? "" : page.lastAnnotId;
+    }
+
+    /**
+     * One 15-minute bite of the annotation reconciliation sweep.
+     * Phase-separated exactly like {@link #sweepMatchableAssets}: (1) read one page of
+     * distinct matchable annotations inside a short transaction, projected to primitives;
+     * (2) probe WBIA over HTTP with no transaction open; (3) heal missing annotations in
+     * a fresh transaction with explicit commits so results survive
+     * {@code rollbackAndClose()}.
+     *
+     * <p>Scope is annotations with {@code matchAgainst == true} that are attached to an
+     * Encounter, deliberately <b>ignoring {@code wbiaRegistered}</b> — that flag is the
+     * thing this sweep exists to stop trusting.</p>
+     */
+    static void sweepMatchableAnnotations(String context, int maxFixes) {
+        // ---- read phase ----
+        AnnotSweepPage page = new AnnotSweepPage();
+        boolean readOk = false;
+        Shepherd readShepherd = new Shepherd(context);
+
+        readShepherd.setAction("AcmIdBot.annotSweepRead");
+        readShepherd.beginDBTransaction();
+        Query query = null;
+        try {
+            System.out.println("AcmIdBot annotation sweep: reading from cursor '" +
+                annotSweepCursor + "'");
+            // enc.annotations.contains(this) both restricts scope to annotations attached
+            // to an Encounter and binds the variable (an unbound VARIABLES declaration is
+            // a silent no-op). The cursor is a bound parameter: a String concatenated into
+            // JDOQL would be an invalid unquoted literal.
+            query = readShepherd.getPM().newQuery(org.ecocean.Annotation.class,
+                "matchAgainst == true && enc.annotations.contains(this) && id > cursor");
+            query.declareVariables("org.ecocean.Encounter enc");
+            query.declareParameters("String cursor");
+            // project only what the sweep needs; materializing 10k managed Annotation
+            // graphs to read two fields would be gratuitous heap pressure
+            query.setResult("distinct id, acmId");
+            query.setOrdering("id ascending");
+            // stream rather than buffer the whole ResultSet client-side (pgjdbc default
+            // fetchSize=0 buffers everything); setRange would break rawExhausted semantics
+            query.getFetchPlan().setFetchSize(1000);
+            Collection c = (Collection)(query.execute(annotSweepCursor));
+            final java.util.Iterator rawIter = c.iterator();
+            java.util.Iterator<String[]> rowIter = new java.util.Iterator<String[]>() {
+                public boolean hasNext() {
+                    return rawIter.hasNext();
+                }
+
+                public String[] next() {
+                    Object o = rawIter.next();
+                    // a two-column projection yields Object[]; be tolerant of a
+                    // single-column collapse rather than throwing mid-page
+                    if (o instanceof Object[]) {
+                        Object[] arr = (Object[])o;
+                        return new String[] {
+                                   (arr.length > 0 && arr[0] != null) ? arr[0].toString() : null,
+                                   (arr.length > 1 && arr[1] != null) ? arr[1].toString() : null
+                        };
+                    }
+                    return new String[] { (o == null) ? null : o.toString(), null };
+                }
+            };
+            collectAnnotSweepPageInto(page, rowIter, ANNOT_SWEEP_PAGE_SIZE);
+            readOk = true;
+        } catch (Exception ex) {
+            System.out.println("Exception in AcmIdBot.sweepMatchableAnnotations read phase!");
+            ex.printStackTrace();
+        } finally {
+            if (query != null) query.closeAll();
+            readShepherd.rollbackAndClose();
+        }
+        if (!readOk) {
+            annotSweepFailCount++;
+            System.out.println("WARNING: AcmIdBot annotation sweep read phase failed (attempt " +
+                annotSweepFailCount + " of " + PAGE_FAIL_LIMIT + " at cursor '" +
+                annotSweepCursor + "')");
+            if (shouldSkipPoisonedPage(annotSweepFailCount)) {
+                if (Util.stringExists(page.lastAnnotId)) {
+                    // partial progress survived the failure: skip precisely past what we
+                    // did manage to read, so the offending row is stepped over once
+                    System.out.println(
+                        "WARNING: AcmIdBot annotation sweep SKIPPING past partially-read page; cursor '"
+                        + annotSweepCursor + "' -> '" + page.lastAnnotId + "'");
+                    annotSweepCursor = page.lastAnnotId;
+                } else {
+                    // Nothing was read at all, so there is no id to skip to and a String
+                    // cursor has no arithmetic to blind-advance with. A read failure this
+                    // early is almost always cursor-independent (DB down, pool exhausted),
+                    // so wrap and keep going. If it IS a poison row at this position,
+                    // wrapping re-reaches it and this line recurs -- which is the point:
+                    // never silently skip a range, because an unswept range is invisible
+                    // while a recurring log line is not.
+                    System.out.println("WARNING: ANNOT SWEEP STUCK at cursor '" +
+                        annotSweepCursor + "' after " + PAGE_FAIL_LIMIT +
+                        " consecutive read failures with no rows read; wrapping to restart. " +
+                        "If this repeats, investigate the annotation rows just past this id.");
+                    annotSweepCursor = "";
+                }
+                annotSweepFailCount = 0;
+            }
+            return; // cursor otherwise unchanged: same page retried next run
+        }
+
+        // ---- probe phase (no transaction open) ----
+        List<String> missingAcmIds = null;
+        try {
+            missingAcmIds = org.ecocean.ia.plugin.WildbookIAM.iaMissingAnnotationIds(
+                new ArrayList<String>(page.acmIdToAnnotId.keySet()), context);
+        } catch (java.io.IOException ex) {
+            annotSweepFailCount++;
+            System.out.println("WARNING: AcmIdBot annotation sweep probe failed (attempt " +
+                annotSweepFailCount + " of " + PAGE_FAIL_LIMIT + " at cursor '" +
+                annotSweepCursor + "'): " + ex.toString());
+            if (shouldSkipPoisonedPage(annotSweepFailCount)) {
+                System.out.println(
+                    "WARNING: AcmIdBot annotation sweep SKIPPING page after repeated failures; cursor '"
+                    + annotSweepCursor + "' -> '" + page.lastAnnotId + "'");
+                if (Util.stringExists(page.lastAnnotId)) annotSweepCursor = page.lastAnnotId;
+                annotSweepFailCount = 0;
+            }
+            return; // cursor otherwise unchanged: same page retried next run
+        }
+
+        // ---- heal phase (own transaction, explicit commits) ----
+        List<String> candidateIds = new ArrayList<String>(page.nullAcmAnnotIds);
+        for (String acmId : missingAcmIds) {
+            String annId = page.acmIdToAnnotId.get(acmId);
+            if (annId != null) candidateIds.add(annId);
+        }
+        java.util.Collections.sort(candidateIds); // ascending id = cursor order
+        AnnotHealTally tally = new AnnotHealTally();
+        tally.resumeAnnotId = page.lastAnnotId;
+        if (candidateIds.size() > 0) healAnnotations(context, candidateIds, maxFixes, tally);
+        annotSweepCursor = nextAnnotCursorAfterSuccess(page, tally.maxFixesHit,
+            tally.resumeAnnotId);
+        annotSweepFailCount = 0;
+        System.out.println("AcmIdBot Annotation Reconciliation Sweep Summary");
+        System.out.println("...page: " + (page.acmIdToAnnotId.size() +
+            page.nullAcmAnnotIds.size()) + " candidates (" + page.acmIdToAnnotId.size() +
+            " probed, " + page.nullAcmAnnotIds.size() + " null/malformed acmId)");
+        System.out.println("......missing from WBIA: " + missingAcmIds.size());
+        System.out.println("......heals sent: " + tally.sent + ", heals confirmed: " +
+            tally.healed + (tally.maxFixesHit ? " (maxFixes cap hit)" : ""));
+        System.out.println("......skipped: " + tally.skippedNoAsset + " no media asset, " +
+            tally.blockedOnAsset + " image not registered at WBIA, " +
+            tally.skippedInvalid + " invalid for identification");
+        System.out.println("......cursor now '" + annotSweepCursor + "'" +
+            (page.rawExhausted && !tally.maxFixesHit ? " (sweep complete, wrapped)" : ""));
+    }
+
+    /** Per-run heal accounting, kept in one object so the summary log stays honest. */
+    static class AnnotHealTally {
+        int sent = 0;
+        int healed = 0;
+        int skippedNoAsset = 0;
+        int blockedOnAsset = 0;
+        int skippedInvalid = 0;
+        boolean maxFixesHit = false;
+        String resumeAnnotId = null;
+    }
+
+    /**
+     * Heal phase: re-register each candidate annotation with WBIA under its own acmId.
+     * Split out of {@link #sweepMatchableAnnotations} to keep that method readable.
+     */
+    private static void healAnnotations(String context, List<String> candidateIds, int maxFixes,
+        AnnotHealTally tally) {
+        Shepherd healShepherd = new Shepherd(context);
+
+        healShepherd.setAction("AcmIdBot.annotSweepHeal");
+        healShepherd.beginDBTransaction();
+        org.ecocean.ia.plugin.WildbookIAM iam = new org.ecocean.ia.plugin.WildbookIAM(context);
+        try {
+            for (String annId : candidateIds) {
+                healShepherd.setAction("AcmIdBot.annotSweepHeal_annot_" + annId);
+                // hoisted so the catch block can revert identifiers we adopted locally
+                // but WBIA never acknowledged
+                Annotation ann = null;
+                MediaAsset ma = null;
+                String priorAnnAcmId = null;
+                String priorMaAcmId = null;
+                boolean annPriorCaptured = false;
+                boolean maPriorCaptured = false;
+                try {
+                    ann = healShepherd.getAnnotation(annId);
+                    if (ann == null) {
+                        System.out.println("WARNING: AcmIdBot annotation sweep skipping " + annId +
+                            " (no longer exists)");
+                        continue;
+                    }
+                    ma = ann.getMediaAsset();
+                    if (ma == null) {
+                        tally.skippedNoAsset++;
+                        continue;
+                    }
+                    // context-aware on purpose: the no-context overload skips the
+                    // validIAClassForIdentification check, so using it would let the sweep
+                    // register annotations identify then rejects
+                    if (!IBEISIA.validForIdentification(ann, context)) {
+                        tally.skippedInvalid++;
+                        continue;
+                    }
+                    priorMaAcmId = ma.getAcmId();
+                    maPriorCaptured = true;
+                    if ((priorMaAcmId == null) || !Util.isUUID(priorMaAcmId))
+                        ma.setAcmId(ma.getUUID());
+                    // WBIA cannot hold an annotation whose image it does not have: the
+                    // annotation POST fails with
+                    // "image_uuid_list has invalid values [(0, None)]". A non-null
+                    // MediaAsset.acmId is NOT evidence of WBIA presence -- closing that gap
+                    // is the whole point of the asset sweep -- and featureless legacy
+                    // annotations reach their asset via the deprecated direct association,
+                    // which the Feature-based asset sweep never traverses. So confirm the
+                    // image here rather than assuming the asset sweep got there first.
+                    if (!ensureImageRegistered(ma, context, healShepherd)) {
+                        tally.blockedOnAsset++;
+                        if (maPriorCaptured) ma.setAcmId(priorMaAcmId);
+                        continue;
+                    }
+                    priorAnnAcmId = ann.getAcmId();
+                    annPriorCaptured = true;
+                    // legacy null or malformed acmIds adopt the annotation's own id before
+                    // sending, matching MlServiceProcessor's convention
+                    if ((priorAnnAcmId == null) || !Util.isUUID(priorAnnAcmId))
+                        ann.setAcmId(ann.getId());
+                    boolean confirmed = iam.sendAnnotationForcedByAcmId(ann, healShepherd);
+                    tally.sent++;
+                    if (confirmed) {
+                        // Setters bump Annotation.version (and so trigger an OpenSearch
+                        // reindex), so only write a field whose value actually changes --
+                        // otherwise a systemic WBIA loss would reindex the whole corpus for
+                        // nothing. Marking registered also un-parks annotations the 30s
+                        // poller abandoned at attempts >= MAX, which nothing else does.
+                        if (!Boolean.TRUE.equals(ann.getWbiaRegistered()))
+                            ann.setWbiaRegistered(Boolean.TRUE);
+                        if (ann.getWbiaRegisterAttempts() != 0) ann.setWbiaRegisterAttempts(0);
+                        // commit so the confirmed acmId + flags survive rollbackAndClose
+                        healShepherd.updateDBTransaction();
+                        tally.healed++;
+                        if (tally.healed >= maxFixes) {
+                            tally.maxFixesHit = true;
+                            tally.resumeAnnotId = annId;
+                            break;
+                        }
+                    } else {
+                        System.out.println(
+                            "WARNING: AcmIdBot annotation sweep could not confirm WBIA registration for "
+                            + annId + "; not counting as healed");
+                        // never persist an identifier WBIA did not acknowledge
+                        ann.setAcmId(priorAnnAcmId);
+                        ma.setAcmId(priorMaAcmId);
+                    }
+                } catch (Exception ec) {
+                    // revert BEFORE any later candidate's commit can persist an identifier
+                    // WBIA never acknowledged
+                    if (annPriorCaptured && (ann != null)) ann.setAcmId(priorAnnAcmId);
+                    if (maPriorCaptured && (ma != null)) ma.setAcmId(priorMaAcmId);
+                    System.out.println("Exception in AcmIdBot annotation sweep heal for " + annId);
+                    ec.printStackTrace();
+                }
+            }
+        } finally {
+            healShepherd.rollbackAndClose();
+        }
+    }
+
+    /**
+     * Probe WBIA for this image and register it if absent. Returns true when WBIA is
+     * known to hold the asset's acmId, i.e. when it is safe to POST an annotation
+     * referencing it. Reuses the asset sweep's own probe and send so there is one
+     * definition of "registered".
+     */
+    private static boolean ensureImageRegistered(MediaAsset ma, String context,
+        Shepherd myShepherd) {
+        String maAcmId = ma.getAcmId();
+
+        if (!Util.stringExists(maAcmId) || !Util.isUUID(maAcmId)) return false;
+        try {
+            List<String> missing = org.ecocean.ia.plugin.WildbookIAM.iaMissingImageIds(
+                java.util.Arrays.asList(maAcmId), context);
+            if (missing.isEmpty()) return true; // WBIA already has it
+            if (ma.isValidImageForIA() == null) {
+                ma.validateSourceImage();
+                myShepherd.updateDBTransaction();
+            }
+            if (!ma.isValidImageForIAForced()) {
+                System.out.println("WARNING: AcmIdBot annotation sweep cannot register unhealable image "
+                    + ma.getId() + " (invalid or unvalidatable for IA)");
+                return false;
+            }
+            if (!ma.hasFamily(myShepherd)) ma.updateStandardChildren();
+            ArrayList<MediaAsset> fixMe = new ArrayList<MediaAsset>();
+            fixMe.add(ma);
+            // checkFirst=false: the probe above already established absence
+            org.json.JSONObject sendRtn = IBEISIA.sendMediaAssetsNew(fixMe, context, false);
+            if (!sendConfirmedAcmId(sendRtn, ma.getAcmId())) {
+                System.out.println(
+                    "WARNING: AcmIdBot annotation sweep could not confirm image registration for asset "
+                    + ma.getId() + "; deferring its annotations");
+                return false;
+            }
+            // persist the confirmed image registration before the annotation POST
+            myShepherd.updateDBTransaction();
+            return true;
+        } catch (Exception ex) {
+            System.out.println("WARNING: AcmIdBot annotation sweep image check failed for asset " +
+                ma.getId() + ": " + ex.toString());
+            return false;
+        }
     }
 }

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -38,6 +38,7 @@ public class AcmIdBot {
             int numAcmIdFixesSent = 0;
             int numAcmIdFixesSuccessful = 0;
             int numInvalidForIA = 0;
+            int numSendFailures = 0;
             for (Feature feat : feats) {
                 MediaAsset asset = feat.getMediaAsset();
                 myShepherd.setAction("AcmIDBot_" + summaryMessage + "_asset_" + asset.getId());
@@ -68,15 +69,20 @@ public class AcmIdBot {
                         }
                     }
                 } catch (Exception ec) {
-                    System.out.println("Exception in AcmIdBot.fixFeats");
+                    // An HTTP status is not a file-integrity verdict, so a failed send must
+                    // NOT flag the image invalid for IA. That flag is terminal in practice:
+                    // WildbookIAM.sendMediaAssets refuses to register a flagged asset, the
+                    // reconciliation sweep skips it before it is even probed, and nothing
+                    // re-validates it (validateSourceImage is only consulted when the flag
+                    // is null). The result was a silent permanent quarantine -- and because
+                    // sendAnnotations does not check the flag, annotations on such an asset
+                    // still get POSTed, which is what produces WBIA's
+                    // "image_uuid_list has invalid values [(0, None)]" 500. Image validity
+                    // belongs to validateSourceImage(), which reads the actual file.
+                    numSendFailures++;
+                    System.out.println("Exception in AcmIdBot.fixFeats for asset " +
+                        ((asset == null) ? "?" : asset.getId()) + ": " + ec.toString());
                     ec.printStackTrace();
-                    // as of now we don't know of a commonality that would suggest a fix
-                    if (ec.toString().contains("HTTP error code : 500")) {
-                        asset.setIsValidImageForIA(false);
-                        myShepherd.updateDBTransaction();
-                        numValidIAFixes--;
-                        numInvalidForIA++;
-                    }
                 }
             }
             System.out.println(summaryMessage);
@@ -87,6 +93,8 @@ public class AcmIdBot {
                 numAcmIdFixesSent);
             System.out.println("......num media assets successfully updated with Acm ID: " +
                 numAcmIdFixesSuccessful);
+            System.out.println("......num sends that failed (retried later, NOT quarantined): " +
+                numSendFailures);
         }
     }
 
@@ -461,20 +469,18 @@ public class AcmIdBot {
                         // can persist an acmId WBIA never acknowledged; probed-missing
                         // assets revert to their original non-null DB acmId
                         if (priorCaptured && asset != null) asset.setAcmId(priorAcmId);
+                        // Deliberately does NOT flag the image invalid for IA on an HTTP
+                        // failure (see the matching note in fixFeats): that flag is a
+                        // terminal, silently self-reinforcing quarantine -- sendMediaAssets
+                        // then refuses to register the asset, this sweep skips it before it
+                        // is ever probed, and nothing re-validates it. Meanwhile
+                        // sendAnnotations ignores the flag and still POSTs annotations on the
+                        // unregistered image, producing WBIA's
+                        // "image_uuid_list has invalid values [(0, None)]" 500. A send
+                        // failure just means retry on a later pass.
                         System.out.println("Exception in AcmIdBot sweep heal for asset " +
-                            assetId);
+                            assetId + ": " + ec.toString());
                         ec.printStackTrace();
-                        // mirror fixFeats: a 500 from WBIA marks the image invalid for IA
-                        if (ec.toString().contains("HTTP error code : 500")) {
-                            try {
-                                if (asset != null) {
-                                    asset.setIsValidImageForIA(false);
-                                    healShepherd.updateDBTransaction();
-                                }
-                            } catch (Exception inner) {
-                                inner.printStackTrace();
-                            }
-                        }
                     }
                 }
             } finally {

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -174,7 +174,7 @@ public class AcmIdBot {
     // WBIA? add_images_json returns the registered image UUIDs; require ours
     // among them before counting (and committing) a heal — otherwise a locally
     // pre-assigned acmId could be persisted although WBIA never registered it
-    public static boolean sendConfirmedAcmId(org.json.JSONObject sendRtn, String expectedAcmId) {
+    static boolean sendConfirmedAcmId(org.json.JSONObject sendRtn, String expectedAcmId) {
         if ((sendRtn == null) || (expectedAcmId == null)) return false;
         org.json.JSONArray batches = sendRtn.optJSONArray("batchResults");
         if (batches == null) return false;

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -511,6 +511,13 @@ public class AcmIdBot {
         final List<String> nullAcmAnnotIds = new ArrayList<String>();
         final java.util.LinkedHashMap<String, String> acmIdToAnnotId =
             new java.util.LinkedHashMap<String, String>();
+        // every distinct annotation id on this page, in the order the DATABASE returned
+        // them. The heal phase walks candidates in this order rather than Java's String
+        // ordering: the cursor's "id > x" comparison happens in Postgres collation, which
+        // is not guaranteed to agree with Java's UTF-16 ordering for hyphenated UUID text.
+        // Resuming from a Java-sorted position could therefore step over candidates the
+        // database considers earlier, silently skipping them for a whole sweep.
+        final List<String> orderedAnnotIds = new ArrayList<String>();
         boolean rawExhausted = false;
         String lastAnnotId = null; // null = nothing read yet
     }
@@ -559,6 +566,7 @@ public class AcmIdBot {
             if (seen.size() >= pageSize) return; // rawExhausted stays false: more remains
             seen.add(annId);
             page.lastAnnotId = annId;
+            page.orderedAnnotIds.add(annId);
             // null or malformed acmId: route straight to the heal path rather than the
             // probe, since a non-UUID value would make WBIA reject the whole probe chunk
             // and could strand the rest of the page
@@ -615,8 +623,21 @@ public class AcmIdBot {
             // to an Encounter and binds the variable (an unbound VARIABLES declaration is
             // a silent no-op). The cursor is a bound parameter: a String concatenated into
             // JDOQL would be an invalid unquoted literal.
+            //
+            // The trailing clause is the anti-race with StartupWildbook's 30s registration
+            // poller, which claims exactly `wbiaRegistered == false && attempts < MAX`.
+            // This sweep takes the precise complement of that queue, so the two workers can
+            // never hold the same annotation: without it, both could POST the same row
+            // concurrently, and because the poller forces `id` while the sweep forces
+            // `acmId`, an `id != acmId` row would end up as TWO WBIA annotations on one
+            // box. Partitioning by the flag beats a lease here because the sweep's whole
+            // purpose is the rows the poller ignores -- the ones whose flag is lying
+            // (wbiaRegistered TRUE or NULL) and the ones it permanently parked.
             query = readShepherd.getPM().newQuery(org.ecocean.Annotation.class,
-                "matchAgainst == true && enc.annotations.contains(this) && id > cursor");
+                "matchAgainst == true && enc.annotations.contains(this) && id > cursor" +
+                " && (wbiaRegistered == null || wbiaRegistered == true" +
+                " || wbiaRegisterAttempts >= " + StartupWildbook.WBIA_REGISTER_MAX_ATTEMPTS +
+                ")");
             query.declareVariables("org.ecocean.Encounter enc");
             query.declareParameters("String cursor");
             // project only what the sweep needs; materializing 10k managed Annotation
@@ -635,16 +656,23 @@ public class AcmIdBot {
 
                 public String[] next() {
                     Object o = rawIter.next();
-                    // a two-column projection yields Object[]; be tolerant of a
-                    // single-column collapse rather than throwing mid-page
-                    if (o instanceof Object[]) {
-                        Object[] arr = (Object[])o;
-                        return new String[] {
-                                   (arr.length > 0 && arr[0] != null) ? arr[0].toString() : null,
-                                   (arr.length > 1 && arr[1] != null) ? arr[1].toString() : null
-                        };
-                    }
-                    return new String[] { (o == null) ? null : o.toString(), null };
+                    // A two-column projection yields Object[]. Anything else must FAIL, not
+                    // be coerced: silently treating an unexpected row shape as
+                    // "id with no acmId" would route every annotation into the
+                    // heal-without-probe bucket, force-adopt acmIds, and re-POST the entire
+                    // corpus to WBIA. A failed read just retries this page.
+                    if (!(o instanceof Object[]))
+                        throw new IllegalStateException(
+                            "annotation sweep expected a two-column projection row, got " +
+                            ((o == null) ? "null" : o.getClass().getName()));
+                    Object[] arr = (Object[])o;
+                    if (arr.length < 2)
+                        throw new IllegalStateException(
+                            "annotation sweep expected 2 projected columns, got " + arr.length);
+                    return new String[] {
+                               (arr[0] == null) ? null : arr[0].toString(),
+                               (arr[1] == null) ? null : arr[1].toString()
+                    };
                 }
             };
             collectAnnotSweepPageInto(page, rowIter, ANNOT_SWEEP_PAGE_SIZE);
@@ -709,12 +737,17 @@ public class AcmIdBot {
         }
 
         // ---- heal phase (own transaction, explicit commits) ----
-        List<String> candidateIds = new ArrayList<String>(page.nullAcmAnnotIds);
+        java.util.Set<String> candidateSet = new java.util.HashSet<String>(page.nullAcmAnnotIds);
         for (String acmId : missingAcmIds) {
             String annId = page.acmIdToAnnotId.get(acmId);
-            if (annId != null) candidateIds.add(annId);
+            if (annId != null) candidateSet.add(annId);
         }
-        java.util.Collections.sort(candidateIds); // ascending id = cursor order
+        // walk in database order (see AnnotSweepPage.orderedAnnotIds), NOT Java String
+        // order, so a maxFixes resume point is a cursor value that cannot skip candidates
+        List<String> candidateIds = new ArrayList<String>();
+        for (String annId : page.orderedAnnotIds) {
+            if (candidateSet.contains(annId)) candidateIds.add(annId);
+        }
         AnnotHealTally tally = new AnnotHealTally();
         tally.resumeAnnotId = page.lastAnnotId;
         if (candidateIds.size() > 0) healAnnotations(context, candidateIds, maxFixes, tally);
@@ -763,11 +796,12 @@ public class AcmIdBot {
                 // hoisted so the catch block can revert identifiers we adopted locally
                 // but WBIA never acknowledged
                 Annotation ann = null;
-                MediaAsset ma = null;
                 String priorAnnAcmId = null;
-                String priorMaAcmId = null;
-                boolean annPriorCaptured = false;
-                boolean maPriorCaptured = false;
+                // The asset's acmId is owned entirely by ensureImageRegistered(); this loop
+                // never touches it. Once that method confirms a registration, the asset's
+                // acmId is the UUID WBIA holds the image under and must survive a later
+                // failure on the annotation half of the work.
+                boolean annAcmIdAdopted = false;
                 try {
                     ann = healShepherd.getAnnotation(annId);
                     if (ann == null) {
@@ -775,7 +809,7 @@ public class AcmIdBot {
                             " (no longer exists)");
                         continue;
                     }
-                    ma = ann.getMediaAsset();
+                    MediaAsset ma = ann.getMediaAsset();
                     if (ma == null) {
                         tally.skippedNoAsset++;
                         continue;
@@ -787,10 +821,6 @@ public class AcmIdBot {
                         tally.skippedInvalid++;
                         continue;
                     }
-                    priorMaAcmId = ma.getAcmId();
-                    maPriorCaptured = true;
-                    if ((priorMaAcmId == null) || !Util.isUUID(priorMaAcmId))
-                        ma.setAcmId(ma.getUUID());
                     // WBIA cannot hold an annotation whose image it does not have: the
                     // annotation POST fails with
                     // "image_uuid_list has invalid values [(0, None)]". A non-null
@@ -801,15 +831,15 @@ public class AcmIdBot {
                     // image here rather than assuming the asset sweep got there first.
                     if (!ensureImageRegistered(ma, context, healShepherd)) {
                         tally.blockedOnAsset++;
-                        if (maPriorCaptured) ma.setAcmId(priorMaAcmId);
                         continue;
                     }
                     priorAnnAcmId = ann.getAcmId();
-                    annPriorCaptured = true;
                     // legacy null or malformed acmIds adopt the annotation's own id before
                     // sending, matching MlServiceProcessor's convention
-                    if ((priorAnnAcmId == null) || !Util.isUUID(priorAnnAcmId))
+                    if ((priorAnnAcmId == null) || !Util.isUUID(priorAnnAcmId)) {
                         ann.setAcmId(ann.getId());
+                        annAcmIdAdopted = true;
+                    }
                     boolean confirmed = iam.sendAnnotationForcedByAcmId(ann, healShepherd);
                     tally.sent++;
                     if (confirmed) {
@@ -833,15 +863,17 @@ public class AcmIdBot {
                         System.out.println(
                             "WARNING: AcmIdBot annotation sweep could not confirm WBIA registration for "
                             + annId + "; not counting as healed");
-                        // never persist an identifier WBIA did not acknowledge
-                        ann.setAcmId(priorAnnAcmId);
-                        ma.setAcmId(priorMaAcmId);
+                        // Never persist an annotation identifier WBIA did not acknowledge --
+                        // but only write the field if we actually changed it, since setAcmId
+                        // bumps version and would otherwise queue a pointless reindex for
+                        // every unconfirmed annotation. The asset's acmId stays as-is: the
+                        // image registration under it was already confirmed.
+                        if (annAcmIdAdopted) ann.setAcmId(priorAnnAcmId);
                     }
                 } catch (Exception ec) {
                     // revert BEFORE any later candidate's commit can persist an identifier
                     // WBIA never acknowledged
-                    if (annPriorCaptured && (ann != null)) ann.setAcmId(priorAnnAcmId);
-                    if (maPriorCaptured && (ma != null)) ma.setAcmId(priorMaAcmId);
+                    if (annAcmIdAdopted && (ann != null)) ann.setAcmId(priorAnnAcmId);
                     System.out.println("Exception in AcmIdBot annotation sweep heal for " + annId);
                     ec.printStackTrace();
                 }
@@ -852,39 +884,63 @@ public class AcmIdBot {
     }
 
     /**
-     * Probe WBIA for this image and register it if absent. Returns true when WBIA is
-     * known to hold the asset's acmId, i.e. when it is safe to POST an annotation
-     * referencing it. Reuses the asset sweep's own probe and send so there is one
-     * definition of "registered".
+     * Probe WBIA for this image and register it if absent. Returns true when WBIA is known
+     * to hold the asset's acmId, i.e. when it is safe to POST an annotation referencing it.
+     * Reuses the asset sweep's own probe and send so there is one definition of
+     * "registered", and owns the asset's acmId outright so the caller never has to reason
+     * about reverting it.
+     *
+     * <p>Step order matters and is not incidental. {@code updateDBTransaction()} is
+     * commit-plus-begin, so it commits <b>every</b> dirty object in the transaction, not
+     * just the field the caller had in mind. Validity is therefore resolved and committed
+     * <b>before</b> any provisional acmId is adopted, and the adopted acmId is committed
+     * only <b>after</b> WBIA confirms it. Otherwise an unconfirmed identifier would be
+     * committed by the validity flush and the later in-memory revert would simply be
+     * discarded by the enclosing {@code rollbackAndClose()}, leaving Wildbook holding an
+     * acmId WBIA never acknowledged.</p>
      */
     private static boolean ensureImageRegistered(MediaAsset ma, String context,
         Shepherd myShepherd) {
-        String maAcmId = ma.getAcmId();
-
-        if (!Util.stringExists(maAcmId) || !Util.isUUID(maAcmId)) return false;
         try {
-            List<String> missing = org.ecocean.ia.plugin.WildbookIAM.iaMissingImageIds(
-                java.util.Arrays.asList(maAcmId), context);
-            if (missing.isEmpty()) return true; // WBIA already has it
+            // 1. resolve validity first, while nothing provisional is pending
             if (ma.isValidImageForIA() == null) {
                 ma.validateSourceImage();
                 myShepherd.updateDBTransaction();
             }
             if (!ma.isValidImageForIAForced()) {
-                System.out.println("WARNING: AcmIdBot annotation sweep cannot register unhealable image "
-                    + ma.getId() + " (invalid or unvalidatable for IA)");
+                System.out.println(
+                    "WARNING: AcmIdBot annotation sweep cannot register unhealable image " +
+                    ma.getId() + " (invalid or unvalidatable for IA)");
                 return false;
             }
-            if (!ma.hasFamily(myShepherd)) ma.updateStandardChildren();
-            ArrayList<MediaAsset> fixMe = new ArrayList<MediaAsset>();
-            fixMe.add(ma);
-            // checkFirst=false: the probe above already established absence
-            org.json.JSONObject sendRtn = IBEISIA.sendMediaAssetsNew(fixMe, context, false);
-            if (!sendConfirmedAcmId(sendRtn, ma.getAcmId())) {
-                System.out.println(
-                    "WARNING: AcmIdBot annotation sweep could not confirm image registration for asset "
-                    + ma.getId() + "; deferring its annotations");
-                return false;
+            // 2. if the asset already carries a well-formed acmId, ask WBIA about it; a
+            // present image needs no further work
+            String maAcmId = ma.getAcmId();
+            if (Util.stringExists(maAcmId) && Util.isUUID(maAcmId)) {
+                if (org.ecocean.ia.plugin.WildbookIAM.iaMissingImageIds(
+                        java.util.Collections.singletonList(maAcmId), context).isEmpty())
+                    return true;
+            }
+            // 3. adopt provisionally, POST, and commit only on confirmation
+            String priorMaAcmId = ma.getAcmId();
+            if ((priorMaAcmId == null) || !Util.isUUID(priorMaAcmId))
+                ma.setAcmId(ma.getUUID());
+            try {
+                if (!ma.hasFamily(myShepherd)) ma.updateStandardChildren();
+                ArrayList<MediaAsset> fixMe = new ArrayList<MediaAsset>();
+                fixMe.add(ma);
+                // checkFirst=false: step 2 already established absence
+                org.json.JSONObject sendRtn = IBEISIA.sendMediaAssetsNew(fixMe, context, false);
+                if (!sendConfirmedAcmId(sendRtn, ma.getAcmId())) {
+                    System.out.println(
+                        "WARNING: AcmIdBot annotation sweep could not confirm image registration for asset "
+                        + ma.getId() + "; deferring its annotations");
+                    ma.setAcmId(priorMaAcmId);
+                    return false;
+                }
+            } catch (Exception sendEx) {
+                ma.setAcmId(priorMaAcmId);
+                throw sendEx;
             }
             // persist the confirmed image registration before the annotation POST
             myShepherd.updateDBTransaction();

--- a/src/main/java/org/ecocean/AcmIdBot.java
+++ b/src/main/java/org/ecocean/AcmIdBot.java
@@ -759,22 +759,35 @@ public class AcmIdBot {
             page.nullAcmAnnotIds.size()) + " candidates (" + page.acmIdToAnnotId.size() +
             " probed, " + page.nullAcmAnnotIds.size() + " null/malformed acmId)");
         System.out.println("......missing from WBIA: " + missingAcmIds.size());
-        System.out.println("......heals sent: " + tally.sent + ", heals confirmed: " +
-            tally.healed + (tally.maxFixesHit ? " (maxFixes cap hit)" : ""));
-        System.out.println("......skipped: " + tally.skippedNoAsset + " no media asset, " +
-            tally.blockedOnAsset + " image not registered at WBIA, " +
-            tally.skippedInvalid + " invalid for identification");
+        System.out.println("......heal candidates: " + candidateIds.size() +
+            "; POSTs sent: " + tally.sent + ", confirmed: " + tally.healed +
+            (tally.maxFixesHit ? " (maxFixes cap hit)" : ""));
+        // buckets are mutually exclusive and, absent a maxFixes break, sum to the
+        // candidate count -- so a mismatch is itself a signal worth investigating
+        System.out.println("......not healed: " + tally.unconfirmed +
+            " unconfirmed by WBIA, " + tally.blockedOnAsset +
+            " image not registered at WBIA, " + tally.skippedInvalid +
+            " invalid for identification, " + tally.skippedNoAsset + " no media asset, " +
+            tally.gone + " deleted mid-run, " + tally.errored + " errored");
         System.out.println("......cursor now '" + annotSweepCursor + "'" +
             (page.rawExhausted && !tally.maxFixesHit ? " (sweep complete, wrapped)" : ""));
     }
 
-    /** Per-run heal accounting, kept in one object so the summary log stays honest. */
+    /**
+     * Per-run heal accounting, kept in one object so the summary log stays honest.
+     * Every candidate lands in exactly one of gone / skippedNoAsset / skippedInvalid /
+     * blockedOnAsset / healed / unconfirmed / errored, so an operator can check that the
+     * buckets add up to the candidate count instead of wondering where rows went.
+     */
     static class AnnotHealTally {
-        int sent = 0;
-        int healed = 0;
+        int sent = 0;         // POSTs attempted (healed + unconfirmed)
+        int healed = 0;       // WBIA echoed our acmId
+        int unconfirmed = 0;  // POST returned, but not with our acmId
+        int gone = 0;         // annotation deleted between read and heal
         int skippedNoAsset = 0;
         int blockedOnAsset = 0;
         int skippedInvalid = 0;
+        int errored = 0;      // threw; see the stack trace above the summary
         boolean maxFixesHit = false;
         String resumeAnnotId = null;
     }
@@ -807,6 +820,7 @@ public class AcmIdBot {
                     if (ann == null) {
                         System.out.println("WARNING: AcmIdBot annotation sweep skipping " + annId +
                             " (no longer exists)");
+                        tally.gone++;
                         continue;
                     }
                     MediaAsset ma = ann.getMediaAsset();
@@ -860,6 +874,7 @@ public class AcmIdBot {
                             break;
                         }
                     } else {
+                        tally.unconfirmed++;
                         System.out.println(
                             "WARNING: AcmIdBot annotation sweep could not confirm WBIA registration for "
                             + annId + "; not counting as healed");
@@ -871,6 +886,7 @@ public class AcmIdBot {
                         if (annAcmIdAdopted) ann.setAcmId(priorAnnAcmId);
                     }
                 } catch (Exception ec) {
+                    tally.errored++;
                     // revert BEFORE any later candidate's commit can persist an identifier
                     // WBIA never acknowledged
                     if (annAcmIdAdopted && (ann != null)) ann.setAcmId(priorAnnAcmId);

--- a/src/main/java/org/ecocean/StartupWildbook.java
+++ b/src/main/java/org/ecocean/StartupWildbook.java
@@ -458,7 +458,9 @@ public class StartupWildbook implements ServletContextListener {
      * migration in {@code archive/sql/ml_service_idempotency.sql} backfills
      * their {@code wbiaRegistered} to {@code TRUE} on deploy.</p>
      */
-    private static final int WBIA_REGISTER_MAX_ATTEMPTS = 10;
+    // package-visible so AcmIdBot's annotation reconciliation sweep can define its scope as
+    // the exact complement of this poller's queue instead of racing it for the same rows
+    static final int WBIA_REGISTER_MAX_ATTEMPTS = 10;
     private static final int WBIA_REGISTER_BATCH_LIMIT = 50;
     private static final long WBIA_REGISTER_POLL_SECONDS = 30L;
 

--- a/src/main/java/org/ecocean/ia/plugin/WildbookIAM.java
+++ b/src/main/java/org/ecocean/ia/plugin/WildbookIAM.java
@@ -409,6 +409,66 @@ public class WildbookIAM extends IAPlugin {
         return rtn;
     }
 
+    /**
+     * Register ONE annotation with WBIA under a forced annotation UUID equal to
+     * its {@code acmId}, and report whether WBIA acknowledged that exact UUID.
+     * This is the heal step of the annotation reconciliation sweep.
+     *
+     * <p>Differs from {@link #sendAnnotationsForceId} in the identifier it
+     * forces ({@code acmId}, not {@code id} — see
+     * {@link #buildForcedRequestMap(WbiaRegisterRequest, String)}) and from
+     * {@link #sendAnnotations} in not letting WBIA mint the UUID at all: the
+     * non-forced path routes its response through
+     * {@code AcmUtil.rectifyAnnotationIds}, which would rewrite {@code acmId}
+     * to WBIA's value on every sweep — churning
+     * {@code Annotation.version} (and so OpenSearch reindexing) and orphaning
+     * any {@code MatchResultProspect} keyed on the old value.</p>
+     *
+     * <p>Performs no already-present check: the sweep has just probed, and the
+     * full-list {@code iaAnnotationIds()} fetch it would need is ~1M UUIDs on a
+     * large install. Callers own eligibility screening; this method assumes the
+     * annotation has a media asset with an acmId, a well-formed own acmId, and
+     * passes {@code validForIdentification}.</p>
+     *
+     * @return true only if WBIA echoed the forced acmId back. A false return
+     *         means the registration must NOT be recorded as successful.
+     */
+    public boolean sendAnnotationForcedByAcmId(Annotation ann, Shepherd myShepherd)
+    throws MalformedURLException, IOException {
+        if ((ann == null) || !Util.stringExists(ann.getAcmId())) return false;
+        String u = IA.getProperty(context, "IBEISIARestUrlAddAnnotations");
+        if (u == null)
+            throw new MalformedURLException(
+                      "WildbookIAM configuration value IBEISIARestUrlAddAnnotations is not set");
+        MediaAsset ma = ann.getMediaAsset();
+        if ((ma == null) || !Util.stringExists(ma.getAcmId())) return false;
+        String forcedAcmId = ann.getAcmId();
+        WbiaRegisterRequest dto = new WbiaRegisterRequest(ann.getId(), forcedAcmId,
+            ma.getAcmId(), ann.getBbox(), ann.getTheta(), ann.getIAClass(),
+            ann.findIndividualId(myShepherd));
+        JSONObject rtn;
+        try {
+            rtn = RestClient.post(new URL(u),
+                IBEISIA.hashMapToJSONObject(buildForcedRequestMap(dto, forcedAcmId)));
+        } catch (Exception ex) {
+            throw new IOException("WBIA add-annotations POST failed for acmId=" + forcedAcmId +
+                    ": " + ex.getMessage(), ex);
+        }
+        // The POST landed at WBIA, so the cached annotation-id list is stale
+        // regardless of how we classify the response below. Invalidate before
+        // validating so a rejected-but-applied POST cannot leave a later caller
+        // looking at a stale "annotation absent" cache.
+        QueryCacheFactory.safeInvalidate(context, "iaAnnotationIds");
+        try {
+            validateForcedResponse(forcedAcmId, rtn);
+        } catch (IOException ex) {
+            IA.log("WARNING: WildbookIAM.sendAnnotationForcedByAcmId() unconfirmed for acmId=" +
+                forcedAcmId + " (ann=" + ann.getId() + "): " + ex.getMessage());
+            return false;
+        }
+        return true;
+    }
+
     // ------------------------------------------------------------------
     // ml-service migration v2: no-Shepherd WBIA registration helpers.
     //
@@ -695,6 +755,44 @@ public class WildbookIAM extends IAPlugin {
      */
     public static List<String> iaMissingImageIds(List<String> acmIds, String context)
     throws IOException {
+        return iaMissingIds(acmIds, context, "/api/image/rowid/uuid/");
+    }
+
+    /**
+     * Ask WBIA which of the given ANNOTATION acmIds it does NOT have, via
+     * GET /api/annot/rowid/uuid/ — the annotation sibling of the image probe
+     * above (wildbook-ia {@code manual_annot_funcs.get_annot_aids_from_uuid},
+     * whose {@code get_annot_missing_uuid} companion defines missing as exactly
+     * "rowid is None", the same semantics {@link #parseRowidProbeResponse}
+     * implements).
+     *
+     * <p>Note this probes the annotation's {@code acmId}, not its {@code id}:
+     * {@code IBEISIA.sendIdentify} builds its query/database annot uuid lists
+     * from {@code getAcmId()}, so the acmId is the only identifier whose
+     * presence at WBIA actually determines whether identification can run.</p>
+     *
+     * <p>(WBIA annotation reconciliation sweep spec §3.)</p>
+     */
+    public static List<String> iaMissingAnnotationIds(List<String> acmIds, String context)
+    throws IOException {
+        return iaMissingIds(acmIds, context, "/api/annot/rowid/uuid/");
+    }
+
+    /**
+     * Shared body for {@link #iaMissingImageIds} and
+     * {@link #iaMissingAnnotationIds}: both WBIA endpoints are
+     * {@code getter_1to1} rowid lookups keyed on UUID, returning a parallel
+     * list with a null entry per unknown UUID.
+     *
+     * <p>Null or malformed (non-UUID) acmIds are skipped rather than sent:
+     * callers treat those objects as heal candidates without probing, and a
+     * malformed value would make WBIA reject the whole chunk and could strand
+     * the rest of the page. Throws IOException if any chunk fails, so callers
+     * never mistake a failed probe for "all present".</p>
+     */
+    private static List<String> iaMissingIds(List<String> acmIds, String context,
+        String endpointPath)
+    throws IOException {
         List<String> missing = new ArrayList<String>();
 
         if (acmIds == null) return missing;
@@ -710,10 +808,10 @@ public class WildbookIAM extends IAPlugin {
             }
             JSONArray resp = null;
             try {
-                resp = apiGetJSONArray("/api/image/rowid/uuid/?uuid_list=[" + sb.toString() +
+                resp = apiGetJSONArray(endpointPath + "?uuid_list=[" + sb.toString() +
                     "]", context);
             } catch (Exception ex) {
-                throw new IOException("WBIA /api/image/rowid/uuid/ probe failed: " +
+                throw new IOException("WBIA " + endpointPath + " probe failed: " +
                         ex.getMessage(), ex);
             }
             // apiGetJSONArray returns null when status.success is false or
@@ -758,6 +856,21 @@ public class WildbookIAM extends IAPlugin {
      * a network round trip.
      */
     static HashMap<String, ArrayList> buildForcedRequestMap(WbiaRegisterRequest dto) {
+        return buildForcedRequestMap(dto, dto.annotationId);
+    }
+
+    /**
+     * As above, but forcing an explicit annotation UUID instead of the DTO's
+     * {@code annotationId}. The reconciliation sweep forces the annotation's
+     * {@code acmId}, because that — not {@code id} — is the identifier
+     * {@code IBEISIA.sendIdentify} asks WBIA about. For ml-service-created
+     * annotations the two are equal ({@code MlServiceProcessor} sets
+     * {@code acmId = getId()}), but for legacy annotations whose acmId WBIA
+     * minted they differ, and forcing the wrong one leaves identification
+     * broken. (WBIA annotation reconciliation sweep spec §4.)
+     */
+    static HashMap<String, ArrayList> buildForcedRequestMap(WbiaRegisterRequest dto,
+        String forcedAnnotUuid) {
         HashMap<String, ArrayList> map = new HashMap<String, ArrayList>();
         map.put("image_uuid_list", new ArrayList<JSONObject>());
         map.put("annot_uuid_list", new ArrayList<JSONObject>());
@@ -766,7 +879,7 @@ public class WildbookIAM extends IAPlugin {
         map.put("annot_name_list", new ArrayList<String>());
         map.put("annot_theta_list", new ArrayList<Double>());
         map.get("image_uuid_list").add(toFancyUUID(dto.mediaAssetAcmId));
-        map.get("annot_uuid_list").add(toFancyUUID(dto.annotationId));
+        map.get("annot_uuid_list").add(toFancyUUID(forcedAnnotUuid));
         map.get("annot_species_list").add(dto.iaClass);
         map.get("annot_bbox_list").add(dto.bbox);
         map.get("annot_name_list").add(

--- a/src/main/webapp/appadmin/repairQuarantinedImages.jsp
+++ b/src/main/webapp/appadmin/repairQuarantinedImages.jsp
@@ -321,6 +321,16 @@ if (commit) {
                     // ambiguous -- fail closed rather than clear a flag on an unverified
                     // uniqueness assumption.
                     int holdersOfAcmId = 1;
+                    // Whether every asset sharing this acmId is byte-identical. WBIA derives
+                    // an image UUID from image CONTENT, so N assets legitimately share one
+                    // acmId when the same photo was uploaded N times -- verified on the live
+                    // install: six assets on one acmId, no parent/child relationship, five of
+                    // them the same filename. In that case registering the bytes once serves
+                    // all of them and there is nothing ambiguous to protect against. But a
+                    // Wildbook-assigned (v4) acmId duplicated by some other path would NOT
+                    // imply identical content, and registering then WOULD overwrite whichever
+                    // image WBIA holds. So decide on evidence: MediaAsset.contentHash.
+                    boolean sharersAreIdentical = false;
                     if (Util.stringExists(priorAcmId)) {
                         Query dupQ = null;
                         try {
@@ -332,22 +342,37 @@ if (commit) {
                             // "ambiguous" -- blocking 100% of candidates. Accept either a
                             // bare aggregate or a single-element collection, since
                             // DataNucleus is not consistent about which it returns.
+                            // Project contentHash per holder: one query yields both the holder
+                            // count and the evidence about identity, and sidesteps the
+                            // aggregate-return-type trouble that count(id) caused earlier.
                             dupQ = sh.getPM().newQuery(MediaAsset.class, "acmId == acmIdParam");
                             dupQ.declareParameters("String acmIdParam");
-                            dupQ.setResult("count(this)");
-                            Object cnt = dupQ.execute(priorAcmId);
-                            if (cnt instanceof Number) {
-                                holdersOfAcmId = ((Number)cnt).intValue();
-                            } else if (cnt instanceof Collection) {
-                                Collection cc = (Collection)cnt;
-                                Object first = cc.isEmpty() ? null : cc.iterator().next();
-                                holdersOfAcmId = (first instanceof Number)
-                                    ? ((Number)first).intValue() : -1;
+                            dupQ.setResult("contentHash");
+                            Object res = dupQ.execute(priorAcmId);
+                            if (res instanceof Collection) {
+                                Collection<?> hashes = (Collection<?>)res;
+                                holdersOfAcmId = hashes.size();
+                                Set<String> distinctHashes = new HashSet<String>();
+                                boolean anyHashUnknown = false;
+                                for (Object h : hashes) {
+                                    String hs = (h == null) ? null : h.toString().trim();
+                                    if ((hs == null) || hs.isEmpty()) {
+                                        anyHashUnknown = true;
+                                    } else {
+                                        distinctHashes.add(hs);
+                                    }
+                                }
+                                // identical only if EVERY holder has a hash and they all agree;
+                                // an unknown hash is never treated as a match
+                                sharersAreIdentical = !anyHashUnknown
+                                    && (distinctHashes.size() == 1);
+                                row.put("sharersByteIdentical", sharersAreIdentical);
+                                if (anyHashUnknown) row.put("someContentHashUnknown", true);
                             } else {
                                 holdersOfAcmId = -1;
                                 System.out.println("repairQuarantinedImages: duplicate-acmId"
-                                    + " count returned unexpected type "
-                                    + ((cnt == null) ? "null" : cnt.getClass().getName())
+                                    + " projection returned unexpected type "
+                                    + ((res == null) ? "null" : res.getClass().getName())
                                     + " for asset " + id);
                             }
                         } catch (Exception dex) {
@@ -359,8 +384,12 @@ if (commit) {
                             if (dupQ != null) dupQ.closeAll();
                         }
                     }
+                    // Ambiguous only when the acmId is shared by assets we cannot prove are
+                    // the same image. Byte-identical sharers are safe: registering those bytes
+                    // once under that UUID is exactly what every one of them needs.
                     boolean acmIdAmbiguous = Util.stringExists(priorAcmId)
-                        && (holdersOfAcmId != 1);
+                        && (holdersOfAcmId != 1)
+                        && !(holdersOfAcmId > 1 && sharersAreIdentical);
                     if (((shared != null) && (shared.intValue() > 1)) || acmIdAmbiguous) {
                         // Two or more assets carry this acmId (or the count could not be
                         // established). One "present at WBIA" answer cannot say which asset

--- a/src/main/webapp/appadmin/repairQuarantinedImages.jsp
+++ b/src/main/webapp/appadmin/repairQuarantinedImages.jsp
@@ -5,7 +5,6 @@ org.ecocean.media.MediaAssetFactory,
 org.ecocean.ia.plugin.WildbookIAM,
 org.ecocean.identity.IBEISIA,
 org.ecocean.Annotation,
-org.ecocean.AcmIdBot,
 org.ecocean.Util,
 javax.jdo.Query,
 java.util.ArrayList,
@@ -378,7 +377,37 @@ if (commit) {
                         // even when the POST below fails. The URI WBIA receives is the
                         // parent's webURL, so children are not needed for registration.
                         JSONObject sendRtn = IBEISIA.sendMediaAssetsNew(one, context, false);
-                        if (AcmIdBot.sendConfirmedAcmId(sendRtn, ma.getAcmId())) {
+                        // Confirmation is inlined rather than calling
+                        // AcmIdBot.sendConfirmedAcmId so this page is STANDALONE: it can be
+                        // dropped into a running install that does not yet have this
+                        // branch's Java deployed, which is the whole point of a repair tool.
+                        // Mirrors that method exactly. sendMediaAssets returns
+                        // {"batchResults":[{"response":[{"__UUID__":"..."}]}]} and a heal
+                        // only counts when OUR uuid comes back in it -- never persist a
+                        // registration WBIA did not acknowledge.
+                        String expectAcm = ma.getAcmId();
+                        JSONArray batches = (sendRtn == null)
+                            ? null : sendRtn.optJSONArray("batchResults");
+                        boolean confirmed = false;
+                        if ((batches != null) && (expectAcm != null)) {
+                            for (int b = 0; (b < batches.length()) && !confirmed; b++) {
+                                // a skipped batch is the literal string "EMPTY BATCH", so
+                                // optJSONObject returns null for it
+                                JSONObject batch = batches.optJSONObject(b);
+                                JSONArray resp = (batch == null)
+                                    ? null : batch.optJSONArray("response");
+                                if (resp == null) continue;
+                                for (int i = 0; i < resp.length(); i++) {
+                                    JSONObject fancy = resp.optJSONObject(i);
+                                    if ((fancy != null) && expectAcm.equals(
+                                            fancy.optString("__UUID__", null))) {
+                                        confirmed = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        if (confirmed) {
                             // rectifyMediaAssetIds may have adopted WBIA's UUID. acmId IS in
                             // the MediaAsset OpenSearch document but setAcmId does not bump
                             // revision, so bump it or the index keeps the stale value.

--- a/src/main/webapp/appadmin/repairQuarantinedImages.jsp
+++ b/src/main/webapp/appadmin/repairQuarantinedImages.jsp
@@ -10,8 +10,10 @@ org.ecocean.Util,
 javax.jdo.Query,
 java.util.ArrayList,
 java.util.Collection,
+java.util.HashMap,
 java.util.HashSet,
 java.util.List,
+java.util.Map,
 java.util.Set,
 org.json.JSONArray,
 org.json.JSONObject" %>
@@ -113,6 +115,7 @@ JSONArray detail = new JSONArray();
 
 int considered = 0, outOfScope = 0, wouldClear = 0, stillInvalid = 0, unrevalidatable = 0;
 int gone = 0, errored = 0, alreadyAtWbia = 0, registered = 0, notConfirmed = 0, commitFailed = 0;
+int ambiguous = 0;
 
 if ("all".equals(scope)) {
     System.out.println("WARNING: repairQuarantinedImages.jsp running with scope=all "
@@ -170,6 +173,15 @@ if ((singleAssetId != null) && ids.isEmpty()) {
 List<Integer> candidateIds = new ArrayList<Integer>();
 List<String> probeAcmIds = new ArrayList<String>();   // deduped, well-formed only
 Set<String> probeSeen = new HashSet<String>();
+// The exact acmId each asset carried when we probed for it. Phase 4 will only accept
+// "WBIA already has this" if the asset STILL carries that same value -- probe evidence has
+// to be bound to the state we later commit, or a value that changed underneath us (another
+// thread, a sweep heal) would be treated as proven present though it was never asked about.
+Map<Integer, String> probedAcmIdByAsset = new HashMap<Integer, String>();
+// acmId is explicitly NOT unique (MediaAssetFactory.loadByAcmId returns the oldest of
+// several). If two candidates share one, a single "present at WBIA" answer cannot tell us
+// WHICH local asset is the registered image, so neither may be auto-cleared.
+Map<String, Integer> candidatesPerAcmId = new HashMap<String, Integer>();
 
 for (Integer id : ids) {
     considered++;
@@ -215,6 +227,10 @@ for (Integer id : ids) {
                     row.put("acmId", acm);
                     if (Util.stringExists(acm) && Util.isUUID(acm)) {
                         if (probeSeen.add(acm)) probeAcmIds.add(acm);
+                        probedAcmIdByAsset.put(id, acm);
+                        Integer seen = candidatesPerAcmId.get(acm);
+                        candidatesPerAcmId.put(acm,
+                            Integer.valueOf((seen == null) ? 1 : seen.intValue() + 1));
                     } else {
                         row.put("acmIdNote", "null/malformed; will be assigned on register");
                     }
@@ -280,23 +296,49 @@ if (commit) {
                     row.put("outcome", "goneBeforeRepair");
                     gone++;
                 } else if (!ma.validateSourceImage()) {
-                    // re-decided under this transaction; validateSourceImage left it false,
-                    // which is the correct persisted state, so commit that verdict
+                    // Re-decided under this transaction and it does not decode after all
+                    // (it decoded in phase 2, so the file changed underneath us, or the
+                    // read was flaky). The flag is already false and must stay false, so
+                    // there is nothing to persist -- fall through to the finally's rollback
+                    // rather than committing a no-op write.
+                    stillInvalid++;
                     row.put("outcome", "stillInvalidOnRecheck");
-                    ok = sh.commitDBTransactionWithStatus();
-                    if (!ok) commitFailed++;
                 } else {
                     String priorAcmId = ma.getAcmId();
-                    boolean needsRegister =
-                        !Util.stringExists(priorAcmId) || !Util.isUUID(priorAcmId)
-                        || missingAtWbia.contains(priorAcmId);
-                    if (!needsRegister) {
-                        // WBIA already holds this image: clearing the flag is backed by
-                        // confirmed remote state
-                        alreadyAtWbia++;
+                    String probedAcmId = probedAcmIdByAsset.get(id);
+                    Integer shared = (probedAcmId == null)
+                        ? null : candidatesPerAcmId.get(probedAcmId);
+                    if ((shared != null) && (shared.intValue() > 1)) {
+                        // Two or more candidates carry this same acmId. One "present at
+                        // WBIA" answer cannot say which of them is the registered image, and
+                        // re-POSTing would just overwrite whichever WBIA holds. Leave both
+                        // flagged and surface it for a human.
+                        ambiguous++;
+                        row.put("outcome", "ambiguousDuplicateAcmId");
+                        row.put("acmId", probedAcmId);
+                        row.put("sharedByCandidates", shared);
+                        System.out.println("repairQuarantinedImages: asset " + id
+                            + " shares acmId " + probedAcmId + " with " + (shared.intValue() - 1)
+                            + " other candidate(s); leaving flagged for manual reconciliation");
+                    } else {
+                    // "WBIA already has it" may ONLY be concluded when the asset still
+                    // carries the exact acmId we probed. Anything else -- null, malformed,
+                    // never probed, or changed since phase 2 -- is unproven and falls through
+                    // to the register branch, which POSTs and demands confirmation.
+                    boolean provenPresent = Util.stringExists(priorAcmId)
+                        && Util.isUUID(priorAcmId)
+                        && priorAcmId.equals(probedAcmId)
+                        && !missingAtWbia.contains(priorAcmId);
+                    if (provenPresent) {
+                        // clearing the flag here is backed by a probe of this exact value
                         row.put("outcome", "clearedFlagWbiaAlreadyHadImage");
                         ok = sh.commitDBTransactionWithStatus();
-                        if (!ok) commitFailed++;
+                        if (ok) {
+                            alreadyAtWbia++;
+                        } else {
+                            commitFailed++;
+                            row.put("outcome", "wbiaHadImageButCommitFailed");
+                        }
                     } else {
                         if (!Util.stringExists(priorAcmId) || !Util.isUUID(priorAcmId))
                             ma.setAcmId(ma.getUUID());
@@ -333,6 +375,7 @@ if (commit) {
                                 + id + "; leaving it flagged for retry");
                         }
                     }
+                    }
                 }
             } catch (Exception ex) {
                 errored++;
@@ -353,6 +396,7 @@ if (commit) {
 result.put("clearedBecauseWbiaAlreadyHadImage", alreadyAtWbia);
 result.put("registeredWithWbiaAndCleared", registered);
 result.put("notConfirmedLeftFlagged", notConfirmed);
+result.put("ambiguousDuplicateAcmIdLeftFlagged", ambiguous);
 result.put("commitFailed", commitFailed);
 
 if (!commit) {

--- a/src/main/webapp/appadmin/repairQuarantinedImages.jsp
+++ b/src/main/webapp/appadmin/repairQuarantinedImages.jsp
@@ -4,12 +4,15 @@ org.ecocean.media.MediaAsset,
 org.ecocean.media.MediaAssetFactory,
 org.ecocean.ia.plugin.WildbookIAM,
 org.ecocean.identity.IBEISIA,
+org.ecocean.Annotation,
 org.ecocean.AcmIdBot,
 org.ecocean.Util,
 javax.jdo.Query,
 java.util.ArrayList,
 java.util.Collection,
+java.util.HashSet,
 java.util.List,
+java.util.Set,
 org.json.JSONArray,
 org.json.JSONObject" %>
 <%
@@ -18,38 +21,46 @@ org.json.JSONObject" %>
  *
  * WHY THIS EXISTS
  * ---------------
- * validImageForIA == false is a terminal state in practice. WildbookIAM.sendMediaAssets
- * refuses to register a flagged asset with WBIA, AcmIdBot's reconciliation sweep drops
- * flagged assets before they are even probed, and nothing re-validates them (
- * MediaAsset.validateSourceImage() is only consulted when the flag is null). Meanwhile
+ * validImageForIA == false is terminal in practice. WildbookIAM.sendMediaAssets refuses to
+ * register a flagged asset with WBIA, AcmIdBot's reconciliation sweep drops flagged assets
+ * before they are even probed, and nothing re-validates them (MediaAsset
+ * .validateSourceImage() is only consulted when the flag is null). Meanwhile
  * WildbookIAM.sendAnnotations does NOT check the flag, so annotations on such an asset are
- * still POSTed to WBIA, which rejects them with
- * "image_uuid_list has invalid values [(0, None)]". So a stale flag actively breaks
- * identification rather than merely hiding a bad image.
- *
- * Historically the flag could also be set purely because WBIA answered HTTP 500 during an
- * image send -- an HTTP status, not a verdict about the file. That logic has been removed,
- * but the rows it created remain.
+ * still POSTed and WBIA rejects them with "image_uuid_list has invalid values [(0, None)]".
+ * A stale flag therefore actively breaks identification rather than merely hiding a bad
+ * image. The HTTP-500 path that could create these flags has been removed, but the rows it
+ * created remain.
  *
  * WHAT THIS DOES
  * --------------
- * Re-decodes each flagged asset's actual file via validateSourceImage() and lets the file
- * itself decide the flag. Genuinely corrupt images stay false on their own merits;
- * wrongly-flagged ones become true. Then, for whatever became valid, it asks WBIA which
- * acmIds it does not know and registers those.
+ * Re-decodes each flagged asset's real file and lets the file decide the flag. Then, for
+ * assets that now decode, asks WBIA which acmIds it does not know and registers those.
  *
- * It never sets the flag true directly -- only validateSourceImage() decides.
+ * THE CENTRAL SAFETY RULE: the flag is cleared ONLY together with a confirmed WBIA state --
+ * either WBIA already has the image, or it confirms the registration we just sent. A local
+ * decode proves ImageIO can read the file; it does NOT prove WBIA can fetch or accept it.
+ * Clearing the flag on a local decode alone would make a transient WBIA failure permanent,
+ * because the asset would no longer match this JSP's own selection filter and so could
+ * never be retried.
+ *
+ * Each asset is processed in its OWN transaction, so one failure cannot roll back or flush
+ * another, and commits are checked with commitDBTransactionWithStatus() because
+ * commitDBTransaction() swallows JDO failures and would let us report a durable success
+ * that never happened.
  *
  * PARAMS
- *   max=<n>        assets to process this run (default 100)
- *   commit=true    actually persist and register; DEFAULT IS A DRY RUN
- *   register=false revalidate only; skip the WBIA probe/registration step
- *   assetId=<id>   operate on exactly one asset (ignores max; good for a first look)
- *   verbose=true   include a per-asset detail array in the output
+ *   max=<n>         assets to consider this run (default 100)
+ *   commit=true     persist and register; DEFAULT IS A DRY RUN
+ *   probe=true      in a dry run, also ask WBIA which acmIds it lacks (remote GETs, read
+ *                   only). Off by default so a dry run touches nothing remote.
+ *   scope=matchable only assets backing a matchAgainst annotation (DEFAULT), since those
+ *                   are the ones identification needs. scope=all is an explicit,
+ *                   logged widening.
+ *   assetId=<id>    operate on exactly one asset; it must still be flagged.
+ *   verbose=true    include a per-asset detail array.
  *
- * NOTE validateSourceImage() only inspects the file for LOCAL asset stores. On any other
- * store it cannot decide, and such assets are reported as "unrevalidatable" rather than
- * being silently treated as either valid or corrupt.
+ * validateSourceImage() only inspects the file for LOCAL stores; on any other store it
+ * cannot decide, and such assets are reported "unrevalidatable" rather than guessed.
  */
 
 String context = ServletUtilities.getContext(request);
@@ -61,16 +72,15 @@ if (maxParam != null) {
         max = Integer.parseInt(maxParam.trim());
     } catch (NumberFormatException nfe) {
         response.setStatus(400);
-        out.println(new JSONObject().put("error", "invalid max parameter: " + maxParam).toString(4));
+        out.println(new JSONObject().put("error", "invalid max: " + maxParam).toString(4));
         return;
     }
     if (max < 1) {
         response.setStatus(400);
-        out.println(new JSONObject().put("error", "max must be a positive integer; got: " + maxParam).toString(4));
+        out.println(new JSONObject().put("error", "max must be positive; got " + maxParam).toString(4));
         return;
     }
 }
-
 Integer singleAssetId = null;
 String assetIdParam = request.getParameter("assetId");
 if (assetIdParam != null) {
@@ -78,196 +88,283 @@ if (assetIdParam != null) {
         singleAssetId = Integer.valueOf(assetIdParam.trim());
     } catch (NumberFormatException nfe) {
         response.setStatus(400);
-        out.println(new JSONObject().put("error", "invalid assetId parameter: " + assetIdParam).toString(4));
+        out.println(new JSONObject().put("error", "invalid assetId: " + assetIdParam).toString(4));
         return;
     }
 }
-
-boolean commit   = "true".equalsIgnoreCase(request.getParameter("commit"));
-boolean register = !"false".equalsIgnoreCase(request.getParameter("register"));
-boolean verbose  = "true".equalsIgnoreCase(request.getParameter("verbose"));
+String scope = request.getParameter("scope");
+if (scope == null) scope = "matchable";
+if (!"matchable".equals(scope) && !"all".equals(scope)) {
+    response.setStatus(400);
+    out.println(new JSONObject().put("error", "scope must be 'matchable' or 'all'").toString(4));
+    return;
+}
+boolean commit     = "true".equalsIgnoreCase(request.getParameter("commit"));
+boolean probeOnly  = "true".equalsIgnoreCase(request.getParameter("probe"));
+boolean doProbe    = commit || probeOnly;
+boolean verbose    = "true".equalsIgnoreCase(request.getParameter("verbose"));
+boolean matchableOnly = "matchable".equals(scope);
 
 JSONObject result = new JSONObject();
 result.put("dryRun", !commit);
-result.put("registerWithWbia", register && commit);
+result.put("scope", scope);
+result.put("willContactWbia", doProbe);
 JSONArray detail = new JSONArray();
 
-int examined = 0, nowValid = 0, stillInvalid = 0, unrevalidatable = 0, errored = 0;
-int probed = 0, missingAtWbia = 0, registered = 0, registerFailed = 0;
+int considered = 0, outOfScope = 0, wouldClear = 0, stillInvalid = 0, unrevalidatable = 0;
+int gone = 0, errored = 0, alreadyAtWbia = 0, registered = 0, notConfirmed = 0, commitFailed = 0;
 
-// ---- phase 1: collect the flagged asset ids (short transaction, primitives out) ----
+if ("all".equals(scope)) {
+    System.out.println("WARNING: repairQuarantinedImages.jsp running with scope=all "
+        + "(assets with no matchAgainst annotation included), commit=" + commit);
+}
+
+// ---- phase 1: select flagged asset ids (short tx, primitives out) ----
 List<Integer> ids = new ArrayList<Integer>();
-Shepherd readShepherd = new Shepherd(context);
-readShepherd.setAction("appadmin.repairQuarantinedImages.read");
-readShepherd.beginDBTransaction();
+String phase1Error = null;
+Shepherd readShepherd = null;
 Query q = null;
 try {
-    if (singleAssetId != null) {
-        ids.add(singleAssetId);
-    } else {
-        q = readShepherd.getPM().newQuery(MediaAsset.class, "validImageForIA == false");
-        q.setResult("id");            // project: no need to materialize the assets here
-        q.setOrdering("id ascending");
-        q.setRange(0, max);
-        Collection c = (Collection)q.execute();
-        for (Object o : c) {
-            if (o != null) ids.add(Integer.valueOf(o.toString()));
-        }
+    readShepherd = new Shepherd(context);
+    readShepherd.setAction("appadmin.repairQuarantinedImages.read");
+    readShepherd.beginDBTransaction();
+    // Always filter on the flag, even for a single assetId: this JSP's whole contract is
+    // "repair quarantined assets", and it must not be usable to re-send an arbitrary asset.
+    String filter = "validImageForIA == false";
+    if (singleAssetId != null) filter += " && id == " + singleAssetId.intValue();
+    q = readShepherd.getPM().newQuery(MediaAsset.class, filter);
+    q.setResult("id");
+    q.setOrdering("id ascending");
+    if (singleAssetId == null) q.setRange(0, max);
+    Collection c = (Collection)q.execute();
+    for (Object o : c) {
+        if (o != null) ids.add(Integer.valueOf(((Number)o).intValue()));
     }
 } catch (Exception ex) {
-    response.setStatus(500);
-    out.println(new JSONObject().put("error", "read phase failed: " + ex.toString()).toString(4));
-    return;
+    phase1Error = ex.toString();
 } finally {
-    if (q != null) q.closeAll();
-    readShepherd.rollbackAndClose();
+    try {
+        if (q != null) q.closeAll();
+    } finally {
+        if (readShepherd != null) readShepherd.rollbackAndClose();
+    }
+}
+if (phase1Error != null) {
+    response.setStatus(500);
+    out.println(new JSONObject().put("error", "read phase failed: " + phase1Error).toString(4));
+    return;
 }
 result.put("flaggedAssetsSelected", ids.size());
+if ((singleAssetId != null) && ids.isEmpty()) {
+    result.put("note", "asset " + singleAssetId
+        + " is not currently flagged validImageForIA=false; nothing to repair");
+    out.println(result.toString(4));
+    return;
+}
 
-// ---- phase 2: re-decode each file and let the file decide the flag ----
-// Collected for phase 3. In a dry run nothing is committed: the enclosing
-// rollbackAndClose() discards validateSourceImage()'s in-memory writes.
-List<Integer> becameValidIds = new ArrayList<Integer>();
-List<String> becameValidAcmIds = new ArrayList<String>();
+// ---- phase 2: decide candidacy WITHOUT persisting anything ----
+// Each asset gets its own transaction and is always rolled back here. validateSourceImage()
+// writes the flag on the managed instance, so the prior value is restored immediately (no PM
+// operation happens in between, so there is no flush point) and the rollback is a second
+// line of defence.
+List<Integer> candidateIds = new ArrayList<Integer>();
+List<String> probeAcmIds = new ArrayList<String>();   // deduped, well-formed only
+Set<String> probeSeen = new HashSet<String>();
 
-Shepherd vShepherd = new Shepherd(context);
-vShepherd.setAction("appadmin.repairQuarantinedImages.revalidate");
-vShepherd.beginDBTransaction();
-try {
-    for (Integer id : ids) {
-        examined++;
-        JSONObject row = new JSONObject();
-        row.put("assetId", id);
-        try {
-            MediaAsset ma = MediaAssetFactory.load(id.intValue(), vShepherd);
-            if (ma == null) {
-                row.put("outcome", "gone");
-                errored++;
-                if (verbose) detail.put(row);
-                continue;
-            }
+for (Integer id : ids) {
+    considered++;
+    JSONObject row = new JSONObject();
+    row.put("assetId", id);
+    Shepherd sh = null;
+    try {
+        sh = new Shepherd(context);
+        sh.setAction("appadmin.repairQuarantinedImages.check." + id);
+        sh.beginDBTransaction();
+        MediaAsset ma = MediaAssetFactory.load(id.intValue(), sh);
+        if (ma == null) {
+            row.put("outcome", "gone");
+            gone++;
+        } else {
             String storeType = null;
             try {
                 if (ma.getStore() != null) storeType = ma.getStore().getType().toString();
             } catch (Exception ignore) { }
             row.put("store", (storeType == null) ? "unknown" : storeType);
-            if (!"LOCAL".equals(storeType)) {
-                // validateSourceImage() is a no-op off LOCAL; do not guess either way
+            boolean inScope = true;
+            if (matchableOnly) {
+                inScope = false;
+                for (Annotation ann : ma.getAnnotations()) {
+                    if ((ann != null) && ann.getMatchAgainst()) { inScope = true; break; }
+                }
+            }
+            if (!inScope) {
+                row.put("outcome", "outOfScope");
+                outOfScope++;
+            } else if (!"LOCAL".equals(storeType)) {
                 row.put("outcome", "unrevalidatable");
                 unrevalidatable++;
-                if (verbose) detail.put(row);
-                continue;
-            }
-            boolean valid = ma.validateSourceImage();   // reads the actual file
-            row.put("outcome", valid ? "nowValid" : "stillInvalid");
-            if (valid) {
-                nowValid++;
-                becameValidIds.add(id);
-                if (Util.stringExists(ma.getAcmId()) && Util.isUUID(ma.getAcmId()))
-                    becameValidAcmIds.add(ma.getAcmId());
-                row.put("acmId", ma.getAcmId());
-                if (commit) vShepherd.updateDBTransaction();
             } else {
-                stillInvalid++;
-                // leave it flagged: the file genuinely does not decode
+                Boolean priorFlag = ma.isValidImageForIA();
+                boolean decodes = ma.validateSourceImage();
+                ma.setIsValidImageForIA(priorFlag);   // leave the instance clean
+                if (decodes) {
+                    wouldClear++;
+                    candidateIds.add(id);
+                    row.put("outcome", "decodesOk");
+                    String acm = ma.getAcmId();
+                    row.put("acmId", acm);
+                    if (Util.stringExists(acm) && Util.isUUID(acm)) {
+                        if (probeSeen.add(acm)) probeAcmIds.add(acm);
+                    } else {
+                        row.put("acmIdNote", "null/malformed; will be assigned on register");
+                    }
+                } else {
+                    stillInvalid++;
+                    row.put("outcome", "stillInvalid");
+                }
             }
-        } catch (Exception ex) {
-            errored++;
-            row.put("outcome", "error");
-            row.put("error", ex.toString());
-            System.out.println("repairQuarantinedImages: asset " + id + " failed: " + ex);
         }
-        if (verbose) detail.put(row);
+    } catch (Exception ex) {
+        errored++;
+        row.put("outcome", "error");
+        row.put("error", ex.toString());
+        System.out.println("repairQuarantinedImages: check failed for asset " + id + ": " + ex);
+    } finally {
+        if (sh != null) sh.rollbackAndClose();   // phase 2 NEVER persists
     }
-} finally {
-    vShepherd.rollbackAndClose();   // dry run: discards; commit run: trailing empty tx only
+    if (verbose) detail.put(row);
 }
 
-result.put("examined", examined);
-result.put("nowValid", nowValid);
+result.put("considered", considered);
+result.put("outOfScope", outOfScope);
+result.put("decodesOk", wouldClear);
 result.put("stillInvalid", stillInvalid);
 result.put("unrevalidatable", unrevalidatable);
+result.put("gone", gone);
 result.put("errored", errored);
 
-// ---- phase 3: ask WBIA which of the newly-valid acmIds it does not know (no tx open) ----
-List<String> missing = new ArrayList<String>();
-if (register && !becameValidAcmIds.isEmpty()) {
+// ---- phase 3: ask WBIA which acmIds it lacks (no transaction open) ----
+Set<String> missingAtWbia = new HashSet<String>();
+boolean probeOk = false;
+if (doProbe && !probeAcmIds.isEmpty()) {
     try {
-        probed = becameValidAcmIds.size();
-        missing = WildbookIAM.iaMissingImageIds(becameValidAcmIds, context);
-        missingAtWbia = missing.size();
+        missingAtWbia.addAll(WildbookIAM.iaMissingImageIds(probeAcmIds, context));
+        probeOk = true;
     } catch (Exception ex) {
         result.put("probeError", ex.toString());
-        missing = new ArrayList<String>();
     }
+    result.put("probedAtWbia", probeAcmIds.size());
+    result.put("missingFromWbia", probeOk ? missingAtWbia.size() : -1);
 }
-result.put("probedAtWbia", probed);
-result.put("missingFromWbia", missingAtWbia);
 
-// ---- phase 4: register the missing ones (own transaction, commit per confirmation) ----
-if (commit && register && !missing.isEmpty()) {
-    Shepherd sShepherd = new Shepherd(context);
-    sShepherd.setAction("appadmin.repairQuarantinedImages.register");
-    sShepherd.beginDBTransaction();
-    try {
-        for (String acmId : missing) {
+// ---- phase 4: per asset, register if needed and clear the flag only on confirmed state ----
+if (commit) {
+    if (!probeOk && !probeAcmIds.isEmpty()) {
+        result.put("abort", "WBIA probe failed; refusing to clear any flag without knowing "
+            + "WBIA's state. Nothing was changed. Retry when WBIA is reachable.");
+    } else {
+        for (Integer id : candidateIds) {
             JSONObject row = new JSONObject();
-            row.put("acmId", acmId);
+            row.put("assetId", id);
+            Shepherd sh = null;
+            boolean ok = false;
             try {
-                MediaAsset ma = MediaAssetFactory.loadByAcmId(acmId, sShepherd);
+                sh = new Shepherd(context);
+                sh.setAction("appadmin.repairQuarantinedImages.repair." + id);
+                sh.beginDBTransaction();
+                // reload by PRIMARY KEY: acmId is explicitly not unique
+                // (MediaAssetFactory.loadByAcmId returns the oldest match), so keying phase
+                // 4 off acmId could repair a different row than the one we examined.
+                MediaAsset ma = MediaAssetFactory.load(id.intValue(), sh);
                 if (ma == null) {
-                    row.put("outcome", "assetGoneBeforeRegister");
-                    registerFailed++;
-                    if (verbose) detail.put(row);
-                    continue;
-                }
-                String before = ma.getAcmId();
-                if (!ma.hasFamily(sShepherd)) ma.updateStandardChildren();
-                ArrayList<MediaAsset> one = new ArrayList<MediaAsset>();
-                one.add(ma);
-                // checkFirst=false: phase 3 already established absence
-                JSONObject sendRtn = IBEISIA.sendMediaAssetsNew(one, context, false);
-                if (AcmIdBot.sendConfirmedAcmId(sendRtn, ma.getAcmId())) {
-                    // rectifyMediaAssetIds may have adopted WBIA's UUID. acmId IS part of
-                    // the MediaAsset OpenSearch document but setAcmId does not bump
-                    // revision, so bump it explicitly or the index keeps the old value.
-                    if ((before == null) || !before.equals(ma.getAcmId())) {
-                        row.put("acmIdChanged", before + " -> " + ma.getAcmId());
-                        ma.setRevision();
-                    }
-                    sShepherd.updateDBTransaction();
-                    registered++;
-                    row.put("outcome", "registered");
+                    row.put("outcome", "goneBeforeRepair");
+                    gone++;
+                } else if (!ma.validateSourceImage()) {
+                    // re-decided under this transaction; validateSourceImage left it false,
+                    // which is the correct persisted state, so commit that verdict
+                    row.put("outcome", "stillInvalidOnRecheck");
+                    ok = sh.commitDBTransactionWithStatus();
+                    if (!ok) commitFailed++;
                 } else {
-                    registerFailed++;
-                    row.put("outcome", "unconfirmedByWbia");
-                    System.out.println("repairQuarantinedImages: WBIA did not confirm " + acmId);
+                    String priorAcmId = ma.getAcmId();
+                    boolean needsRegister =
+                        !Util.stringExists(priorAcmId) || !Util.isUUID(priorAcmId)
+                        || missingAtWbia.contains(priorAcmId);
+                    if (!needsRegister) {
+                        // WBIA already holds this image: clearing the flag is backed by
+                        // confirmed remote state
+                        alreadyAtWbia++;
+                        row.put("outcome", "clearedFlagWbiaAlreadyHadImage");
+                        ok = sh.commitDBTransactionWithStatus();
+                        if (!ok) commitFailed++;
+                    } else {
+                        if (!Util.stringExists(priorAcmId) || !Util.isUUID(priorAcmId))
+                            ma.setAcmId(ma.getUUID());
+                        ArrayList<MediaAsset> one = new ArrayList<MediaAsset>();
+                        one.add(ma);
+                        // NOTE: deliberately no updateStandardChildren() here. It writes
+                        // files into the asset store and creates child MediaAssets as a
+                        // side effect; those writes are not rollbackable and would happen
+                        // even when the POST below fails. The URI WBIA receives is the
+                        // parent's webURL, so children are not needed for registration.
+                        JSONObject sendRtn = IBEISIA.sendMediaAssetsNew(one, context, false);
+                        if (AcmIdBot.sendConfirmedAcmId(sendRtn, ma.getAcmId())) {
+                            // rectifyMediaAssetIds may have adopted WBIA's UUID. acmId IS in
+                            // the MediaAsset OpenSearch document but setAcmId does not bump
+                            // revision, so bump it or the index keeps the stale value.
+                            if ((priorAcmId == null) || !priorAcmId.equals(ma.getAcmId())) {
+                                row.put("acmIdChanged", priorAcmId + " -> " + ma.getAcmId());
+                                ma.setRevision();
+                            }
+                            ok = sh.commitDBTransactionWithStatus();
+                            if (ok) {
+                                registered++;
+                                row.put("outcome", "registeredAndFlagCleared");
+                            } else {
+                                commitFailed++;
+                                row.put("outcome", "registeredButCommitFailed");
+                            }
+                        } else {
+                            // WBIA did not acknowledge: roll back so the flag STAYS false
+                            // and this asset is selected again on a later run
+                            notConfirmed++;
+                            row.put("outcome", "notConfirmedByWbiaLeftFlagged");
+                            System.out.println("repairQuarantinedImages: WBIA did not confirm asset "
+                                + id + "; leaving it flagged for retry");
+                        }
+                    }
                 }
             } catch (Exception ex) {
-                registerFailed++;
-                row.put("outcome", "registerError");
+                errored++;
+                row.put("outcome", "error");
                 row.put("error", ex.toString());
-                System.out.println("repairQuarantinedImages: register failed for " + acmId +
-                    ": " + ex);
+                System.out.println("repairQuarantinedImages: repair failed for asset " + id
+                    + ": " + ex);
+            } finally {
+                // rollbackAndClose is a no-op rollback after a successful commit, and
+                // discards everything on any unconfirmed or failed path
+                if (sh != null) sh.rollbackAndClose();
             }
             if (verbose) detail.put(row);
         }
-    } finally {
-        sShepherd.rollbackAndClose();
     }
 }
-result.put("registeredWithWbia", registered);
-result.put("registerFailed", registerFailed);
+
+result.put("clearedBecauseWbiaAlreadyHadImage", alreadyAtWbia);
+result.put("registeredWithWbiaAndCleared", registered);
+result.put("notConfirmedLeftFlagged", notConfirmed);
+result.put("commitFailed", commitFailed);
 
 if (!commit) {
-    result.put("note",
-        "DRY RUN: nothing persisted and nothing sent to WBIA. Re-run with &commit=true to apply. "
-        + "Flag changes shown here were computed by actually decoding each file.");
+    result.put("note", "DRY RUN: nothing persisted, nothing registered. 'decodesOk' counts "
+        + "assets whose files really were decoded just now and which would be candidates. "
+        + "Re-run with &commit=true to apply."
+        + (doProbe ? "" : " Add &probe=true to also ask WBIA what it is missing."));
 }
+result.put("safetyNote", "A flag is only ever cleared together with confirmed WBIA state "
+    + "(image already present, or registration acknowledged). Assets left flagged -- "
+    + "stillInvalid or notConfirmed -- are selected again on the next run, by design.");
 if (verbose) result.put("detail", detail);
-result.put("remainingHint",
-    "Re-run until flaggedAssetsSelected is 0. Assets reported stillInvalid keep the flag by "
-    + "design -- their files do not decode -- and will be selected again on every run.");
 
 out.println(result.toString(4));
 %>

--- a/src/main/webapp/appadmin/repairQuarantinedImages.jsp
+++ b/src/main/webapp/appadmin/repairQuarantinedImages.jsp
@@ -260,13 +260,9 @@ for (Integer id : ids) {
     if (verbose) detail.put(row);
 }
 
-result.put("considered", considered);
-result.put("outOfScope", outOfScope);
-result.put("decodesOk", wouldClear);
-result.put("stillInvalid", stillInvalid);
-result.put("unrevalidatable", unrevalidatable);
-result.put("gone", gone);
-result.put("errored", errored);
+// NOTE: all counters are reported AFTER phase 4, below. Writing any of them here would
+// silently drop phase 4's increments -- a live run showed "errored": 0 alongside a detail
+// row that plainly errored, because errored/gone/stillInvalid had already been serialized.
 
 // ---- phase 3: ask WBIA which acmIds it lacks (no transaction open) ----
 Set<String> missingAtWbia = new HashSet<String>();
@@ -485,6 +481,13 @@ if (commit) {
     }
 }
 
+result.put("considered", considered);
+result.put("outOfScope", outOfScope);
+result.put("decodesOk", wouldClear);
+result.put("stillInvalid", stillInvalid);
+result.put("unrevalidatable", unrevalidatable);
+result.put("gone", gone);
+result.put("errored", errored);
 result.put("clearedBecauseWbiaAlreadyHadImage", alreadyAtWbia);
 result.put("registeredWithWbiaAndCleared", registered);
 result.put("notConfirmedLeftFlagged", notConfirmed);

--- a/src/main/webapp/appadmin/repairQuarantinedImages.jsp
+++ b/src/main/webapp/appadmin/repairQuarantinedImages.jsp
@@ -1,0 +1,273 @@
+<%@ page contentType="text/plain; charset=utf-8" language="java" import="org.ecocean.servlet.ServletUtilities,
+org.ecocean.shepherd.core.Shepherd,
+org.ecocean.media.MediaAsset,
+org.ecocean.media.MediaAssetFactory,
+org.ecocean.ia.plugin.WildbookIAM,
+org.ecocean.identity.IBEISIA,
+org.ecocean.AcmIdBot,
+org.ecocean.Util,
+javax.jdo.Query,
+java.util.ArrayList,
+java.util.Collection,
+java.util.List,
+org.json.JSONArray,
+org.json.JSONObject" %>
+<%
+/*
+ * Repair MediaAssets stuck at validImageForIA == false.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * validImageForIA == false is a terminal state in practice. WildbookIAM.sendMediaAssets
+ * refuses to register a flagged asset with WBIA, AcmIdBot's reconciliation sweep drops
+ * flagged assets before they are even probed, and nothing re-validates them (
+ * MediaAsset.validateSourceImage() is only consulted when the flag is null). Meanwhile
+ * WildbookIAM.sendAnnotations does NOT check the flag, so annotations on such an asset are
+ * still POSTed to WBIA, which rejects them with
+ * "image_uuid_list has invalid values [(0, None)]". So a stale flag actively breaks
+ * identification rather than merely hiding a bad image.
+ *
+ * Historically the flag could also be set purely because WBIA answered HTTP 500 during an
+ * image send -- an HTTP status, not a verdict about the file. That logic has been removed,
+ * but the rows it created remain.
+ *
+ * WHAT THIS DOES
+ * --------------
+ * Re-decodes each flagged asset's actual file via validateSourceImage() and lets the file
+ * itself decide the flag. Genuinely corrupt images stay false on their own merits;
+ * wrongly-flagged ones become true. Then, for whatever became valid, it asks WBIA which
+ * acmIds it does not know and registers those.
+ *
+ * It never sets the flag true directly -- only validateSourceImage() decides.
+ *
+ * PARAMS
+ *   max=<n>        assets to process this run (default 100)
+ *   commit=true    actually persist and register; DEFAULT IS A DRY RUN
+ *   register=false revalidate only; skip the WBIA probe/registration step
+ *   assetId=<id>   operate on exactly one asset (ignores max; good for a first look)
+ *   verbose=true   include a per-asset detail array in the output
+ *
+ * NOTE validateSourceImage() only inspects the file for LOCAL asset stores. On any other
+ * store it cannot decide, and such assets are reported as "unrevalidatable" rather than
+ * being silently treated as either valid or corrupt.
+ */
+
+String context = ServletUtilities.getContext(request);
+
+int max = 100;
+String maxParam = request.getParameter("max");
+if (maxParam != null) {
+    try {
+        max = Integer.parseInt(maxParam.trim());
+    } catch (NumberFormatException nfe) {
+        response.setStatus(400);
+        out.println(new JSONObject().put("error", "invalid max parameter: " + maxParam).toString(4));
+        return;
+    }
+    if (max < 1) {
+        response.setStatus(400);
+        out.println(new JSONObject().put("error", "max must be a positive integer; got: " + maxParam).toString(4));
+        return;
+    }
+}
+
+Integer singleAssetId = null;
+String assetIdParam = request.getParameter("assetId");
+if (assetIdParam != null) {
+    try {
+        singleAssetId = Integer.valueOf(assetIdParam.trim());
+    } catch (NumberFormatException nfe) {
+        response.setStatus(400);
+        out.println(new JSONObject().put("error", "invalid assetId parameter: " + assetIdParam).toString(4));
+        return;
+    }
+}
+
+boolean commit   = "true".equalsIgnoreCase(request.getParameter("commit"));
+boolean register = !"false".equalsIgnoreCase(request.getParameter("register"));
+boolean verbose  = "true".equalsIgnoreCase(request.getParameter("verbose"));
+
+JSONObject result = new JSONObject();
+result.put("dryRun", !commit);
+result.put("registerWithWbia", register && commit);
+JSONArray detail = new JSONArray();
+
+int examined = 0, nowValid = 0, stillInvalid = 0, unrevalidatable = 0, errored = 0;
+int probed = 0, missingAtWbia = 0, registered = 0, registerFailed = 0;
+
+// ---- phase 1: collect the flagged asset ids (short transaction, primitives out) ----
+List<Integer> ids = new ArrayList<Integer>();
+Shepherd readShepherd = new Shepherd(context);
+readShepherd.setAction("appadmin.repairQuarantinedImages.read");
+readShepherd.beginDBTransaction();
+Query q = null;
+try {
+    if (singleAssetId != null) {
+        ids.add(singleAssetId);
+    } else {
+        q = readShepherd.getPM().newQuery(MediaAsset.class, "validImageForIA == false");
+        q.setResult("id");            // project: no need to materialize the assets here
+        q.setOrdering("id ascending");
+        q.setRange(0, max);
+        Collection c = (Collection)q.execute();
+        for (Object o : c) {
+            if (o != null) ids.add(Integer.valueOf(o.toString()));
+        }
+    }
+} catch (Exception ex) {
+    response.setStatus(500);
+    out.println(new JSONObject().put("error", "read phase failed: " + ex.toString()).toString(4));
+    return;
+} finally {
+    if (q != null) q.closeAll();
+    readShepherd.rollbackAndClose();
+}
+result.put("flaggedAssetsSelected", ids.size());
+
+// ---- phase 2: re-decode each file and let the file decide the flag ----
+// Collected for phase 3. In a dry run nothing is committed: the enclosing
+// rollbackAndClose() discards validateSourceImage()'s in-memory writes.
+List<Integer> becameValidIds = new ArrayList<Integer>();
+List<String> becameValidAcmIds = new ArrayList<String>();
+
+Shepherd vShepherd = new Shepherd(context);
+vShepherd.setAction("appadmin.repairQuarantinedImages.revalidate");
+vShepherd.beginDBTransaction();
+try {
+    for (Integer id : ids) {
+        examined++;
+        JSONObject row = new JSONObject();
+        row.put("assetId", id);
+        try {
+            MediaAsset ma = MediaAssetFactory.load(id.intValue(), vShepherd);
+            if (ma == null) {
+                row.put("outcome", "gone");
+                errored++;
+                if (verbose) detail.put(row);
+                continue;
+            }
+            String storeType = null;
+            try {
+                if (ma.getStore() != null) storeType = ma.getStore().getType().toString();
+            } catch (Exception ignore) { }
+            row.put("store", (storeType == null) ? "unknown" : storeType);
+            if (!"LOCAL".equals(storeType)) {
+                // validateSourceImage() is a no-op off LOCAL; do not guess either way
+                row.put("outcome", "unrevalidatable");
+                unrevalidatable++;
+                if (verbose) detail.put(row);
+                continue;
+            }
+            boolean valid = ma.validateSourceImage();   // reads the actual file
+            row.put("outcome", valid ? "nowValid" : "stillInvalid");
+            if (valid) {
+                nowValid++;
+                becameValidIds.add(id);
+                if (Util.stringExists(ma.getAcmId()) && Util.isUUID(ma.getAcmId()))
+                    becameValidAcmIds.add(ma.getAcmId());
+                row.put("acmId", ma.getAcmId());
+                if (commit) vShepherd.updateDBTransaction();
+            } else {
+                stillInvalid++;
+                // leave it flagged: the file genuinely does not decode
+            }
+        } catch (Exception ex) {
+            errored++;
+            row.put("outcome", "error");
+            row.put("error", ex.toString());
+            System.out.println("repairQuarantinedImages: asset " + id + " failed: " + ex);
+        }
+        if (verbose) detail.put(row);
+    }
+} finally {
+    vShepherd.rollbackAndClose();   // dry run: discards; commit run: trailing empty tx only
+}
+
+result.put("examined", examined);
+result.put("nowValid", nowValid);
+result.put("stillInvalid", stillInvalid);
+result.put("unrevalidatable", unrevalidatable);
+result.put("errored", errored);
+
+// ---- phase 3: ask WBIA which of the newly-valid acmIds it does not know (no tx open) ----
+List<String> missing = new ArrayList<String>();
+if (register && !becameValidAcmIds.isEmpty()) {
+    try {
+        probed = becameValidAcmIds.size();
+        missing = WildbookIAM.iaMissingImageIds(becameValidAcmIds, context);
+        missingAtWbia = missing.size();
+    } catch (Exception ex) {
+        result.put("probeError", ex.toString());
+        missing = new ArrayList<String>();
+    }
+}
+result.put("probedAtWbia", probed);
+result.put("missingFromWbia", missingAtWbia);
+
+// ---- phase 4: register the missing ones (own transaction, commit per confirmation) ----
+if (commit && register && !missing.isEmpty()) {
+    Shepherd sShepherd = new Shepherd(context);
+    sShepherd.setAction("appadmin.repairQuarantinedImages.register");
+    sShepherd.beginDBTransaction();
+    try {
+        for (String acmId : missing) {
+            JSONObject row = new JSONObject();
+            row.put("acmId", acmId);
+            try {
+                MediaAsset ma = MediaAssetFactory.loadByAcmId(acmId, sShepherd);
+                if (ma == null) {
+                    row.put("outcome", "assetGoneBeforeRegister");
+                    registerFailed++;
+                    if (verbose) detail.put(row);
+                    continue;
+                }
+                String before = ma.getAcmId();
+                if (!ma.hasFamily(sShepherd)) ma.updateStandardChildren();
+                ArrayList<MediaAsset> one = new ArrayList<MediaAsset>();
+                one.add(ma);
+                // checkFirst=false: phase 3 already established absence
+                JSONObject sendRtn = IBEISIA.sendMediaAssetsNew(one, context, false);
+                if (AcmIdBot.sendConfirmedAcmId(sendRtn, ma.getAcmId())) {
+                    // rectifyMediaAssetIds may have adopted WBIA's UUID. acmId IS part of
+                    // the MediaAsset OpenSearch document but setAcmId does not bump
+                    // revision, so bump it explicitly or the index keeps the old value.
+                    if ((before == null) || !before.equals(ma.getAcmId())) {
+                        row.put("acmIdChanged", before + " -> " + ma.getAcmId());
+                        ma.setRevision();
+                    }
+                    sShepherd.updateDBTransaction();
+                    registered++;
+                    row.put("outcome", "registered");
+                } else {
+                    registerFailed++;
+                    row.put("outcome", "unconfirmedByWbia");
+                    System.out.println("repairQuarantinedImages: WBIA did not confirm " + acmId);
+                }
+            } catch (Exception ex) {
+                registerFailed++;
+                row.put("outcome", "registerError");
+                row.put("error", ex.toString());
+                System.out.println("repairQuarantinedImages: register failed for " + acmId +
+                    ": " + ex);
+            }
+            if (verbose) detail.put(row);
+        }
+    } finally {
+        sShepherd.rollbackAndClose();
+    }
+}
+result.put("registeredWithWbia", registered);
+result.put("registerFailed", registerFailed);
+
+if (!commit) {
+    result.put("note",
+        "DRY RUN: nothing persisted and nothing sent to WBIA. Re-run with &commit=true to apply. "
+        + "Flag changes shown here were computed by actually decoding each file.");
+}
+if (verbose) result.put("detail", detail);
+result.put("remainingHint",
+    "Re-run until flaggedAssetsSelected is 0. Assets reported stillInvalid keep the flag by "
+    + "design -- their files do not decode -- and will be selected again on every run.");
+
+out.println(result.toString(4));
+%>

--- a/src/main/webapp/appadmin/repairQuarantinedImages.jsp
+++ b/src/main/webapp/appadmin/repairQuarantinedImages.jsp
@@ -133,9 +133,19 @@ try {
     // Always filter on the flag, even for a single assetId: this JSP's whole contract is
     // "repair quarantined assets", and it must not be usable to re-send an arbitrary asset.
     String filter = "validImageForIA == false";
+    // Push the matchable-scope test into the QUERY rather than filtering after selection.
+    // Filtering afterwards meant out-of-scope assets consumed the window -- one run examined
+    // 200 and found 185 of them out of scope, leaving 15 real candidates. Worse, because
+    // there is no cursor and skipped assets stay flagged, every subsequent run re-selected
+    // the exact same 200 and made no progress at all. Selecting only in-scope assets makes
+    // the window entirely useful and lets the backlog actually drain.
+    if (matchableOnly)
+        filter += " && features.contains(feat) && feat.annotation.matchAgainst == true";
     if (singleAssetId != null) filter += " && id == " + singleAssetId.intValue();
     q = readShepherd.getPM().newQuery(MediaAsset.class, filter);
-    q.setResult("id");
+    if (matchableOnly) q.declareVariables("org.ecocean.media.Feature feat");
+    // distinct: an asset with several matchable features would otherwise repeat
+    q.setResult("distinct id");
     q.setOrdering("id ascending");
     if (singleAssetId == null) q.setRange(0, max);
     Collection c = (Collection)q.execute();
@@ -318,15 +328,37 @@ if (commit) {
                     if (Util.stringExists(priorAcmId)) {
                         Query dupQ = null;
                         try {
-                            dupQ = sh.getPM().newQuery(MediaAsset.class, "acmId == :a");
-                            dupQ.setResult("count(id)");
+                            // count(this) with an explicitly declared parameter, matching the
+                            // one working precedent in this codebase (Shepherd:3197, which
+                            // casts the result to Long). An earlier version used count(id)
+                            // with an implicit :param and produced a non-Number result for
+                            // EVERY asset, which the fail-closed guard below then read as
+                            // "ambiguous" -- blocking 100% of candidates. Accept either a
+                            // bare aggregate or a single-element collection, since
+                            // DataNucleus is not consistent about which it returns.
+                            dupQ = sh.getPM().newQuery(MediaAsset.class, "acmId == acmIdParam");
+                            dupQ.declareParameters("String acmIdParam");
+                            dupQ.setResult("count(this)");
                             Object cnt = dupQ.execute(priorAcmId);
-                            holdersOfAcmId = (cnt instanceof Number)
-                                ? ((Number)cnt).intValue() : -1;
+                            if (cnt instanceof Number) {
+                                holdersOfAcmId = ((Number)cnt).intValue();
+                            } else if (cnt instanceof Collection) {
+                                Collection cc = (Collection)cnt;
+                                Object first = cc.isEmpty() ? null : cc.iterator().next();
+                                holdersOfAcmId = (first instanceof Number)
+                                    ? ((Number)first).intValue() : -1;
+                            } else {
+                                holdersOfAcmId = -1;
+                                System.out.println("repairQuarantinedImages: duplicate-acmId"
+                                    + " count returned unexpected type "
+                                    + ((cnt == null) ? "null" : cnt.getClass().getName())
+                                    + " for asset " + id);
+                            }
                         } catch (Exception dex) {
                             holdersOfAcmId = -1;
                             System.out.println("repairQuarantinedImages: duplicate-acmId check"
-                                + " failed for asset " + id + " (" + priorAcmId + "): " + dex);
+                                + " FAILED for asset " + id + " (" + priorAcmId + "): " + dex);
+                            dex.printStackTrace();
                         } finally {
                             if (dupQ != null) dupQ.closeAll();
                         }
@@ -339,7 +371,10 @@ if (commit) {
                         // is the registered image, and re-POSTing would overwrite whichever
                         // one WBIA holds. Leave it flagged and surface it for a human.
                         ambiguous++;
-                        row.put("outcome", "ambiguousDuplicateAcmId");
+                        // distinguish a genuine duplicate from a failed count, so a broken
+                        // guard can never again masquerade as a data problem
+                        row.put("outcome", (holdersOfAcmId < 0)
+                            ? "duplicateCheckFailed" : "ambiguousDuplicateAcmId");
                         row.put("acmId", priorAcmId);
                         row.put("assetsHoldingThisAcmId", holdersOfAcmId);
                         if (shared != null) row.put("sharedByCandidatesThisRun", shared);

--- a/src/main/webapp/appadmin/repairQuarantinedImages.jsp
+++ b/src/main/webapp/appadmin/repairQuarantinedImages.jsp
@@ -308,18 +308,46 @@ if (commit) {
                     String probedAcmId = probedAcmIdByAsset.get(id);
                     Integer shared = (probedAcmId == null)
                         ? null : candidatesPerAcmId.get(probedAcmId);
-                    if ((shared != null) && (shared.intValue() > 1)) {
-                        // Two or more candidates carry this same acmId. One "present at
-                        // WBIA" answer cannot say which of them is the registered image, and
-                        // re-POSTing would just overwrite whichever WBIA holds. Leave both
-                        // flagged and surface it for a human.
+                    // acmId is explicitly NOT unique. Counting duplicates only among this
+                    // run's candidates is not enough: a sharing asset outside this page (or
+                    // not flagged at all) would still make WBIA's "present" answer ambiguous,
+                    // since it could belong to that other asset. So count ALL assets holding
+                    // this acmId, inside this same transaction. A failed count is treated as
+                    // ambiguous -- fail closed rather than clear a flag on an unverified
+                    // uniqueness assumption.
+                    int holdersOfAcmId = 1;
+                    if (Util.stringExists(priorAcmId)) {
+                        Query dupQ = null;
+                        try {
+                            dupQ = sh.getPM().newQuery(MediaAsset.class, "acmId == :a");
+                            dupQ.setResult("count(id)");
+                            Object cnt = dupQ.execute(priorAcmId);
+                            holdersOfAcmId = (cnt instanceof Number)
+                                ? ((Number)cnt).intValue() : -1;
+                        } catch (Exception dex) {
+                            holdersOfAcmId = -1;
+                            System.out.println("repairQuarantinedImages: duplicate-acmId check"
+                                + " failed for asset " + id + " (" + priorAcmId + "): " + dex);
+                        } finally {
+                            if (dupQ != null) dupQ.closeAll();
+                        }
+                    }
+                    boolean acmIdAmbiguous = Util.stringExists(priorAcmId)
+                        && (holdersOfAcmId != 1);
+                    if (((shared != null) && (shared.intValue() > 1)) || acmIdAmbiguous) {
+                        // Two or more assets carry this acmId (or the count could not be
+                        // established). One "present at WBIA" answer cannot say which asset
+                        // is the registered image, and re-POSTing would overwrite whichever
+                        // one WBIA holds. Leave it flagged and surface it for a human.
                         ambiguous++;
                         row.put("outcome", "ambiguousDuplicateAcmId");
-                        row.put("acmId", probedAcmId);
-                        row.put("sharedByCandidates", shared);
-                        System.out.println("repairQuarantinedImages: asset " + id
-                            + " shares acmId " + probedAcmId + " with " + (shared.intValue() - 1)
-                            + " other candidate(s); leaving flagged for manual reconciliation");
+                        row.put("acmId", priorAcmId);
+                        row.put("assetsHoldingThisAcmId", holdersOfAcmId);
+                        if (shared != null) row.put("sharedByCandidatesThisRun", shared);
+                        System.out.println("repairQuarantinedImages: asset " + id + " acmId "
+                            + priorAcmId + " is held by " + holdersOfAcmId
+                            + " asset(s) (-1 = count failed); leaving flagged for manual"
+                            + " reconciliation");
                     } else {
                     // "WBIA already has it" may ONLY be concluded when the asset still
                     // carries the exact acmId we probed. Anything else -- null, malformed,

--- a/src/test/java/org/ecocean/AcmIdBotAnnotSweepTest.java
+++ b/src/test/java/org/ecocean/AcmIdBotAnnotSweepTest.java
@@ -1,0 +1,209 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure-logic coverage of the WBIA annotation reconciliation sweep helpers
+ * (spec docs/superpowers/specs/2026-08-03-wbia-annotation-reconciliation-sweep-design.md):
+ * page collection (dedup, acmId bucketing, exhaustion) and cursor advancement
+ * (wrap-around, maxFixes clamp) over a String/UUID cursor.
+ *
+ * <p>Sibling of {@link AcmIdBotSweepTest}, which covers the MediaAsset sweep. Two
+ * structural differences worth keeping in mind while reading:</p>
+ * <ul>
+ *   <li>{@code Annotation.id} is a String UUID primary key, so the cursor is
+ *       lexicographic and its "start from the beginning" sentinel is the empty string
+ *       rather than 0.</li>
+ *   <li>The read query projects {@code (id, acmId)} rather than materializing
+ *       Annotation entities, so the collector consumes {@code String[]} rows.</li>
+ * </ul>
+ */
+class AcmIdBotAnnotSweepTest {
+    // a projection row as the read phase yields it: [0] = id, [1] = acmId
+    private static String[] row(String id, String acmId) {
+        return new String[] { id, acmId };
+    }
+
+    // Arrays.asList() with a single String[] would bind as varargs of String and yield a
+    // List<String>, so single-row inputs go through singletonList instead.
+    private static java.util.Iterator<String[]> oneRow(String id, String acmId) {
+        return java.util.Collections.singletonList(row(id, acmId)).iterator();
+    }
+
+    private static final String UUID_A = "aaaaaaaa-0000-4000-8000-000000000001";
+    private static final String UUID_B = "bbbbbbbb-0000-4000-8000-000000000002";
+    private static final String UUID_C = "cccccccc-0000-4000-8000-000000000003";
+
+    // ---------- collectAnnotSweepPage ----------
+
+    @Test void bucketsNullAcmSeparatelyFromProbeable() {
+        List<String[]> in = Arrays.asList(
+            row("id-1", UUID_A), row("id-2", null), row("id-3", UUID_B));
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(in.iterator(), 10);
+
+        assertEquals(2, page.acmIdToAnnotId.size());
+        assertEquals(1, page.nullAcmAnnotIds.size());
+        assertEquals("id-2", page.nullAcmAnnotIds.get(0));
+        assertTrue(page.rawExhausted, "short input should exhaust");
+        assertEquals("id-3", page.lastAnnotId);
+    }
+
+    @Test void mapsAcmIdBackToItsAnnotationId() {
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(
+            oneRow("id-1", UUID_A), 10);
+
+        assertEquals("id-1", page.acmIdToAnnotId.get(UUID_A));
+    }
+
+    @Test void dedupesRepeatedAnnotations() {
+        // the scope query joins through Encounter, so an annotation attached to more
+        // than one encounter can appear twice even with SQL distinct as a backstop
+        List<String[]> in = Arrays.asList(
+            row("id-1", UUID_A), row("id-1", UUID_A), row("id-2", UUID_B), row("id-1", UUID_A));
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(in.iterator(), 10);
+
+        assertEquals(2, page.acmIdToAnnotId.size());
+        assertTrue(page.rawExhausted);
+        assertEquals("id-2", page.lastAnnotId);
+    }
+
+    @Test void skipsNullRows() {
+        List<String[]> in = Arrays.asList(null, row("id-2", UUID_A));
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(in.iterator(), 10);
+
+        assertEquals(1, page.acmIdToAnnotId.size());
+        assertTrue(page.rawExhausted);
+    }
+
+    @Test void skipsRowsWithNoIdAtAll() {
+        // an id-less row could not be re-loaded in the heal phase, and must not
+        // become the cursor either
+        List<String[]> in = Arrays.asList(row(null, UUID_A), row("id-2", UUID_B));
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(in.iterator(), 10);
+
+        assertEquals(1, page.acmIdToAnnotId.size());
+        assertEquals("id-2", page.lastAnnotId);
+    }
+
+    @Test void pageLimitStopsCollectionAndMarksNotExhausted() {
+        List<String[]> in = new ArrayList<String[]>();
+
+        for (int i = 1; i <= 5; i++) in.add(row("id-" + i, UUID_A.replace("001", "00" + i)));
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(in.iterator(), 3);
+
+        assertEquals(3, page.acmIdToAnnotId.size());
+        assertFalse(page.rawExhausted, "limit hit before input end: not exhausted");
+        assertEquals("id-3", page.lastAnnotId);
+    }
+
+    @Test void exactlyFullPageWithNoMoreInputIsExhausted() {
+        List<String[]> in = Arrays.asList(
+            row("id-1", UUID_A), row("id-2", UUID_B), row("id-3", UUID_C));
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(in.iterator(), 3);
+
+        assertEquals(3, page.acmIdToAnnotId.size());
+        assertTrue(page.rawExhausted, "input ended exactly at limit: exhausted");
+    }
+
+    @Test void emptyInputIsExhaustedWithNullSentinelLastId() {
+        AcmIdBot.AnnotSweepPage page =
+            AcmIdBot.collectAnnotSweepPage(new ArrayList<String[]>().iterator(), 10);
+
+        assertTrue(page.rawExhausted);
+        assertNull(page.lastAnnotId, "empty page has no last id");
+        assertEquals(0, page.acmIdToAnnotId.size());
+        assertEquals(0, page.nullAcmAnnotIds.size());
+    }
+
+    @Test void routesMalformedAcmIdToNullBucket() {
+        // a non-UUID value would make WBIA reject the whole probe chunk and could
+        // strand the rest of the page, so it goes straight to the heal path
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(
+            oneRow("id-7", "not-a-valid-uuid"), 10);
+
+        assertEquals(1, page.nullAcmAnnotIds.size());
+        assertEquals("id-7", page.nullAcmAnnotIds.get(0));
+        assertEquals(0, page.acmIdToAnnotId.size());
+    }
+
+    @Test void duplicateAcmIdKeepsLatterAnnotation() {
+        // two annotations sharing one acmId is corrupt data; the sweep must not lose
+        // the page over it, and only one of them can be probed/healed this pass
+        List<String[]> in = Arrays.asList(row("id-1", UUID_A), row("id-2", UUID_A));
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(in.iterator(), 10);
+
+        assertEquals(1, page.acmIdToAnnotId.size());
+        assertEquals("id-2", page.acmIdToAnnotId.get(UUID_A));
+        assertEquals("id-2", page.lastAnnotId);
+    }
+
+    // ---------- partial-read progress (Codex finding #4) ----------
+
+    @Test void partialProgressSurvivesAnIterationFailure() {
+        // The page is populated in place, so a throw partway through iteration still
+        // leaves the caller a last-safely-read id to make a TARGETED skip to. Without
+        // this the sweep would retry the same poison page forever: a String cursor has
+        // no "cursor += PAGE_SIZE" blind advance available to it.
+        AcmIdBot.AnnotSweepPage page = new AcmIdBot.AnnotSweepPage();
+        java.util.Iterator<String[]> exploding = new java.util.Iterator<String[]>() {
+            private int n = 0;
+            public boolean hasNext() { return true; }
+            public String[] next() {
+                if (++n > 2) throw new IllegalStateException("simulated bad row");
+                return row("id-" + n, UUID_A.replace("001", "00" + n));
+            }
+        };
+
+        try {
+            AcmIdBot.collectAnnotSweepPageInto(page, exploding, 10);
+        } catch (RuntimeException expected) { /* the read phase catches this */ }
+        assertEquals("id-2", page.lastAnnotId, "partial progress must be visible to the caller");
+        assertFalse(page.rawExhausted, "a failed read never counts as exhaustion");
+    }
+
+    // ---------- nextAnnotCursorAfterSuccess ----------
+
+    @Test void normalPageAdvancesToLastAnnotId() {
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(
+            Arrays.asList(row("id-7", UUID_A), row("id-9", UUID_B)).iterator(), 1);
+
+        assertFalse(page.rawExhausted);
+        assertEquals("id-7",
+            AcmIdBot.nextAnnotCursorAfterSuccess(page, false, page.lastAnnotId));
+    }
+
+    @Test void exhaustionWrapsCursorToEmptyString() {
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(
+            oneRow("id-7", UUID_A), 10);
+
+        assertTrue(page.rawExhausted);
+        assertEquals("", AcmIdBot.nextAnnotCursorAfterSuccess(page, false, page.lastAnnotId),
+            "wrap-around restarts the sweep from the beginning");
+    }
+
+    @Test void maxFixesClampBeatsExhaustionWrap() {
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(
+            Arrays.asList(row("id-7", UUID_A), row("id-9", UUID_B)).iterator(), 10);
+
+        assertTrue(page.rawExhausted);
+        // cap hit while healing id-7: resume from id-7, do NOT wrap
+        assertEquals("id-7", AcmIdBot.nextAnnotCursorAfterSuccess(page, true, "id-7"));
+    }
+
+    @Test void emptyPageHoldsCursorRatherThanNullingIt() {
+        // an empty page is exhaustion: wrap, never write a null cursor
+        AcmIdBot.AnnotSweepPage page =
+            AcmIdBot.collectAnnotSweepPage(new ArrayList<String[]>().iterator(), 10);
+
+        assertEquals("", AcmIdBot.nextAnnotCursorAfterSuccess(page, false, page.lastAnnotId));
+    }
+}

--- a/src/test/java/org/ecocean/AcmIdBotAnnotSweepTest.java
+++ b/src/test/java/org/ecocean/AcmIdBotAnnotSweepTest.java
@@ -146,6 +146,31 @@ class AcmIdBotAnnotSweepTest {
         assertEquals("id-2", page.lastAnnotId);
     }
 
+    // ---------- database-order preservation ----------
+
+    @Test void recordsEveryDistinctIdInDatabaseOrder() {
+        // The heal phase must walk candidates in the order the DB returned them, because
+        // the cursor's "id > x" comparison happens in Postgres collation, which need not
+        // agree with Java's UTF-16 ordering for hyphenated UUID text. These ids are
+        // deliberately NOT in Java sort order.
+        List<String[]> in = Arrays.asList(
+            row("zz-1", UUID_A), row("aa-2", null), row("mm-3", UUID_B));
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(in.iterator(), 10);
+
+        assertEquals(Arrays.asList("zz-1", "aa-2", "mm-3"), page.orderedAnnotIds,
+            "page order must be the database's, not re-sorted");
+        assertEquals("mm-3", page.lastAnnotId, "cursor follows the last row the DB gave");
+    }
+
+    @Test void orderedIdsExcludeSkippedRowsAndDuplicates() {
+        List<String[]> in = Arrays.asList(
+            row("id-1", UUID_A), null, row(null, UUID_B), row("id-1", UUID_A),
+            row("id-2", UUID_C));
+        AcmIdBot.AnnotSweepPage page = AcmIdBot.collectAnnotSweepPage(in.iterator(), 10);
+
+        assertEquals(Arrays.asList("id-1", "id-2"), page.orderedAnnotIds);
+    }
+
     // ---------- partial-read progress (Codex finding #4) ----------
 
     @Test void partialProgressSurvivesAnIterationFailure() {

--- a/src/test/java/org/ecocean/ia/plugin/WildbookIAMRegisterTest.java
+++ b/src/test/java/org/ecocean/ia/plugin/WildbookIAMRegisterTest.java
@@ -63,6 +63,40 @@ class WildbookIAMRegisterTest {
         assertEquals("____", map.get("annot_name_list").get(0));
     }
 
+    // --- buildForcedRequestMap: explicit forced UUID ----------------------
+    // (WBIA annotation reconciliation sweep spec §4; Codex finding #1)
+
+    @Test void forcedUuidOverloadSendsTheAcmIdNotTheAnnotationId() {
+        // The reconciliation sweep must force the acmId, because that -- not id -- is
+        // what IBEISIA.sendIdentify asks WBIA about. For legacy annotations whose acmId
+        // WBIA minted, the two differ, and forcing the id would register a UUID
+        // identification never looks up: exactly the bug under repair. Presence of the
+        // id at WBIA is never evidence that the acmId is registered.
+        HashMap<String, ArrayList> map =
+            WildbookIAM.buildForcedRequestMap(sampleDto(), "ann-acm-1");
+        JSONObject annUuid = (JSONObject)map.get("annot_uuid_list").get(0);
+
+        assertEquals("ann-acm-1", WildbookIAM.fromFancyUUID(annUuid));
+    }
+
+    @Test void forcedUuidOverloadLeavesTheRestOfThePayloadAlone() {
+        HashMap<String, ArrayList> map =
+            WildbookIAM.buildForcedRequestMap(sampleDto(), "ann-acm-1");
+        JSONObject imgUuid = (JSONObject)map.get("image_uuid_list").get(0);
+
+        assertEquals("ma-acm-1", WildbookIAM.fromFancyUUID(imgUuid));
+        assertEquals("right_dorsalfin", map.get("annot_species_list").get(0));
+        assertEquals("indiv-1", map.get("annot_name_list").get(0));
+    }
+
+    @Test void defaultBuildForcedRequestMapStillForcesTheAnnotationId() {
+        // the existing 30s poller path must be unchanged by the new overload
+        HashMap<String, ArrayList> map = WildbookIAM.buildForcedRequestMap(sampleDto());
+        JSONObject annUuid = (JSONObject)map.get("annot_uuid_list").get(0);
+
+        assertEquals("ann-uuid-1", WildbookIAM.fromFancyUUID(annUuid));
+    }
+
     // --- validateForcedResponse ------------------------------------------
 
     @Test void validateForcedResponseAcceptsMatchingId() throws IOException {


### PR DESCRIPTION
## Problem

`AcmIdBot` already reconciles **MediaAssets** against WBIA: it probes `/api/image/rowid/uuid/` for every asset backing a `matchAgainst` annotation and re-registers whatever WBIA does not have. **Annotations had no equivalent.**

They relied on `StartupWildbook.startWbiaRegistrationPollingThread` (30s), which pushes a newly created annotation once and then trusts `Annotation.wbiaRegistered` forever. Nothing ever asks WBIA whether an annotation is actually there, so a local boolean stands in for knowledge of remote state — and anything that makes that boolean wrong makes it wrong permanently:

- A WBIA database rebuilt, restored from an older snapshot, or hand-pruned leaves Wildbook still marked "registered". Annotations deleted WBIA-side are the same. So is a POST that returned success but didn't persist.
- `archive/sql/ml_service_idempotency.sql` set `WBIAREGISTERED = TRUE WHERE "ACMID" IS NOT NULL` on deploy — an assumption, never verified against WBIA. Every row it touched was excluded from the poller from then on.
- Annotations parked at `wbiaRegisterAttempts >= 10` never retry, including ones parked during a transient outage that has long since ended. Nothing in the codebase un-parks them.

The observable symptom is identification failing permanently with WBIA `code 600 "Missing image and/or annotation UUIDs"`, requeued to no effect. (Note the image count in that message is structurally always 0 — `sendIdentify` sends no image uuid list at all — so it is never evidence that image sync is healthy.)

## What this adds

`AcmIdBot.sweepMatchableAnnotations()`, a sibling of the existing asset sweep sharing its read/probe/heal phase separation, its poisoned-page guard, and its explicit-commit discipline. Scope is annotations with `matchAgainst == true` attached to an Encounter, deliberately **ignoring `wbiaRegistered`** — that flag is the thing the sweep exists to stop trusting.

Three things differ from the asset sweep and are where review attention is best spent.

**It keys on `acmId`, not `id`.** `IBEISIA.sendIdentify` builds its annot uuid lists from `getAcmId()`. For ml-service and manually drawn annotations `acmId == id`, so this never mattered; for legacy WBIA-era rows whose acmId WBIA itself minted (`IBEISIA:1274`, `:2172`, `AcmUtil.rectifyAnnotationIds`) they differ, and the existing `sendAnnotationsForceId` forces `id` — registering a UUID identification never looks up. Re-running the old push path would re-register the same wrong identifier indefinitely. Hence the new `buildForcedRequestMap(dto, forcedAnnotUuid)` overload (existing callers unchanged) and `sendAnnotationForcedByAcmId`, which performs **no** already-present check: presence of the `id` at WBIA is never evidence the `acmId` is registered.

**The heal confirms the backing image, rather than trusting `MediaAsset.acmId != null`.** WBIA rejects an annotation whose image it lacks with `image_uuid_list has invalid values [(0, None)]`, and a non-null acmId is not evidence of presence — closing that gap is the whole point of the asset sweep. This cannot be delegated: the two sweeps have independent cursors, and **featureless legacy annotations** reach their asset through the deprecated `__getMediaAsset()` association that the `Feature`-based asset sweep never traverses, so their images were invisible to it.

**It partitions against the 30s poller instead of locking.** The poller claims exactly `wbiaRegistered == false && attempts < MAX`; the sweep takes the exact complement. Without this both could POST the same annotation, and since the poller forces `id` while the sweep forces `acmId`, an `id != acmId` row would land in WBIA as two annotations on one box. `MAX` is now shared from `StartupWildbook` rather than duplicated. The null case is spelled out rather than written `!= false`, since three-valued logic would silently drop the rows the deploy backfill never touched.

## Implementation notes worth knowing

- `Annotation.id` is a 36-char String PK, so the cursor is lexicographic and has no `cursor += PAGE_SIZE` blind advance. The page is populated **in place** so partial progress survives an iteration failure and the poisoned-page guard can skip precisely; only a page that read nothing at all wraps, loudly.
- Candidates are healed in **database order**, not `Collections.sort` order. Postgres collation need not agree with Java UTF-16 ordering for hyphenated UUID text, and a mismatch would let a `maxFixes` resume step over candidates the database considers earlier.
- The read query projects `(id, acmId)` with `distinct` and a bound `String cursor` parameter, rather than materializing 10k managed `Annotation` graphs. An unexpected projection row shape **throws** instead of being coerced — coercion would route every row into the null-acmId bucket and re-POST the entire corpus.
- `updateDBTransaction()` is commit-plus-begin and so commits *every* dirty object, which makes step order in `ensureImageRegistered` load-bearing: commit validity → probe → adopt → POST → commit only after confirmation. Adopting first meant the validity flush committed an unconfirmed acmId, after which the in-memory revert was discarded by the enclosing `rollbackAndClose()`.
- Eligibility uses the **context-aware** `validForIdentification(ann, context)`; the no-context overload skips the iaClass check and would let the sweep register annotations identification then rejects.
- Registration flags are written only when their value changes, since both setters bump `Annotation.version` and would otherwise reindex the corpus for nothing across a systemic WBIA loss.

The WBIA endpoint was verified in source rather than assumed: `@register_api('/api/annot/rowid/uuid/')` on `get_annot_aids_from_uuid` (`wbia/control/manual_annot_funcs.py:1126`), decorated `getter_1to1`; its `get_annot_missing_uuid` companion defines missing as exactly `aid is None`, matching what `parseRowidProbeResponse` already implements.

## Scale, stated plainly

At 1M matchable annotations a healthy full pass is 100 runs ≈ **25 hours**; if everything needs repair, `maxFixes = 500` makes it ~2,000 runs ≈ **21 days**. That is appropriate for continuous background reconciliation and **not** an incident response — a bulk-repair admin JSP is a deferred follow-up. The summary log reports the candidate count against mutually exclusive outcome buckets so an operator can see the rate and check the numbers reconcile.

## Explicitly out of scope

Real defects found in the same investigation, each separately PR-worthy; bundling them would make this diff unreviewable.

- **`IBEISIA.iaCheckMissing` is dead code** — the only in-request self-heal on a 600. Its image branch is a literal no-op (`// TODO: actually send the mediaasset duh`, printing "FAKE ATTEMPT"), and its annotation branch calls `__sendAnnotations(...)` but never assigns the result to `srtn`, so `tryAgain` is always false and the identify is never retried. This is why an affected job burns all its requeues. This PR makes the *next* identify succeed; it does not rescue an in-flight one.
- **`sendAnnotations` / `sendIdentify` eligibility mismatch**: annotations whose MediaAsset lacks an acmId are asked about but never sent.
- **`sendAnnotationsAsNeeded` swallows send exceptions** into `sendAnnotMAException` while identify proceeds regardless.
- Durable cursor across restart; admin JSP for bulk repair; configurable limits with run-duration telemetry.

Annotations failing `validForIdentification` (bad bbox/iaClass) are reported as `skippedInvalid`, not healed — those need data fixes, not registration.

## Testing

`mvn test`: **829 tests, 0 failures, 0 errors**. 17 new pure-logic tests for page collection (dedup, bucketing, exhaustion boundaries, null/id-less rows, duplicate acmId, DB-order preservation, partial-read progress) and cursor policy (advance, wrap, `maxFixes` clamp). 3 new tests lock the forced-UUID regression: the sweep's overload must send the `acmId` while the poller's existing path still sends the `id`. The pre-existing 15 asset-sweep tests are unchanged and still pass.

Design and the full three-round Codex review disposition (8 spec findings → 3 implementation findings → converged) are in `docs/superpowers/specs/2026-08-03-wbia-annotation-reconciliation-sweep-design.md`.

## Deployment

Code-only; no schema change (`WBIAREGISTERED` / `WBIAREGISTERATTEMPTS` already exist). The sweep starts itself with the existing `AcmIdBot` scheduler on the next Tomcat start. `/tmp/WB_AcmIdBot_SHUTDOWN` still disables the whole bot if it needs to be stopped in a hurry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
