### PR TITLE
fix(encounter): sort Individual ID typeahead results by name descending

### DIFF
--- a/frontend/src/__tests__/pages/Encounter/EncounterStore.test.js
+++ b/frontend/src/__tests__/pages/Encounter/EncounterStore.test.js
@@ -181,6 +181,19 @@ describe("EncounterStore", () => {
       );
       expect(store.individualSearchResults).toEqual(mockResults);
     });
+
+    it("should sort individual search results by name descending", async () => {
+      axios.post.mockResolvedValue({ data: { hits: [] } });
+
+      await store.searchIndividualsByNameAndId("Whale");
+
+      expect(axios.post).toHaveBeenCalledWith(
+        "/api/v3/search/individual?size=20&from=0",
+        expect.objectContaining({
+          sort: [{ names: { order: "desc", unmapped_type: "keyword" } }],
+        }),
+      );
+    });
   });
 
   describe("Sighting Search", () => {

--- a/frontend/src/pages/Encounter/stores/EncounterStore.js
+++ b/frontend/src/pages/Encounter/stores/EncounterStore.js
@@ -1290,6 +1290,13 @@ class EncounterStore {
 
     try {
       const searchQuery = {
+        // Wildcard should-clauses are constant-scoring, so without an explicit
+        // sort the hits come back in arbitrary index order (same class of
+        // problem as quicksearch issue #1541). Sort by name, Z→A per request.
+        // (multi-valued names sort by their highest value under desc order;
+        // unmapped_type keeps the query working on an index without the
+        // names mapping)
+        sort: [{ names: { order: "desc", unmapped_type: "keyword" } }],
         query: {
           bool: {
             filter: [


### PR DESCRIPTION
## What
The Individual ID typeahead on `/react/encounter` returned matches in no meaningful order. This adds a body `sort` to the individual search query so results come back in descending (Z→A) name order.

## Why
The typeahead POSTs to `/api/v3/search/individual` with two `wildcard` should-clauses (`names`, `id`). Wildcard queries are constant-scoring, so every hit got the same relevance score and OpenSearch returned internal index order — effectively arbitrary. Same class of problem as the quicksearch ordering fix (#1541 / #1697); same body-sort pattern applied here.

Descending order was explicitly requested in QA feedback.

## How
- `EncounterStore.searchIndividualsByNameAndId` now sends `sort: [{ names: { order: "desc", unmapped_type: "keyword" } }]`. The `names` field is a case-insensitive keyword (`MarkedIndividual.opensearchMapping`), so no backend/mapping change is needed; `queryPit` passes body sort through untouched when no `sort` URL param is present.
- Jest test asserts the POST body contains the sort (fails if removed).

## Testing
- New test watched fail before the fix (missing `sort` in body), passes after.
- Full `EncounterStore.test.js` suite: 55 passed + new test; the 2 failures in the "Encounter Annotations / Match Result Clickable" group are pre-existing — they fail identically on unmodified `main`-equivalent HEAD with this change stashed.
- Codex adversarial review: converged, no Critical/Major findings (one comment-wording nit, fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)