### PR TITLE
Fix taxonomy-backfill JSP: DataNucleus misparses POSIX regex classes as named SQL parameters

### DIFF
--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -1259,11 +1259,16 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
     // nothing else. So it strips every space and control character instead of trying to reproduce
     // exactly what String.trim() removes, and Java has the final say per row.
     //
-    // [[:space:][:cntrl:]] rather than \s: a backslash in the pattern is consumed before the regex
-    // engine sees it on a connection with standard_conforming_strings off.
+    // The pattern is bound as a query parameter, never written into the SQL text: DataNucleus
+    // scans the whole SQL string for :name tokens without respecting string literals, so the
+    // POSIX classes ([:space:] etc) would be misparsed as named parameters. Binding also delivers
+    // the pattern to the regex engine byte-for-byte, so it owes nothing to
+    // standard_conforming_strings the way a backslash in a literal would.
+    static final String TAXONOMY_BACKFILL_BLANK_REGEX = "[[:space:][:cntrl:]]";
+
     private static String blankTaxonomyPartSql(String column) {
         return "COALESCE(lower(regexp_replace(\"" + column +
-               "\", '[[:space:][:cntrl:]]', '', 'g')), '') IN ('', 'none', 'unknown')";
+               "\", ?, '', 'g')), '') IN ('', 'none', 'unknown')";
     }
 
     /**
@@ -1292,7 +1297,8 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         List<MarkedIndividual> candidates = null;
         try {
             candidates = new ArrayList<MarkedIndividual>(
-                (Collection<MarkedIndividual>)query.execute(startId));
+                (Collection<MarkedIndividual>)query.executeWithArray(startId,
+                TAXONOMY_BACKFILL_BLANK_REGEX, TAXONOMY_BACKFILL_BLANK_REGEX));
         } finally {
             query.closeAll();
         }

--- a/src/test/java/org/ecocean/MarkedIndividualTaxonomyBackfillDbTest.java
+++ b/src/test/java/org/ecocean/MarkedIndividualTaxonomyBackfillDbTest.java
@@ -1,0 +1,136 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Properties;
+import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.shepherd.core.TestPMFUtil;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Runs the taxonomy backfill's candidate query through real DataNucleus against real Postgres.
+ * The mock-based sibling (MarkedIndividualTaxonomyBackfillTest) can never catch what this pins:
+ * DataNucleus parses the SQL *text* at execute time -- it once misread the POSIX classes'
+ * :space/:cntrl in a regex literal as named parameters and threw JDOUserException before the
+ * query ever reached Postgres, so every run of individualTaxonomyBackfill.jsp failed.
+ */
+@Testcontainers
+class MarkedIndividualTaxonomyBackfillDbTest {
+    @Container
+    static PostgreSQLContainer<?> postgres =
+        new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("wildbook_test")
+            .withUsername("wildbook")
+            .withPassword("wildbook");
+
+    static String blankId;
+    static String paddedId;
+    static String noSourceId;
+    static String identifiedId;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        CommonConfiguration.initialize("context0", new Properties());
+
+        Properties props = new Properties();
+        props.setProperty("datanucleus.ConnectionUserName", postgres.getUsername());
+        props.setProperty("datanucleus.ConnectionPassword", postgres.getPassword());
+        props.setProperty("datanucleus.ConnectionDriverName", postgres.getDriverClassName());
+        props.setProperty("datanucleus.ConnectionURL", postgres.getJdbcUrl());
+        props.setProperty("datanucleus.schema.autoCreateTables", "true");
+        TestPMFUtil.closePMF("context0");
+
+        Shepherd sh = new Shepherd("context0", props);
+        try {
+            sh.beginDBTransaction();
+
+            // the #1113 zombie: taxonomy fields hold "" while the encounter knows the species
+            Encounter encBlank = encounter(sh, "Delphinus", "delphis");
+            blankId = storeIndividual(sh, "BlankIndividual", encBlank, "", "");
+
+            // a padded placeholder only the whitespace/control-stripping regex sees as blank
+            Encounter encPadded = encounter(sh, "Orcinus", "orca");
+            paddedId = storeIndividual(sh, "PaddedIndividual", encPadded, " Unknown\t", "none");
+
+            // blank with nothing to inherit: stays a candidate but yields no update
+            Encounter encEmpty = encounter(sh, null, null);
+            noSourceId = storeIndividual(sh, "NoSourceIndividual", encEmpty, null, null);
+
+            // a real identification must never be offered to the backfill
+            Encounter encReal = encounter(sh, "Rhincodon", "typus");
+            identifiedId = storeIndividual(sh, "IdentifiedIndividual", encReal, "Rhincodon",
+                "typus");
+
+            sh.commitDBTransaction();
+        } catch (Exception e) {
+            sh.rollbackDBTransaction();
+            throw e;
+        } finally {
+            sh.closeDBTransaction();
+        }
+    }
+
+    @AfterAll
+    static void tearDown() {
+        TestPMFUtil.closePMF("context0");
+    }
+
+    private static Encounter encounter(Shepherd sh, String genus, String specificEpithet) {
+        Encounter enc = new Encounter();
+
+        // keep postStore from enqueueing IndexingManager work: its worker PMs hold open
+        // transactions that make tearDown's closePMF fail and leak this class's PMF (pointing at
+        // a stopped container) into whatever Testcontainers class runs next
+        enc.setSkipAutoIndexing(true);
+        enc.setGenus(genus);
+        enc.setSpecificEpithet(specificEpithet);
+        sh.storeNewEncounter(enc);
+        return enc;
+    }
+
+    // the constructor inherits the encounter's taxonomy, so overwrite afterwards to recreate the
+    // legacy rows the backfill exists for
+    private static String storeIndividual(Shepherd sh, String name, Encounter enc, String genus,
+        String specificEpithet) {
+        MarkedIndividual indiv = new MarkedIndividual(name, enc);
+
+        indiv.setSkipAutoIndexing(true);
+        indiv.setGenus(genus);
+        indiv.setSpecificEpithet(specificEpithet);
+        sh.storeNewMarkedIndividual(indiv);
+        return indiv.getId();
+    }
+
+    @Test void candidateQueryExecutesAndSelectsExactlyTheBlankRows() {
+        Shepherd sh = new Shepherd("context0");
+
+        sh.setAction("MarkedIndividualTaxonomyBackfillDbTest");
+        sh.beginDBTransaction();
+        try {
+            // dry run with an explicit cursor: exercises the real query without touching
+            // SystemValue, and throws JDOUserException here if DataNucleus misparses the SQL
+            JSONObject res = MarkedIndividual.backfillTaxonomyFromEncounters(sh, "", 100, false);
+
+            assertEquals(3, res.getInt("_examined"),
+                "the two blank rows and the no-source row are candidates; the identified row is not");
+            JSONObject updates = res.getJSONObject("updates");
+            assertEquals("Delphinus delphis", updates.getString(blankId),
+                "the empty-string zombie inherits its encounter's taxonomy");
+            assertEquals("Orcinus orca", updates.getString(paddedId),
+                "the padded placeholder counts as blank and inherits too");
+            assertFalse(updates.has(identifiedId),
+                "an individual with a real taxonomy is left alone");
+            assertEquals(1, res.getInt("_noTaxonomyOnEncounters"),
+                "the blank individual with a taxonomy-less encounter has nothing to inherit");
+        } finally {
+            sh.rollbackDBTransaction();
+            sh.closeDBTransaction();
+        }
+    }
+}

--- a/src/test/java/org/ecocean/MarkedIndividualTaxonomyBackfillTest.java
+++ b/src/test/java/org/ecocean/MarkedIndividualTaxonomyBackfillTest.java
@@ -33,7 +33,7 @@ class MarkedIndividualTaxonomyBackfillTest {
         shepherd = mock(Shepherd.class);
         when(shepherd.getPM()).thenReturn(pm);
         when(pm.newQuery(anyString(), anyString())).thenReturn(query);
-        when(query.execute(any())).thenReturn(candidates);
+        when(query.executeWithArray(any(), any(), any())).thenReturn(candidates);
         return shepherd;
     }
 
@@ -51,6 +51,18 @@ class MarkedIndividualTaxonomyBackfillTest {
         enc.setGenus(genus);
         enc.setSpecificEpithet(specificEpithet);
         return enc;
+    }
+
+    @Test void candidateSqlContainsNoColonForDataNucleusToMistakeForANamedParameter() {
+        // DataNucleus scans the whole SQL text for :name tokens without respecting string
+        // literals, so a POSIX class like [:space:] in a regex literal is parsed as a named
+        // parameter and execution fails with "SQL query has parameter ... yet not found"
+        String sql = MarkedIndividual.backfillTaxonomySql(5);
+
+        assertEquals(-1, sql.indexOf(':'),
+            "any colon in the SQL text is misparsed as a named parameter: " + sql);
+        assertEquals(3, sql.length() - sql.replace("?", "").length(),
+            "cursor plus one bound regex per taxonomy column: " + sql);
     }
 
     @Test void committingRunWritesFixablesAndAdvancesThePastEverythingExamined() {
@@ -137,7 +149,7 @@ class MarkedIndividualTaxonomyBackfillTest {
             JSONObject res = MarkedIndividual.backfillTaxonomyFromEncounters(sh, null, 100, false);
             assertEquals("ind-500", res.getString("_startId"),
                 "a run with no explicit startId picks up where the last committing run stopped");
-            verify(query).execute("ind-500");
+            verify(query).executeWithArray(eq("ind-500"), any(), any());
         }
     }
 
@@ -147,7 +159,7 @@ class MarkedIndividualTaxonomyBackfillTest {
         try (MockedStatic<SystemValue> sv = mockStatic(SystemValue.class)) {
             sv.when(() -> SystemValue.getString(any(), anyString())).thenReturn("ind-500");
             MarkedIndividual.backfillTaxonomyFromEncounters(sh, "ind-100", 100, false);
-            verify(query).execute("ind-100");
+            verify(query).executeWithArray(eq("ind-100"), any(), any());
         }
     }
 
@@ -159,7 +171,9 @@ class MarkedIndividualTaxonomyBackfillTest {
             JSONObject res = MarkedIndividual.backfillTaxonomyFromEncounters(sh, null, 100, false);
             assertEquals("", res.getString("_startId"),
                 "with no stored cursor every id sorts after the starting point");
-            verify(query).execute("");
+            verify(query).executeWithArray(eq(""),
+                eq(MarkedIndividual.TAXONOMY_BACKFILL_BLANK_REGEX),
+                eq(MarkedIndividual.TAXONOMY_BACKFILL_BLANK_REGEX));
         }
     }
 

--- a/src/test/java/org/ecocean/MarkedIndividualTaxonomyTest.java
+++ b/src/test/java/org/ecocean/MarkedIndividualTaxonomyTest.java
@@ -260,11 +260,16 @@ class MarkedIndividualTaxonomyTest {
                 " display as blank, so they are candidates too: " + sql);
         }
         // A row this query misses can never be fixed, so it must not be narrower than
-        // hasNoTaxonomyOfItsOwn(): btrim() would leave the tabs String.trim() removes, and a backslash
-        // pattern would be eaten on a connection with standard_conforming_strings off.
-        assertTrue(sql.contains("regexp_replace") && sql.contains("[[:space:][:cntrl:]]"),
+        // hasNoTaxonomyOfItsOwn(): btrim() would leave the tabs String.trim() removes. The regex
+        // is bound as a parameter, not written into the SQL, because DataNucleus misparses the
+        // POSIX classes' colons as named parameters (and a literal backslash pattern would be
+        // eaten on a connection with standard_conforming_strings off).
+        assertTrue(sql.contains("regexp_replace(\"GENUS\", ?") &&
+            sql.contains("regexp_replace(\"SPECIFICEPITHET\", ?"),
             "the query must treat as blank everything hasNoTaxonomyOfItsOwn() does: " + sql);
-        assertFalse(sql.contains("\\"), "and must not depend on backslash escaping to do it: " + sql);
+        assertEquals("[[:space:][:cntrl:]]", MarkedIndividual.TAXONOMY_BACKFILL_BLANK_REGEX,
+            "the bound pattern strips every space and control character");
+        assertFalse(sql.contains("\\"), "the SQL must not depend on backslash escaping: " + sql);
     }
 
     @Test void backfillBatchSizeIsBounded() {


### PR DESCRIPTION
Fixes the taxonomy-backfill admin JSP (`appadmin/individualTaxonomyBackfill.jsp`, added in #1709), which failed on every run with:

```
javax.jdo.JDOUserException: SQL query has parameter "space" yet not found in the query :
SELECT "INDIVIDUALID" FROM "MARKEDINDIVIDUAL" WHERE "INDIVIDUALID" > ?
AND COALESCE(lower(regexp_replace("GENUS", '[[:space:][:cntrl:]]', '', 'g')), '') IN ('', 'none', 'unknown') ...
```

## Root cause

DataNucleus scans the entire SQL text of a `javax.jdo.query.SQL` query for `:name` tokens **without respecting string literals**. The POSIX character classes `[[:space:][:cntrl:]]` in the blank-taxonomy regex were therefore misparsed as named parameters `:space` and `:cntrl`, which then conflicted with the positional `?` cursor parameter, so the query failed at execute time — the SQL never reached PostgreSQL at all.

(The POSIX classes had themselves been chosen over `\s` to avoid a backslash being eaten on connections with `standard_conforming_strings` off — one quoting hazard traded for another.)

## Fix

Bind the regex pattern as a positional parameter instead of writing it into the SQL text:

- `blankTaxonomyPartSql()` now emits `regexp_replace("COL", ?, '', 'g')`; the pattern lives in the `TAXONOMY_BACKFILL_BLANK_REGEX` constant and is passed via `query.executeWithArray(startId, pattern, pattern)`.
- No colons remain anywhere in the SQL text, so DataNucleus has nothing to misparse — and as a bound parameter the pattern reaches the regex engine byte-for-byte regardless of `standard_conforming_strings`, resolving the original concern more robustly than the literal did.

Query semantics are unchanged: verified against PostgreSQL 15 with a prepared statement that blank-ish values (`' Unknown \t'`, `NULL`, `''`) still select and real taxonomies don't.

## Tests

- New regression test asserts the generated SQL contains no `:` at all and exactly the 3 `?` placeholders the bound arguments fill.
- `backfillWalksTheTableByCursor` updated to pin the new contract (pattern bound as a parameter, POSIX classes in the constant).
- Existing backfill behavior tests updated from `execute(cursor)` to `executeWithArray(cursor, pattern, pattern)`.
- New `MarkedIndividualTaxonomyBackfillDbTest` (Testcontainers) runs the real query through real DataNucleus + Postgres — the layer where the bug lived and where mocks can't reach. Verified it reproduces the production `JDOUserException` verbatim against the pre-fix code, and that the fixed query selects exactly the blank/padded/no-source rows and skips identified ones. Entities are seeded with `setSkipAutoIndexing(true)` so IndexingManager worker PMs don't block `closePMF` in teardown (the cross-class PMF contamination hazard from #1613).

All 32 tests across the three taxonomy test classes pass. Codex adversarial review: converged, no Critical/Major findings (its one Minor suggestion — a live DataNucleus execution test — is included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
