### PR TITLE
tiny tweak to get sort order of names correct

### DIFF
--- a/frontend/src/pages/Encounter/stores/EncounterStore.js
+++ b/frontend/src/pages/Encounter/stores/EncounterStore.js
@@ -1296,7 +1296,7 @@ class EncounterStore {
         // (multi-valued names sort by their highest value under desc order;
         // unmapped_type keeps the query working on an index without the
         // names mapping)
-        sort: [{ names: { order: "desc", unmapped_type: "keyword" } }],
+        sort: [{ names: { order: "desc", mode: "min", unmapped_type: "keyword" } }],
         query: {
           bool: {
             filter: [


### PR DESCRIPTION
#1716 got most of the way to solving the problem, but the nature of the `names: []` array was still causing the resulting list to be unsorted. adding `"mode": "min"` to the opensearch query seems to result in the right ordering.